### PR TITLE
fix: Let the transport assign the Update ID

### DIFF
--- a/hub/bolt_transport.go
+++ b/hub/bolt_transport.go
@@ -108,6 +108,7 @@ func (t *BoltTransport) Dispatch(update *Update) error {
 	default:
 	}
 
+	AssignUUID(update)
 	updateJSON, err := json.Marshal(*update)
 	if err != nil {
 		return err

--- a/hub/publish.go
+++ b/hub/publish.go
@@ -44,16 +44,16 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	u := newUpdate(
-		topics,
-		private,
-		Event{
+	u := &Update{
+		Topics:  topics,
+		Private: private,
+		Event: Event{
 			r.PostForm.Get("data"),
 			r.PostForm.Get("id"),
 			r.PostForm.Get("type"),
 			retry,
 		},
-	)
+	}
 
 	// Broadcast the update
 	if err := h.transport.Dispatch(u); err != nil {

--- a/hub/subscribe.go
+++ b/hub/subscribe.go
@@ -185,7 +185,11 @@ func (h *Hub) dispatchSubscriptionUpdate(s *Subscriber, active bool) {
 			panic(err)
 		}
 
-		u := newUpdate([]string{subscription.ID}, true, Event{Data: string(json)})
+		u := &Update{
+			Topics:  []string{subscription.ID},
+			Private: true,
+			Event:   Event{Data: string(json)},
+		}
 		h.transport.Dispatch(u)
 	}
 }

--- a/hub/transport.go
+++ b/hub/transport.go
@@ -86,6 +86,7 @@ func (t *LocalTransport) Dispatch(update *Update) error {
 	default:
 	}
 
+	AssignUUID(update)
 	t.Lock()
 	defer t.Unlock()
 	for subscriber := range t.subscribers {

--- a/hub/update.go
+++ b/hub/update.go
@@ -20,17 +20,11 @@ type serializedUpdate struct {
 	event string
 }
 
-func newUpdate(topics []string, private bool, event Event) *Update {
-	u := &Update{
-		Topics:  topics,
-		Private: private,
-		Event:   event,
-	}
+// AssignUUID generates a new UUID an assign it to the given update if no ID is already set.
+func AssignUUID(u *Update) {
 	if u.ID == "" {
 		u.ID = "urn:uuid:" + uuid.Must(uuid.NewV4()).String()
 	}
-
-	return u
 }
 
 func newSerializedUpdate(u *Update) *serializedUpdate {

--- a/hub/update_test.go
+++ b/hub/update_test.go
@@ -8,13 +8,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewUpdate(t *testing.T) {
-	u := newUpdate([]string{"foo"}, true, Event{Retry: 3})
+func TestAssingUUID(t *testing.T) {
+	u := &Update{
+		Topics:  []string{"foo"},
+		Private: true,
+		Event:   Event{Retry: 3},
+	}
+	AssignUUID(u)
 
 	assert.Equal(t, []string{"foo"}, u.Topics)
 	assert.True(t, u.Private)
 	assert.Equal(t, uint64(3), u.Retry)
-
 	assert.True(t, strings.HasPrefix(u.ID, "urn:uuid:"))
 
 	_, err := uuid.FromString(strings.TrimPrefix(u.ID, "urn:uuid:"))


### PR DESCRIPTION
This is useful for instance when the ID is a sequence generated by the transport.