### PR TITLE
Fix IE browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In addition, a managed and high-scalability version of Mercure is [available in 
 * designed with [hypermedia in mind](https://en.wikipedia.org/wiki/HATEOAS), also supports [GraphQL](https://graphql.org/)
 * auto-discoverable through [web linking](https://tools.ietf.org/html/rfc5988)
 * message encryption support
-* can work with old browsers (IE7+) using an `EventSource` polyfill
+* can work with old browsers (IE8+) using an `EventSource` polyfill
 * [connection-less push](https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource-push) in controlled environments (e.g. browsers on mobile handsets tied to specific carriers)
 
 The reference hub implementation:


### PR DESCRIPTION
Browser support mentioned seems wrong. Maybe refer to the link below?

> Browser support:
>> IE 10+, Firefox 3.5+, Chrome 3+, Safari 4+, Opera 12+
>> IE 8 - IE 9: XDomainRequest is used internally, which has some limitations (2KB padding is requried, no way to send cookies, no way to use client certificates)

https://github.com/Yaffle/EventSource#browser-support