### PR TITLE
Stop server shutdown hanging on error

### DIFF
--- a/hub/server.go
+++ b/hub/server.go
@@ -66,7 +66,7 @@ func (h *Hub) Serve() {
 	}
 
 	if err != http.ErrServerClosed {
-		log.Error(err)
+		log.Fatal(err)
 	}
 
 	<-idleConnsClosed


### PR DESCRIPTION
If mercure attempts to start up, whilst not having permissions to bind to ADDR, the program will hang after printing the error message.