### PR TITLE
Make it deployable on PaaS like Scalingo

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: ADDR=":${PORT}" mercure

--- a/README.md
+++ b/README.md
@@ -210,6 +210,21 @@ To install Mercure in a [Kubernetes](https://kubernetes.io) cluster, use the off
 
     helm install stable/mercure
 
+#### Scalingo (PaaS)
+
+To deploy your own Mercure hub in a single click:
+
+[![Deploy](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/dunglas/mercure)
+
+How to deploy updates after initial deployment:
+
+```
+git clone git@github.com:dunglas/mercure
+cd mercure
+git remote add <app name> git@scalingo.com:<app name>.git
+git push <app name> master
+```
+
 ### Environment Variables
 
 * `ACME_CERT_DIR`: the directory where to store Let's Encrypt certificates

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,13 @@
+{
+  "name": "Mercure",
+  "description": "Server-sent live updates: protocol and reference implementation",
+  "website": "https://mercure.rocks/",
+  "repository": "https://github.com/dunglas/mercure",
+  "logo": "https://cdn.scalingo.com/documentation/technologies/mercure.svg",
+  "env": {
+    "JWT_KEY": {
+      "description": "Key to protect JWT tokens",
+      "generator": "secret"
+    }
+  }
+}


### PR DESCRIPTION
As a follow up of what has been done https://github.com/dunglas/mercure/issues/52

This PR is doing two things:

- Adding compatibility with the PaaS Scalingo (with the `Procfile` file)
- Add a one-click deployment button in the README next to Docker/Kubernetes deployment methods

This could help to make Mercure more famous and easier to deploy and try.

If you want to try how the button is working (as it requires the scalingo.json to be present in the repo), here is a working version in our fork: https://github.com/Scalingo/mercure-scalingo

If you've any question, don't hesitate.

Note: Thanks to the `Procfile`, it would also make the application deployable on `Heroku`