### PR TITLE
Fixed a typo in openapi.yaml

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -18,7 +18,7 @@ paths:
     get:
       summary: Subscribe to updates
       externalDocs:
-        description: Sucbriptions specification
+        description: Subscriptions specification
         url: https://github.com/dunglas/mercure/blob/master/spec/mercure.md#subscriptions
       parameters:
         - name: topic


### PR DESCRIPTION
Fixed a typo in openapi.yaml's description of the get endpoint for subscribing to updates