### PR TITLE
spec: explicitly allow to use string as IDs

### DIFF
--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -40,7 +40,7 @@ NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL**, when they appear in this docu
 interpreted as described in [@!RFC2119].
 
  *  Topic: The unit to which one can subscribe to changes. The topic **MUST** be identified by an
-    IRI [!@RFC3987] or by a string. Using an HTTPS [@!RFC2818] or HTTP [@!RFC7230] URI [@!RFC3986]
+    IRI [!@RFC3987] or by a string. Using an HTTPS [@!RFC7230] or HTTP [@!RFC7230] URI [@!RFC3986]
     is **RECOMMENDED**.
 
  *  Publisher: An owner of a topic. Notifies the hub when the topic feed has been updated. As in

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -53,7 +53,7 @@ interpreted as described in [@!RFC2119].
 
  *  Target: A subscriber, or a group of subscribers. A publisher is able to securely dispatch
     updates to specific targets. The target **MUST** be identified by an URI [!@RFC3987] or by a
-    string. Using an HTTPS [@!RFC2818] or HTTP [@!RFC7230] URI is **RECOMMENDED**.
+    string. Using an HTTPS [@!RFC7230] or HTTP [@!RFC7230] URI is **RECOMMENDED**.
 
  *  Hub: A server that handles subscription requests and distributes the content to subscribers
     when the corresponding topics have been updated.

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -39,8 +39,9 @@ The keywords **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **S
 NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL**, when they appear in this document, are to be
 interpreted as described in [@!RFC2119].
 
- *  Topic: An HTTP [@!RFC7230] or HTTPS [@!RFC2818] topic URL. The unit to which one can subscribe
-    to changes.
+ *  Topic: The unit to which one can subscribe to changes. The topic **MUST** be identified by an
+    IRI [!@RFC3987] or by a string. Using an HTTPS [@!RFC2818] or HTTP [@!RFC7230] URI [@!RFC3986]
+    is **RECOMMENDED**.
 
  *  Publisher: An owner of a topic. Notifies the hub when the topic feed has been updated. As in
     almost all pubsub systems, the publisher is unaware of the subscribers, if any. Other pubsub
@@ -51,8 +52,8 @@ interpreted as described in [@!RFC2119].
     Progressive Web App or a Mobile App, but can also be a server.
 
  *  Target: A subscriber, or a group of subscribers. A publisher is able to securely dispatch
-    updates to specific targets. Using an HTTP [@!RFC7230] or HTTPS [@!RFC2818] URL to identify
-    targets is **RECOMMENDED**.
+    updates to specific targets. The target **MUST** be identified by an URI [!@RFC3987] or by a
+    string. Using an HTTPS [@!RFC2818] or HTTP [@!RFC7230] URI is **RECOMMENDED**.
 
  *  Hub: A server that handles subscription requests and distributes the content to subscribers
     when the corresponding topics have been updated.

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -52,7 +52,7 @@ interpreted as described in [@!RFC2119].
     Progressive Web App or a Mobile App, but can also be a server.
 
  *  Target: A subscriber, or a group of subscribers. A publisher is able to securely dispatch
-    updates to specific targets. The target **MUST** be identified by an URI [!@RFC3987] or by a
+    updates to specific targets. The target **MUST** be identified by an IRI [!@RFC3987] or by a
     string. Using an HTTPS [@!RFC7230] or HTTP [@!RFC7230] URI is **RECOMMENDED**.
 
  *  Hub: A server that handles subscription requests and distributes the content to subscribers


### PR DESCRIPTION
Because it's a frequent feature request, and is already supported by the hub.
Using URIs as identifiers still is the best practice.