### PR TITLE
Add a load test

### DIFF
--- a/LoadTest.scala
+++ b/LoadTest.scala
@@ -1,0 +1,50 @@
+/** Load test for Mercure.
+ *
+ * 1. Grab Gatling 3 on https://gatling.io
+ * 2. Run path/to/gatling/bin/gatling.sh --simulations-folder .
+*/
+
+package mercure
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import scala.concurrent.duration._
+
+class LoadTest extends Simulation {
+  /** The hub URL */
+  val HubUrl = "http://localhost:3001/hub"
+  /** JWT to use to publish */
+  val Jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyJmb28iLCJiYXIiXSwicHVibGlzaCI6WyJmb28iXX19.LRLvirgONK13JgacQ_VbcjySbVhkSmHy3IznH3tA9PM"
+  /** Number of concurrent subscribers to connect */
+  val ConcurrentSubscribers = 10000
+  /** Number of concurent publishers */
+  val ConcurrentPublishers = 2
+
+  val httpProtocol = http
+    .baseUrl(HubUrl)
+
+  val scenarioPublish = scenario("Publish")
+    .pause(2) // Wait for subscribers
+    .exec(
+      http("Publish")
+        .post("")
+        .header("Authorization", "Bearer "+Jwt)
+        .formParamMap(Map("topic" -> "http://example.com", "data" -> "Hi"))
+        .check(status.is(200))
+    )
+
+  val scenarioSubscribe = scenario("Subscribe")
+    .exec(
+      sse("Subscribe").connect("?topic=http://example.com")
+        .await(10)(
+          sse.checkMessage("Check content").check(regex("""(.*)Hi(.*)"""))
+        )
+    )
+    .pause(15)
+    .exec(sse("Close").close())
+
+  setUp(
+    scenarioSubscribe.inject(atOnceUsers(ConcurrentSubscribers)).protocols(httpProtocol),
+    scenarioPublish.inject(atOnceUsers(ConcurrentPublishers)).protocols(httpProtocol)
+  )
+}

--- a/LoadTest.scala
+++ b/LoadTest.scala
@@ -2,6 +2,12 @@
  *
  * 1. Grab Gatling 3 on https://gatling.io
  * 2. Run path/to/gatling/bin/gatling.sh --simulations-folder .
+ *
+ * Available environment variables (all optional):
+ *   - HUB_URL: the URL of the hub to test
+ *   - JWT: the JWT to use for authenticating the publisher
+ *   - SUBSCRIBERS: the number of concurrent subscribers
+ *   - PUBLISHERS: the number of concurrent publishers
 */
 
 package mercure
@@ -9,16 +15,17 @@ package mercure
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import scala.concurrent.duration._
+import scala.util.Properties
 
 class LoadTest extends Simulation {
   /** The hub URL */
-  val HubUrl = "http://localhost:3001/hub"
+  val HubUrl = Properties.envOrElse("HUB_URL", "http://localhost:3001/hub" )
   /** JWT to use to publish */
-  val Jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyJmb28iLCJiYXIiXSwicHVibGlzaCI6WyJmb28iXX19.LRLvirgONK13JgacQ_VbcjySbVhkSmHy3IznH3tA9PM"
+  val Jwt = Properties.envOrElse("JWT", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyJmb28iLCJiYXIiXSwicHVibGlzaCI6WyJmb28iXX19.LRLvirgONK13JgacQ_VbcjySbVhkSmHy3IznH3tA9PM")
   /** Number of concurrent subscribers to connect */
-  val ConcurrentSubscribers = 10000
+  val ConcurrentSubscribers = Properties.envOrElse("SUBSCRIBERS", "10000").toInt
   /** Number of concurent publishers */
-  val ConcurrentPublishers = 2
+  val ConcurrentPublishers = Properties.envOrElse("PUBLISHERS", "2").toInt
 
   val httpProtocol = http
     .baseUrl(HubUrl)

--- a/README.md
+++ b/README.md
@@ -300,6 +300,13 @@ In summary, use the Push API to send notifications to offline users (that will b
 * [`EventSource` implementation for Node](https://github.com/EventSource/eventsource)
 * [Server-Sent Events client for Go](https://github.com/donovanhide/eventsource)
 
+## Load Testing
+
+A [Gatling](https://gatling.io)-based load test is provided in this repository.
+It allows to test any implementation of the protocol, including the reference implementation.
+
+See [`LoadTest.scala`](LoadTest.scala) to learn how to use it.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Add a load test built on top of [Gatling](https://gatling.io/).

On my computer (MacBook Pro, 2,5 GHz Intel Core i7, 16 Go 1600 MHz DDR3), Mercure is able to handle 10k concurrent users, after I reach the limit of available file descriptors (not sure if it's "because" of Mercure or Gatling itself). (the limit could be increased using `ulimit`).