### PR TITLE
Open the HTTP body to hint clients that all headers have been sent

### DIFF
--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -95,7 +95,7 @@ func TestServe(t *testing.T) {
 		defer resp.Body.Close()
 		body, _ := ioutil.ReadAll(resp.Body)
 
-		assert.Equal(t, []byte("id: first\ndata: hello\n\n"), body)
+		assert.Equal(t, []byte(":\nid: first\ndata: hello\n\n"), body)
 	}()
 
 	go func() {
@@ -109,7 +109,7 @@ func TestServe(t *testing.T) {
 		defer resp.Body.Close()
 		body, _ := ioutil.ReadAll(resp.Body)
 
-		assert.Equal(t, []byte("id: first\ndata: hello\n\n"), body)
+		assert.Equal(t, []byte(":\nid: first\ndata: hello\n\n"), body)
 	}()
 
 	wgConnected.Wait()

--- a/hub/subscribe.go
+++ b/hub/subscribe.go
@@ -120,6 +120,10 @@ func sendHeaders(w http.ResponseWriter) {
 
 	// NGINX support https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering
 	w.Header().Set("X-Accel-Buffering", "no")
+
+	// Write a comment in the body
+	// Go currently doesn't provide a better way to flush the headers
+	fmt.Fprint(w, ":\n")
 	w.(http.Flusher).Flush()
 }
 

--- a/hub/subscribe_test.go
+++ b/hub/subscribe_test.go
@@ -160,7 +160,7 @@ func TestSubscribe(t *testing.T) {
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "id: b\ndata: Hello World\n\nid: c\ndata: Great\n\n", w.Body.String())
+	assert.Equal(t, ":\nid: b\ndata: Hello World\n\nid: c\ndata: Great\n\n", w.Body.String())
 }
 
 func TestUnsubscribe(t *testing.T) {
@@ -234,7 +234,7 @@ func TestSubscribeTarget(t *testing.T) {
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "event: test\nid: b\ndata: Hello World\n\nretry: 1\nid: c\ndata: Great\n\n", w.Body.String())
+	assert.Equal(t, ":\nevent: test\nid: b\ndata: Hello World\n\nretry: 1\nid: c\ndata: Great\n\n", w.Body.String())
 }
 
 func TestSubscribeAllTargets(t *testing.T) {
@@ -274,7 +274,7 @@ func TestSubscribeAllTargets(t *testing.T) {
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "id: a\ndata: Foo\n\nevent: test\nid: b\ndata: Hello World\n\n", w.Body.String())
+	assert.Equal(t, ":\nid: a\ndata: Foo\n\nevent: test\nid: b\ndata: Hello World\n\n", w.Body.String())
 }
 
 func TestSendMissedEvents(t *testing.T) {
@@ -309,7 +309,7 @@ func TestSendMissedEvents(t *testing.T) {
 		defer w.Done()
 		req := httptest.NewRequest("GET", "http://example.com/hub?topic=http://example.com/foos/{id}&Last-Event-ID=a", nil)
 		hub.SubscribeHandler(wr1, req)
-		assert.Equal(t, "id: b\ndata: d2\n\n", wr1.Body.String())
+		assert.Equal(t, ":\nid: b\ndata: d2\n\n", wr1.Body.String())
 	}(&wg)
 
 	wr2 := newCloseNotifyingRecorder()
@@ -318,7 +318,7 @@ func TestSendMissedEvents(t *testing.T) {
 		req := httptest.NewRequest("GET", "http://example.com/hub?topic=http://example.com/foos/{id}", nil)
 		req.Header.Add("Last-Event-ID", "a")
 		hub.SubscribeHandler(wr2, req)
-		assert.Equal(t, "id: b\ndata: d2\n\n", wr2.Body.String())
+		assert.Equal(t, ":\nid: b\ndata: d2\n\n", wr2.Body.String())
 	}(&wg)
 
 	for {
@@ -368,7 +368,7 @@ func TestSubscribeHeartbeat(t *testing.T) {
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "id: b\ndata: Hello World\n\n:\n", w.Body.String())
+	assert.Equal(t, ":\nid: b\ndata: Hello World\n\n:\n", w.Body.String())
 }
 
 // From https://github.com/go-martini/martini/blob/master/response_writer_test.go


### PR DESCRIPTION
Currently, if a CORS error occurs, it is caught by the browser only when an event is dispatched (and it can take some time). This patch force the server to start the HTTP body when headers have been sent.