### PR TITLE
Second pass of specification doc

### DIFF
--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -46,7 +46,7 @@ The keywords **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **S
 ![Discovery Schema](discovery.png)
 
 If the publisher is a server, it **SHOULD** advertise the URL of one or more hubs to the subscriber, allowing it to receive live updates when topics are updated.
-If more than one hub URL is specified, it is expected that the publisher notifies each hub, so the subscriber **MAY** subscribe to one or more of them.
+If more than one hub URL is specified, it is expected that the publisher will notify each hub, so the subscriber **MAY** subscribe to one or more of them.
 
 The publisher **SHOULD** include at least one Link Header [@!RFC5988] with `rel=mercure` (a hub link header).
 The target URL of these links **MUST** be a hub implementing the Mercure protocol.
@@ -57,7 +57,7 @@ In the meantime, the relation type `https://git.io/mercure` **MAY** be used inst
 The publisher **MAY** provide the following target attributes in the Link Headers:
 
 * `last-event-id`: the globally unique identifier of the last event dispatched by the publisher at the time of the generation of this resource. If provided, it **MUST** be passed to the hub through a query parameter called `Last-Event-ID` and will be used to ensure that possible updates having been made during between the resource generation time and the connection to the hub are not lost. See section #Re-Connection-and-State-Reconciliation. If this attribute is provided, the publisher **MUST** always set the `id` parameter when sending updates to the hub.
-* `content-type`: the content type of the updates that will pushed by the hub. If omited, the subscriber **MUST** assume that the content type will be the same than the one of the original resource. Setting the `content-type` attribute is especially useful to hint that partial updates will be pushed, using formats such as JSON Patch [@RFC6902] or JSON Merge Patch [@RFC7386].
+* `content-type`: the content type of the updates that will pushed by the hub. If omitted, the subscriber **MUST** assume that the content type will be the same as that of the original resource. Setting the `content-type` attribute is especially useful to hint that partial updates will be pushed, using formats such as JSON Patch [@RFC6902] or JSON Merge Patch [@RFC7386].
 * `key-set=<JWKS>`: the key(s) to decrypt updates encoded in the JWKS (JSON Web Key Set) format (see the Encryption section).
 
 All these attributes are optional.
@@ -85,12 +85,12 @@ Note: the discovery mechanism described in this section [is strongly inspired fr
 
 ![Subscriptions Schema](subscriptions.png)
 
-The subscriber subscribes to a URL exposed by a hub to receive updates of one or many topics.
+The subscriber subscribes to a URL exposed by a hub to receive updates from one or many topics.
 To subscribe to updates, the client opens an HTTPS connection following the [Server-Sent Events specification](https://html.spec.whatwg.org/multipage/server-sent-events.html) to the hub's subscription URL advertised
 by the publisher. The `GET` HTTP method must be used.
 The connection **SHOULD** use HTTP/2 to leverage mutliplexing and other advanced features of this protocol.
 
-The subscriber specifies the list of topics to get updates for by using one or several query parameters named `topic`.
+The subscriber specifies the list of topics to get updates from by using one or several query parameters named `topic`.
 The value of these query parameters **MUST** be URI templates [@!RFC6570].
 
 Note: a URL is also a valid URI template.
@@ -98,7 +98,7 @@ Note: a URL is also a valid URI template.
 The protocol doesn't specify the maximum number of `topic` parameters that can be sent, but the hub **MAY** apply an arbitrary limit.
 
 The [EventSource JavaScript interface](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface) **MAY** be used to establish the connection.
-Any other appropriate mechanism including but not limited to [readable streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams) and [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest) (used by popular polyfills) **MAY** also be used.
+Any other appropriate mechanism including, but not limited to, [readable streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams) and [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest) (used by popular polyfills) **MAY** also be used.
 
 The hub sends updates concerning all subscribed resources matching the provided URI templates and the provided targets (see section #Authorization). If no targets are specified, the update is dispatched to all subscribers.
 The hub **MUST** send these updates as [text/event-stream compliant events](https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model).
@@ -130,26 +130,26 @@ eventSource.onmessage = function ({data}) {
 };
 ```
 
-The hub **MAY** require that the subscribers are authorized to receive any update.
+The hub **MAY** require that subscribers are authorized to receive updates.
 
 # Publication
 
 The publisher send updates by issuing `POST` HTTPS requests on the hub URL.
 When it receives an update, the hub dispatches it to subscribers using the established server-sent events connections.
 
-An application CAN send events directly to the subscribers without using an external hub server, if it is able to do so.
+An application CAN send events directly to subscribers without using an external hub server, if it is able to do so.
 In this case, it **MAY NOT** implement the endpoint to publish updates.
 
 The request **MUST** be encoded using the `application/x-www-form-urlencoded` format and contain the following data:
 
-* `topic`: IRIs of the updated topic. If this key is present several times, the first occurrence is considered to be the canonical URL of the topic, and other ones are considered to be alternate URLs. The hub **MUST** dispatch this update to subscribers subscribed to both canonical or alternate URLs.
+* `topic`: IRIs of the updated topic. If this key is present several times, the first occurrence is considered to be the canonical URL of the topic, and other ones are considered to be alternate URLs. The hub **MUST** dispatch this update to subscribers that are subscribed to both canonical or alternate URLs.
 * `data`: The content of the new version of this topic.
 * `target` (optional): Target audience of this update. This key can be present several times. See section #Authorization for further information.
-* `id` (optional): The topic's revision identifier, it will be used as the SSE's `id` property. If omitted, the hub **MUST** generate a valid globally unique id. It `MAY` be a UUID. Even if provided, the hub **MAY** ignore the id provided by the client and generate its own id.
+* `id` (optional): The topic's revision identifier: it will be used as the SSE's `id` property. If omitted, the hub **MUST** generate a valid globally unique id. It `MAY` be a UUID. Even if provided, the hub **MAY** ignore the id provided by the client and generate its own id.
 * `type` (optional): The SSE's `event` property (a specific event type)
 * `retry` (optional): The SSE's `retry` property (the reconnection time)
 
-In case of success, the HTTP response's body **MUST** be the `id` associated to this update generated by the hub and a success HTTP status code **MUST** be returned.
+In the event of success, the HTTP response's body **MUST** be the `id` associated to this update generated by the hub and a success HTTP status code **MUST** be returned.
 The publisher **MUST** be authorized to publish updates. See section #Authorization.
 
 # Authorization
@@ -162,18 +162,18 @@ Two mechanisms are defined to present the JWS to the hub:
 * using an `Authorization` HTTP header
 * using a cookie
 
-If a publisher or the subscriber is not a web browser, it **SHOULD** use an `Authorization` HTTP header. This `Authorization` header **MUST** contain the string `Bearer ` followed by the JWS.
-The hub will check that the JWS conforms to the rules defined later to ensure that the client is authorized to publish or subscribe to updates.
+If the publisher or the subscriber is not a web browser, it **SHOULD** use an `Authorization` HTTP header. This `Authorization` header **MUST** contain the string `Bearer ` followed by the JWS.
+The hub will check that the JWS conforms to the rules (defined later) ensuring that the client is authorized to publish or subscribe to updates.
 
 By the `EventSource` specification, web browsers can not set custom HTTP headers for such connections, and they can only be estabilished using the `GET` HTTP method.
 However, cookies are supported and can be included even in cross-domain requests if [the CORS credentials are set](https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsourceinit-withcredentials):
 
-If a publisher or a subscriber is a web browser, it **SHOULD** send a cookie called `mercureAuthorization` containing the JWS when connecting to the hub.
+If the publisher or the subscriber is a web browser, it **SHOULD** send a cookie called `mercureAuthorization` containing the JWS when connecting to the hub.
 
-Whenever possible, to improve the overall security, the `mercureAuthorization` cookie **SHOULD** be set during the discovery. See section #Discovery.
+Whenever possible, the `mercureAuthorization` cookie **SHOULD** be set during the discovery to improve the overall security. See section #Discovery.
 Consequently, if the cookie is set during the discovery, both the publisher and the hub have to share the same second level domain. The `Domain` attribute **MAY** be used to allow the publisher and the hub to use different subdomains.
 
-The cookie **SHOULD** have the `Secure`, `HttpOnly` and `SameSite` attributes set. Setting the cookie's `Path` attribute **SHOULD** also be set to the hub's URL. See section #Security-Considerations.
+The cookie **SHOULD** have the `Secure`, `HttpOnly` and `SameSite` attributes set. The cookie's `Path` attribute **SHOULD** also be set to the hub's URL. See section #Security-Considerations.
 
 When using authorization mechanisms, the connection **MUST** use an encryption layer such as HTTPS.
 
@@ -184,8 +184,8 @@ If a client tries to execute an operation it is not allowed to, a 403 HTTP statu
 
 Publishers **MUST** be authorized to dispatch updates to the hub, and **MUST** prove that they are allowed to send updates.
 
-To be allowed to publish an update, the JWT presented by the publisher **MUST** contain a claim called `mercure`, and this claim **MUST** contain a `publish` key.
-JWT's `mercure.publish` contains an array of targets the publisher is allowed to dispatch updates to.
+To be allowed to publish an update, the JWS presented by the publisher **MUST** contain a claim called `mercure`, and this claim **MUST** contain a `publish` key.
+`mercure.publish` **MUST** contain an array of targets the publisher is allowed to dispatch updates to.
 
 If `mercure.publish`:
 
@@ -201,34 +201,34 @@ If an update contains at least one target the publisher is not authorized for, t
 Subscribers **MAY** need to be authorized to connect to the hub.
 To receive updates destined to specific targets, they **MUST** be authorized, and **MUST** prove they belong to at least one of the specified targets. If the subscriber is not authorized, it **MUST NOT** receive any update having at least one target.
 
-To receive updates destined to specific targets, the JWS presented by the subscriber **MUST** have a claim named `mercure` with a key named `subscribe` that contains an array of strings: the list of targets the user is authorized to receive updates for. The targets **SHOULD** be IRIs.
+To receive updates destined for specific targets, the JWS presented by the subscriber **MUST** have a claim named `mercure` with a key named `subscribe` that contains an array of strings: a list of targets the user is authorized to receive updates for. The targets **SHOULD** be IRIs.
 
-If at least one target is specified, the update **MUST NOT** be sent to the subscriber by the hub, unless the `mercure.subscribe` property of the JWS presented by the subscriber contains at least one of the specified targets.
+If at least one target is specified, the update **MUST NOT** be sent to the subscriber by the hub, unless the `mercure.subscribe` array of the JWS presented by the subscriber contains at least one of the specified targets.
 
 If the `mercure.subscribe` array contains the reserved string value `*`, then the subscriber is authorized to receive updates destined for all targets.
 
-# Re-Connection and State Reconciliation
+# Reconnection and State Reconciliation
 
 To allow re-establishment in case of connection lost, events dispatched by the hub **SHOULD** include an `id` property.
 The value contained in this `id` property **SHOULD** be a globally unique identifier.
 To do so, a UUID [@!RFC4122] **MAY** be used.
 
-According to the server-sent events specification, in case of connection lost the subscriber will try to automatically reconnect. During the reconnection, the subscriber **MUST** send the last received event id in a [Last-Event-ID](https://html.spec.whatwg.org/multipage/iana.html#last-event-id) HTTP header.
+According to the server-sent events specification, in case of connection lost the subscriber will try to automatically re-connect. During the re-connection, the subscriber **MUST** send the last received event id in a [Last-Event-ID](https://html.spec.whatwg.org/multipage/iana.html#last-event-id) HTTP header.
 
-The server-sent events specification doesn't allow this HTTP header to be set during the first connection (before a re-connection).
+The server-sent events specification doesn't allow this HTTP header to be set during the first connection (before a reconnection).
 In order to fetch any update dispatched between the initial resource generation by the publisher and the connection to the hub, the subscriber **MUST** send the event id provided during the discovery in the `last-event-id` link's attribute in a query parameter named `Last-Event-ID` when connecting to the hub.
 
 If both the `Last-Event-ID` HTTP header and the query parameter are present, the HTTP header **MUST** take precedence.
 
-If the `Last-Event-ID` HTTP header or query parameter exists, the hub **SHOULD** send to the subscriber all events published since the one having this identifier.
+If the `Last-Event-ID` HTTP header or query parameter exists, the hub **SHOULD** send all events published following the one bearing this identifier to the subscriber.
 
-The hub **MAY** discard some messages for operational reasons. The subscriber **MUST NOT** assume that no update will be lost, and **MUST** re-fetch the original topic to ensure this (for instance, after a long deconnection time).
+The hub **MAY** discard some messages for operational reasons. The subscriber **MUST NOT** assume that no update will be lost, and **MUST** re-fetch the original topic to ensure this (for instance, after a long disconnection time).
 
 The hub **MAY** also specify the reconnection time using the `retry` key, as specified in the server-sent events format.
 
 # Encryption
 
-Using HTTPS doesn't prevent the hub from accessing the update's content.
+Using HTTPS does not prevent the hub from accessing the update's content.
 Depending of the intended privacy of information contained in the update, it **MAY** be necessary to prevent eavesdropping by the hub.
 
 To make sure that the message content can not be read by the hub, the publisher **MAY** encode the message before sending it to the hub.
@@ -237,29 +237,29 @@ The publisher **MAY** provide the relevant encryption key(s) in the `key-set` at
 The `key-set` attribute **SHOULD** contain a key encoded using the JSON Web Key Set [@!RFC7517] format.
 Any other out-of-band mechanism **MAY** be used instead to share the key between the publisher and the subscriber.
 
-Updates encyption is considered a best practice to prevent mass surveillance.
+Update encyption is considered a best practice to prevent mass surveillance.
 This is especially relevant if the hub is managed by an external provider.
 
 # Security Considerations
 
 The confidentiality of the secret key(s) used to generate the JWTs is a primary concern.
-The secret key(s) **MUST** be stored securely. They **MUST** be revoked immediatly in case of compromission.
+The secret key(s) **MUST** be stored securely. They **MUST** be revoked immediately in the event of compromission.
 
-Possessing a valid JWTs allows any client to subscribe, or to publish to the hub.
-Their confidentiality **MUST** therefore be ensured. To do so, JWTs **MUST** only be transmited over secure connections.
+Possessing valid JWTs allows any client to subscribe, or to publish to the hub.
+Their confidentiality **MUST** therefore be ensured. To do so, JWTs **MUST** only be transmitted over secure connections.
 
-Also, when the client is a web browser, to be resilient to [Cross-site Scription (XSS) attacks](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)), the JWT **SHOULD** not be made accessible to JavaScript scripts.
+Also, when the client is a web browser, the JWT **SHOULD** not be made accessible to JavaScript scripts for resilience against [Cross-site Scription (XSS) attacks](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)).
 It's the main reason why, when the client is a web browser, using `HttpOnly` cookies as the authorization mechanism **SHOULD** always be preferred.
 
-In case of compromission, revoking a JWT before its expiration is often difficult.
-So, using short-lived token is strongly **RECOMMENDED**.
+In the event of compromission, revoking JWTs before their expiration is often difficult.
+To that end, using short-lived tokens is strongly **RECOMMENDED**.
 
 The publish endpoint of the hub may be targeted by [Cross-Site Request Forgery (CSRF) attacks](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)) when the cookie-based authorization mechanism is used.
 Therefore, implementations supporting this mechanism **MUST** mitigate such attacks.
 
 The first prevention method to implement is to set the `mercureAuthorization` cookie's `SameSite` attribute.
-However, [some web browsers still not support this attribute](https://caniuse.com/#feat=same-site-cookie-attribute) and will stay vulnerable.
-In addition, hub implementations **SHOULD** use the `Origin` and `Referer` HTTP headers set by web browsers to verify that the source origin matches the target origin. If none of these headers are available, the hub **SHOULD** discard the request.
+However, [some web browsers still not support this attribute](https://caniuse.com/#feat=same-site-cookie-attribute) and will remain vulnerable.
+Additionally, hub implementations **SHOULD** use the `Origin` and `Referer` HTTP headers set by web browsers to verify that the source origin matches the target origin. If none of these headers are available, the hub **SHOULD** discard the request.
 
 CSRF prevention techniques, including those previously mentioned, are described in depth in [OWASP's Cross-Site Request Forgery (CSRF) Prevention Cheat Sheet](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet). 
 

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -46,7 +46,7 @@ The keywords **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **S
 ![Discovery Schema](discovery.png)
 
 If the publisher is a server, it **SHOULD** advertise the URL of one or more hubs to the subscriber, allowing it to receive live updates when topics are updated.
-If more than one hub URL is specified, it is expected that the publisher will notify each hub, so the subscriber **MAY** subscribe to one or more of them.
+If more than one hub URL is specified, it is **RECOMMENDED** that the publisher notifies each hub, so the subscriber **MAY** subscribe to one or more of them.
 
 The publisher **SHOULD** include at least one Link Header [@!RFC5988] with `rel=mercure` (a hub link header).
 The target URL of these links **MUST** be a hub implementing the Mercure protocol.
@@ -145,7 +145,7 @@ The request **MUST** be encoded using the `application/x-www-form-urlencoded` fo
 * `topic`: IRIs of the updated topic. If this key is present several times, the first occurrence is considered to be the canonical URL of the topic, and other ones are considered to be alternate URLs. The hub **MUST** dispatch this update to subscribers that are subscribed to both canonical or alternate URLs.
 * `data`: The content of the new version of this topic.
 * `target` (optional): Target audience of this update. This key can be present several times. See section #Authorization for further information.
-* `id` (optional): The topic's revision identifier: it will be used as the SSE's `id` property. If omitted, the hub **MUST** generate a valid globally unique id. It `MAY` be a UUID. Even if provided, the hub **MAY** ignore the id provided by the client and generate its own id.
+* `id` (optional): The topic's revision identifier: it will be used as the SSE's `id` property. If omitted, the hub **MUST** generate a valid globally unique id. It **MAY** be a UUID. Even if provided, the hub **MAY** ignore the id provided by the client and generate its own id.
 * `type` (optional): The SSE's `event` property (a specific event type)
 * `retry` (optional): The SSE's `retry` property (the reconnection time)
 
@@ -178,7 +178,7 @@ The cookie **SHOULD** have the `Secure`, `HttpOnly` and `SameSite` attributes se
 When using authorization mechanisms, the connection **MUST** use an encryption layer such as HTTPS.
 
 If both an `Authorization` HTTP header and a cookie named `mercureAuthorization` are presented by the client, the cookie **MUST** be ignored.
-If a client tries to execute an operation it is not allowed to, a 403 HTTP status code **SHOULD** be returned.
+If the client tries to execute an operation it is not allowed to, a 403 HTTP status code **SHOULD** be returned.
 
 ## Publishers
 

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -184,7 +184,7 @@ If a client tries to execute an operation it is not allowed to, a 403 HTTP statu
 
 Publishers **MUST** be authorized to dispatch updates to the hub, and **MUST** prove that they are allowed to send updates.
 
-To be allowed to publish an update, the JWS presented by the publisher **MUST** contain a claim called `mercure`, and this claim **MUST** contain a `publish` key.
+To be allowed to publish an update, the JWT presented by the publisher **MUST** contain a claim called `mercure`, and this claim **MUST** contain a `publish` key.
 `mercure.publish` **MUST** contain an array of targets the publisher is allowed to dispatch updates to.
 
 If `mercure.publish`:


### PR DESCRIPTION
As promised :)

You'll see by my second commit that I reverted my "JWT to JWS" change - JWT hadn't been mentioned previously in the document and thus was undefined and may have been referenced in error.  If JWT is correct, then "JSON Web Token (JWT)" should be used in the first instance with a link to https://tools.ietf.org/html/rfc7519.

Let me know if you'd like this change to be made.