### PR TITLE
Add metric to display build stat

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -13,7 +13,7 @@ type AppVersionInfo struct {
 	Version      string
 	BuildDate    string
 	Commit       string
-	GOVersion    string
+	GoVersion    string
 	OS           string
 	Architecture string
 }
@@ -54,7 +54,7 @@ func (v *AppVersionInfo) NewMetricsCollector() *prometheus.GaugeVec {
 		"version":      v.Version,
 		"built_at":     v.BuildDate,
 		"commit":       v.Commit,
-		"go_version":   v.GOVersion,
+		"go_version":   v.GoVersion,
 		"os":           v.OS,
 		"architecture": v.Architecture,
 	}
@@ -90,7 +90,7 @@ func init() { //nolint:gochecknoinits
 		Version:      version,
 		BuildDate:    buildDate,
 		Commit:       commit,
-		GOVersion:    runtime.Version(),
+		GoVersion:    runtime.Version(),
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 	}

--- a/common/version.go
+++ b/common/version.go
@@ -2,14 +2,20 @@ package common
 
 import (
 	"fmt"
+	"runtime"
 	"runtime/debug"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type AppVersionInfo struct {
-	Version   string
-	BuildDate string
-	Commit    string
+	Version      string
+	BuildDate    string
+	Commit       string
+	GOVersion    string
+	OS           string
+	Architecture string
 }
 
 var AppVersion AppVersionInfo //nolint:gochecknoglobals
@@ -43,6 +49,33 @@ func (v *AppVersionInfo) ChangelogURL() string {
 	return fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(v.Version, "v"))
 }
 
+func (v *AppVersionInfo) NewMetricsCollector() *prometheus.GaugeVec {
+	labels := map[string]string{
+		"version":      v.Version,
+		"built_at":     v.BuildDate,
+		"commit":       v.Commit,
+		"go_version":   v.GOVersion,
+		"os":           v.OS,
+		"architecture": v.Architecture,
+	}
+
+	labelNames := make([]string, 0, len(labels))
+	for n := range labels {
+		labelNames = append(labelNames, n)
+	}
+
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mercure_version_info",
+			Help: "A metric with a constant '1' value labeled by different build stats fields.",
+		},
+		labelNames,
+	)
+	buildInfo.With(labels).Set(1)
+
+	return buildInfo
+}
+
 func init() { //nolint:gochecknoinits
 	if version == "dev" {
 		info, ok := debug.ReadBuildInfo()
@@ -54,8 +87,11 @@ func init() { //nolint:gochecknoinits
 	version = strings.TrimPrefix(version, "v")
 
 	AppVersion = AppVersionInfo{
-		Version:   version,
-		BuildDate: buildDate,
-		Commit:    commit,
+		Version:      version,
+		BuildDate:    buildDate,
+		Commit:       commit,
+		GOVersion:    runtime.Version(),
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
 	}
 }

--- a/common/version_test.go
+++ b/common/version_test.go
@@ -3,13 +3,18 @@ package common
 import (
 	"testing"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionInfo(t *testing.T) {
 	v := AppVersionInfo{
-		Version:   "dev",
-		BuildDate: "",
+		Version:      "dev",
+		BuildDate:    "",
+		Commit:       "",
+		GOVersion:    "go1.14.2",
+		OS:           "linux",
+		Architecture: "amd64",
 	}
 
 	assert.Equal(t, v.Shortline(), "dev")
@@ -18,9 +23,12 @@ func TestVersionInfo(t *testing.T) {
 
 func TestVersionInfoWithBuildDate(t *testing.T) {
 	v := AppVersionInfo{
-		Version:   "1.0.0",
-		BuildDate: "2020-05-03T18:42:44Z",
-		Commit:    "",
+		Version:      "1.0.0",
+		BuildDate:    "2020-05-03T18:42:44Z",
+		Commit:       "",
+		GOVersion:    "go1.14.2",
+		OS:           "linux",
+		Architecture: "amd64",
 	}
 
 	assert.Equal(t, v.Shortline(), "1.0.0, built at 2020-05-03T18:42:44Z")
@@ -29,9 +37,12 @@ func TestVersionInfoWithBuildDate(t *testing.T) {
 
 func TestVersionInfoWithCommit(t *testing.T) {
 	v := AppVersionInfo{
-		Version:   "1.0.0",
-		BuildDate: "",
-		Commit:    "96ee2b9",
+		Version:      "1.0.0",
+		BuildDate:    "",
+		Commit:       "96ee2b9",
+		GOVersion:    "go1.14.2",
+		OS:           "linux",
+		Architecture: "amd64",
 	}
 
 	assert.Equal(t, v.Shortline(), "1.0.0, commit 96ee2b9")
@@ -40,11 +51,49 @@ func TestVersionInfoWithCommit(t *testing.T) {
 
 func TestVersionInfoWithBuildDateAndCommit(t *testing.T) {
 	v := AppVersionInfo{
-		Version:   "1.0.0",
-		BuildDate: "2020-05-03T18:42:44Z",
-		Commit:    "96ee2b9",
+		Version:      "1.0.0",
+		BuildDate:    "2020-05-03T18:42:44Z",
+		Commit:       "96ee2b9",
+		GOVersion:    "go1.14.2",
+		OS:           "linux",
+		Architecture: "amd64",
 	}
 
 	assert.Equal(t, v.Shortline(), "1.0.0, commit 96ee2b9, built at 2020-05-03T18:42:44Z")
 	assert.Equal(t, v.ChangelogURL(), "https://github.com/dunglas/mercure/releases/tag/v1.0.0")
+}
+
+func TestVersionMetricsCollectorInitialization(t *testing.T) {
+	var metricOut dto.Metric
+
+	v := AppVersionInfo{
+		Version:      "1.0.0",
+		BuildDate:    "2020-05-03T18:42:44Z",
+		Commit:       "96ee2b9",
+		GOVersion:    "go1.14.2",
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+
+	c := v.NewMetricsCollector()
+
+	labelValues := map[string]string{
+		"version":      v.Version,
+		"built_at":     v.BuildDate,
+		"commit":       v.Commit,
+		"go_version":   v.GOVersion,
+		"os":           v.OS,
+		"architecture": v.Architecture,
+	}
+	m, err := c.GetMetricWith(labelValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = m.Write(&metricOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1.0, *metricOut.Gauge.Value)
 }

--- a/common/version_test.go
+++ b/common/version_test.go
@@ -12,7 +12,7 @@ func TestVersionInfo(t *testing.T) {
 		Version:      "dev",
 		BuildDate:    "",
 		Commit:       "",
-		GOVersion:    "go1.14.2",
+		GoVersion:    "go1.14.2",
 		OS:           "linux",
 		Architecture: "amd64",
 	}
@@ -26,7 +26,7 @@ func TestVersionInfoWithBuildDate(t *testing.T) {
 		Version:      "1.0.0",
 		BuildDate:    "2020-05-03T18:42:44Z",
 		Commit:       "",
-		GOVersion:    "go1.14.2",
+		GoVersion:    "go1.14.2",
 		OS:           "linux",
 		Architecture: "amd64",
 	}
@@ -40,7 +40,7 @@ func TestVersionInfoWithCommit(t *testing.T) {
 		Version:      "1.0.0",
 		BuildDate:    "",
 		Commit:       "96ee2b9",
-		GOVersion:    "go1.14.2",
+		GoVersion:    "go1.14.2",
 		OS:           "linux",
 		Architecture: "amd64",
 	}
@@ -54,7 +54,7 @@ func TestVersionInfoWithBuildDateAndCommit(t *testing.T) {
 		Version:      "1.0.0",
 		BuildDate:    "2020-05-03T18:42:44Z",
 		Commit:       "96ee2b9",
-		GOVersion:    "go1.14.2",
+		GoVersion:    "go1.14.2",
 		OS:           "linux",
 		Architecture: "amd64",
 	}
@@ -70,7 +70,7 @@ func TestVersionMetricsCollectorInitialization(t *testing.T) {
 		Version:      "1.0.0",
 		BuildDate:    "2020-05-03T18:42:44Z",
 		Commit:       "96ee2b9",
-		GOVersion:    "go1.14.2",
+		GoVersion:    "go1.14.2",
 		OS:           "linux",
 		Architecture: "amd64",
 	}
@@ -81,7 +81,7 @@ func TestVersionMetricsCollectorInitialization(t *testing.T) {
 		"version":      v.Version,
 		"built_at":     v.BuildDate,
 		"commit":       v.Commit,
-		"go_version":   v.GOVersion,
+		"go_version":   v.GoVersion,
 		"os":           v.OS,
 		"architecture": v.Architecture,
 	}

--- a/hub/metrics.go
+++ b/hub/metrics.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"github.com/dunglas/mercure/common"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -43,6 +44,9 @@ func NewMetrics() *Metrics {
 // Register configures the Prometheus registry with all collected metrics.
 func (m *Metrics) Register(r *mux.Router) {
 	registry := prometheus.NewRegistry()
+
+	// Metrics about current version
+	registry.MustRegister(common.AppVersion.NewMetricsCollector())
 
 	// Metrics about the Hub
 	registry.MustRegister(m.subscribers)


### PR DESCRIPTION
The last PR about metrics data :)

Add a metric to display build stats about the Hub.

Output sample:

```text
# ...
# HELP mercure_version_info A metric with a constant '1' value labeled by different build stats fields.
# TYPE mercure_version_info gauge
mercure_version_info{architecture="amd64",built_at="2020-05-12T17:08:41Z",commit="93cade8",go_version="go1.14.2",os="linux",version="0.9.0-next"} 1
# ...
```