### PR TITLE
Add --version flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ before:
 builds:
 - <<: &build_defaults
     ldflags:
-      - -s -w -X github.com/dunglas/mercure/common.version={{ .Version }} -X github.com/dunglas/mercure/common.commit={{ .Commit }} -X github.com/dunglas/mercure/common.buildDate={{ .Date }}
+      - -s -w -X github.com/dunglas/mercure/common.version={{ .Version }} -X github.com/dunglas/mercure/common.commit={{ .ShortCommit }} -X github.com/dunglas/mercure/common.buildDate={{ .Date }}
   env:
     - CGO_ENABLED=0
   goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ before:
 builds:
 - <<: &build_defaults
     ldflags:
-      - -s -w -X github.com/dunglas/mercure/common.version={{ .Version }} -X github.com/dunglas/mercure/common.buildDate={{ .Date }}
+      - -s -w -X github.com/dunglas/mercure/common.version={{ .Version }} -X github.com/dunglas/mercure/common.commit={{ .Commit }} -X github.com/dunglas/mercure/common.buildDate={{ .Date }}
   env:
     - CGO_ENABLED=0
   goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ before:
 builds:
 - <<: &build_defaults
     ldflags:
-      - -s -w -X github.com/dunglas/mercure/cmd.version={{ .Version }} -X github.com/dunglas/mercure/cmd.buildDate={{ .Date }}
+      - -s -w -X github.com/dunglas/mercure/common.version={{ .Version }} -X github.com/dunglas/mercure/common.buildDate={{ .Date }}
   env:
     - CGO_ENABLED=0
   goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,9 @@ before:
   hooks:
   - go mod download
 builds:
--
+- <<: &build_defaults
+    ldflags:
+      - -s -w -X github.com/dunglas/mercure/cmd.version={{ .Version }} -X github.com/dunglas/mercure/cmd.buildDate={{ .Date }}
   env:
     - CGO_ENABLED=0
   goos:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,6 @@ func init() { //nolint:gochecknoinits
 	appVersion := common.AppVersion
 	rootCmd.Version = appVersion.Shortline()
 
-	versionTemplate := fmt.Sprintf("mercure version %s\n%s\n", rootCmd.Version, appVersion.ChangelogURL())
+	versionTemplate := fmt.Sprintf("Mercure.rocks Hub version %s\n%s\n", rootCmd.Version, appVersion.ChangelogURL())
 	rootCmd.SetVersionTemplate(versionTemplate)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,22 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"regexp"
-	"runtime/debug"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/dunglas/mercure/common"
 	"github.com/dunglas/mercure/hub"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-// version is the running Hub version and is dynamically set at build
-var version = "dev" //nolint:gochecknoglobals
-
-// buildDate stores the build date and is dynamically set at build
-var buildDate = "" //nolint:gochecknoglobals
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{ //nolint:gochecknoglobals
@@ -49,35 +41,9 @@ func init() { //nolint:gochecknoinits
 	fs := rootCmd.Flags()
 	hub.SetFlags(fs, v)
 
-	rootCmd.Version = buildVersion()
+	appVersion := common.AppVersion
+	rootCmd.Version = appVersion.Shortline()
 
-	versionTemplate := fmt.Sprintf("mercure version %s\n%s\n", rootCmd.Version, changelogURL(version))
+	versionTemplate := fmt.Sprintf("mercure version %s\n%s\n", rootCmd.Version, appVersion.ChangelogURL())
 	rootCmd.SetVersionTemplate(versionTemplate)
-}
-
-func buildVersion() string {
-	if version == "dev" {
-		info, ok := debug.ReadBuildInfo()
-		if ok && info.Main.Version != "(devel)" {
-			version = info.Main.Version
-		}
-	}
-
-	version = strings.TrimPrefix(version, "v")
-
-	if buildDate == "" {
-		return version
-	}
-
-	return fmt.Sprintf("%s (%s)", version, buildDate)
-}
-
-func changelogURL(version string) string {
-	path := "https://github.com/dunglas/mercure"
-	r := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
-	if !r.MatchString(version) {
-		return fmt.Sprintf("%s/releases/latest", path)
-	}
-
-	return fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(version, "v"))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,10 +14,10 @@ import (
 )
 
 // version is the running Hub version and is dynamically set at build
-var version = "dev"
+var version = "dev" //nolint:gochecknoglobals
 
 // buildDate stores the build date and is dynamically set at build
-var buildDate = ""
+var buildDate = "" //nolint:gochecknoglobals
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{ //nolint:gochecknoglobals
@@ -56,7 +56,7 @@ func init() { //nolint:gochecknoinits
 }
 
 func buildVersion() string {
-	if version == "DEV" {
+	if version == "dev" {
 		info, ok := debug.ReadBuildInfo()
 		if ok && info.Main.Version != "(devel)" {
 			version = info.Main.Version

--- a/common/version.go
+++ b/common/version.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"fmt"
+	"regexp"
+	"runtime/debug"
+	"strings"
+)
+
+type AppVersionInfo struct {
+	Version   string
+	BuildDate string
+}
+
+var AppVersion AppVersionInfo //nolint:gochecknoglobals
+
+// these variables are dynamically set at build.
+var version = "dev" //nolint:gochecknoglobals
+var buildDate = ""  //nolint:gochecknoglobals
+
+func (v *AppVersionInfo) Shortline() string {
+	if v.BuildDate == "" {
+		return v.Version
+	}
+
+	return fmt.Sprintf("%s (%s)", v.Version, v.BuildDate)
+}
+
+func (v *AppVersionInfo) ChangelogURL() string {
+	path := "https://github.com/dunglas/mercure"
+	r := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
+	if !r.MatchString(v.Version) {
+		return fmt.Sprintf("%s/releases/latest", path)
+	}
+
+	return fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(v.Version, "v"))
+}
+
+func init() { //nolint:gochecknoinits
+	if version == "dev" {
+		info, ok := debug.ReadBuildInfo()
+		if ok && info.Main.Version != "(devel)" {
+			version = info.Main.Version
+		}
+	}
+
+	version = strings.TrimPrefix(version, "v")
+
+	AppVersion = AppVersionInfo{
+		Version:   version,
+		BuildDate: buildDate,
+	}
+}

--- a/common/version.go
+++ b/common/version.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"regexp"
 	"runtime/debug"
 	"strings"
 )
@@ -36,8 +35,8 @@ func (v *AppVersionInfo) Shortline() string {
 
 func (v *AppVersionInfo) ChangelogURL() string {
 	path := "https://github.com/dunglas/mercure"
-	r := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
-	if !r.MatchString(v.Version) {
+
+	if v.Version == "dev" {
 		return fmt.Sprintf("%s/releases/latest", path)
 	}
 

--- a/common/version.go
+++ b/common/version.go
@@ -10,6 +10,7 @@ import (
 type AppVersionInfo struct {
 	Version   string
 	BuildDate string
+	Commit    string
 }
 
 var AppVersion AppVersionInfo //nolint:gochecknoglobals
@@ -17,13 +18,20 @@ var AppVersion AppVersionInfo //nolint:gochecknoglobals
 // these variables are dynamically set at build.
 var version = "dev"
 var buildDate = "" //nolint:gochecknoglobals
+var commit = ""    //nolint:gochecknoglobals
 
 func (v *AppVersionInfo) Shortline() string {
-	if v.BuildDate == "" {
-		return v.Version
+	shortline := v.Version
+
+	if v.Commit != "" {
+		shortline += fmt.Sprintf(", commit %s", v.Commit)
 	}
 
-	return fmt.Sprintf("%s (%s)", v.Version, v.BuildDate)
+	if v.BuildDate != "" {
+		shortline += fmt.Sprintf(", built at %s", v.BuildDate)
+	}
+
+	return shortline
 }
 
 func (v *AppVersionInfo) ChangelogURL() string {
@@ -49,5 +57,6 @@ func init() { //nolint:gochecknoinits
 	AppVersion = AppVersionInfo{
 		Version:   version,
 		BuildDate: buildDate,
+		Commit:    commit,
 	}
 }

--- a/common/version.go
+++ b/common/version.go
@@ -15,8 +15,8 @@ type AppVersionInfo struct {
 var AppVersion AppVersionInfo //nolint:gochecknoglobals
 
 // these variables are dynamically set at build.
-var version = "dev" //nolint:gochecknoglobals
-var buildDate = ""  //nolint:gochecknoglobals
+var version = "dev"
+var buildDate = "" //nolint:gochecknoglobals
 
 func (v *AppVersionInfo) Shortline() string {
 	if v.BuildDate == "" {

--- a/common/version_test.go
+++ b/common/version_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDevelopmentVersionInfo(t *testing.T) {
+func TestVersionInfo(t *testing.T) {
 	v := AppVersionInfo{
 		Version:   "dev",
 		BuildDate: "",
@@ -16,12 +16,35 @@ func TestDevelopmentVersionInfo(t *testing.T) {
 	assert.Equal(t, v.ChangelogURL(), "https://github.com/dunglas/mercure/releases/latest")
 }
 
-func TestTaggedVersionInfo(t *testing.T) {
+func TestVersionInfoWithBuildDate(t *testing.T) {
 	v := AppVersionInfo{
 		Version:   "1.0.0",
 		BuildDate: "2020-05-03T18:42:44Z",
+		Commit:    "",
 	}
 
-	assert.Equal(t, v.Shortline(), "1.0.0 (2020-05-03T18:42:44Z)")
+	assert.Equal(t, v.Shortline(), "1.0.0, built at 2020-05-03T18:42:44Z")
+	assert.Equal(t, v.ChangelogURL(), "https://github.com/dunglas/mercure/releases/tag/v1.0.0")
+}
+
+func TestVersionInfoWithCommit(t *testing.T) {
+	v := AppVersionInfo{
+		Version:   "1.0.0",
+		BuildDate: "",
+		Commit:    "96ee2b9",
+	}
+
+	assert.Equal(t, v.Shortline(), "1.0.0, commit 96ee2b9")
+	assert.Equal(t, v.ChangelogURL(), "https://github.com/dunglas/mercure/releases/tag/v1.0.0")
+}
+
+func TestVersionInfoWithBuildDateAndCommit(t *testing.T) {
+	v := AppVersionInfo{
+		Version:   "1.0.0",
+		BuildDate: "2020-05-03T18:42:44Z",
+		Commit:    "96ee2b9",
+	}
+
+	assert.Equal(t, v.Shortline(), "1.0.0, commit 96ee2b9, built at 2020-05-03T18:42:44Z")
 	assert.Equal(t, v.ChangelogURL(), "https://github.com/dunglas/mercure/releases/tag/v1.0.0")
 }

--- a/common/version_test.go
+++ b/common/version_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDevelopmentVersionInfo(t *testing.T) {
+	v := AppVersionInfo{
+		Version:   "dev",
+		BuildDate: "",
+	}
+
+	assert.Equal(t, v.Shortline(), "dev")
+	assert.Equal(t, v.ChangelogURL(), "https://github.com/dunglas/mercure/releases/latest")
+}
+
+func TestTaggedVersionInfo(t *testing.T) {
+	v := AppVersionInfo{
+		Version:   "1.0.0",
+		BuildDate: "2020-05-03T18:42:44Z",
+	}
+
+	assert.Equal(t, v.Shortline(), "1.0.0 (2020-05-03T18:42:44Z)")
+	assert.Equal(t, v.ChangelogURL(), "https://github.com/dunglas/mercure/releases/tag/v1.0.0")
+}


### PR DESCRIPTION
Proposal for #249 

Output in development mode :

```text
$ go run main.go --version

Mercure.rocks Hub version dev
https://github.com/dunglas/mercure/releases/latest
```

Output with tagged version : 

```text
$ ./mercure --version

Mercure.rocks Hub version 0.10.0, commit 2159374, build at 2020-04-30T20:11:23Z
https://github.com/dunglas/mercure/releases/tag/v0.10.0
```