### PR TITLE
Replace yaourt with yay in documentation

### DIFF
--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -73,6 +73,6 @@ To install Mercure in a [Kubernetes](https://kubernetes.io) cluster, use the off
 
 Mercure is available [on the AUR](https://aur.archlinux.org/packages/mercure), you can install it with your favorite AUR wrapper:
 
-    yaourt -S mercure
+    yay -S mercure
 
 Or download the `PKGBUILD` and compile and install it: `makepkg -sri`.


### PR DESCRIPTION
Yaourt is deprecated (https://github.com/archlinuxfr/yaourt) and unmaintained. Yay is (one of) the best alternative since 2019 (https://wiki.archlinux.org/index.php/AUR_helpers#Pacman_wrappers).