### PR TITLE
Make the subscription web API optional

### DIFF
--- a/hub/server.go
+++ b/hub/server.go
@@ -166,6 +166,9 @@ func (h *Hub) registerSubscriptionHandlers(r *mux.Router) {
 	if !h.config.GetBool("subscriptions") {
 		return
 	}
+	if _, ok := h.transport.(TransportSubscribers); !ok {
+		return
+	}
 
 	r.UseEncodedPath()
 	r.SkipClean(true)

--- a/hub/subscribe.go
+++ b/hub/subscribe.go
@@ -13,8 +13,7 @@ import (
 
 // SubscribeHandler creates a keep alive connection and sends the events to the subscribers.
 func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
-	_, ok := w.(http.Flusher)
-	if !ok {
+	if _, ok := w.(http.Flusher); !ok {
 		panic("http.ResponseWriter must be an instance of http.Flusher")
 	}
 

--- a/hub/subscribe_test.go
+++ b/hub/subscribe_test.go
@@ -398,7 +398,7 @@ func TestSubscriptionEvents(t *testing.T) {
 		defer wg.Done()
 
 		for {
-			_, s := hub.transport.GetSubscribers()
+			_, s := hub.transport.(TransportSubscribers).GetSubscribers()
 			if len(s) == 2 {
 				break
 			}

--- a/hub/subscription.go
+++ b/hub/subscription.go
@@ -107,8 +107,12 @@ func (h *Hub) initSubscription(currentURL string, w http.ResponseWriter, r *http
 		return "", nil, false
 	}
 
-	lastEventID, subscribers = h.transport.GetSubscribers()
+	transport, ok := h.transport.(TransportSubscribers)
+	if !ok {
+		panic("The transport isn't an instance of hub.TransportSubscribers")
+	}
 
+	lastEventID, subscribers = transport.GetSubscribers()
 	if r.Header.Get("If-None-Match") == lastEventID {
 		w.WriteHeader(http.StatusNotModified)
 		return "", nil, false

--- a/hub/subscription_test.go
+++ b/hub/subscription_test.go
@@ -111,7 +111,7 @@ func TestSubscriptionsHandler(t *testing.T) {
 	assert.Equal(t, subscriptionsURL, subscriptions.ID)
 	assert.Equal(t, "Subscriptions", subscriptions.Type)
 
-	lastEventID, subscribers := hub.transport.GetSubscribers()
+	lastEventID, subscribers := hub.transport.(TransportSubscribers).GetSubscribers()
 
 	assert.Equal(t, lastEventID, subscriptions.LastEventID)
 	require.NotEmpty(t, subscribers)
@@ -162,7 +162,7 @@ func TestSubscriptionsHandlerForTopic(t *testing.T) {
 	assert.Equal(t, defaultHubURL+"/subscriptions/"+escapedBarTopic, subscriptions.ID)
 	assert.Equal(t, "Subscriptions", subscriptions.Type)
 
-	lastEventID, subscribers := hub.transport.GetSubscribers()
+	lastEventID, subscribers := hub.transport.(TransportSubscribers).GetSubscribers()
 
 	assert.Equal(t, lastEventID, subscriptions.LastEventID)
 	require.NotEmpty(t, subscribers)
@@ -206,7 +206,7 @@ func TestSubscriptionHandler(t *testing.T) {
 	var subscription subscription
 	json.Unmarshal(w.Body.Bytes(), &subscription)
 	expectedSub := s.getSubscriptions(s.Topics[1], "https://mercure.rocks/", true)[1]
-	expectedSub.LastEventID, _ = hub.transport.GetSubscribers()
+	expectedSub.LastEventID, _ = hub.transport.(TransportSubscribers).GetSubscribers()
 	assert.Equal(t, expectedSub, subscription)
 
 	req = httptest.NewRequest("GET", defaultHubURL+"/subscriptions/notexist/"+s.EscapedID, nil)

--- a/hub/transport.go
+++ b/hub/transport.go
@@ -20,11 +20,14 @@ type Transport interface {
 	// AddSubscriber adds a new subscriber to the transport.
 	AddSubscriber(s *Subscriber) error
 
-	// GetSubscribers gets the last event ID and the list of active subscribers at this time.
-	GetSubscribers() (string, []*Subscriber)
-
 	// Close closes the Transport.
 	Close() error
+}
+
+// TransportSubscribers provide a method to retrieve the list of active subscribers.
+type TransportSubscribers interface {
+	// GetSubscribers gets the last event ID and the list of active subscribers at this time.
+	GetSubscribers() (string, []*Subscriber)
 }
 
 var (

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -516,7 +516,7 @@ Example:
 
 ## Subscription API
 
-If the hub supports subscription events (see (#subscription-events)), it **MUST** also expose active
+If the hub supports subscription events (see (#subscription-events)), it **SHOULD** also expose active
 subscriptions through a web API.
 
 For instance, subscribers interested in maintaining a list of active subscriptions can call the web


### PR DESCRIPTION
The web API can be difficult to implement with some transports such as Kafka. Also it has already been requested to make it optional (https://github.com/dunglas/mercure/pull/295#discussion_r427100346).

This PR changes the spec to allow to not implement the API even if subscription events are available, and introduce a new interface for this feature (so transports not supporting just have to no implement the `GetSubscribers()` method.

/cc @docteurklein @soyuka 