### PR TITLE
Try to clarify difference between protocol and hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The protocol has been published as [an Internet Draft](https://datatracker.ietf.
 A reference, production-grade, implementation of [**a Mercure hub**](https://mercure.rocks/docs/hub/install) (the server) is also available in this repository.
 It's a free software (AGPL) written in Go. It is provided along with a library that can be used in any Go application to implement the Mercure protocol directly (without a hub) and an official Docker image.
 
-In addition, a managed and high-scalability version of Mercure is [available on Mercure.rocks](https://mercure.rocks/pricing).
+In addition, a managed and high-scalability version of the Mercure.rocks hub is [available on Mercure.rocks](https://mercure.rocks/pricing).
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,13 +9,12 @@
 * [Frequently Asked Questions](spec/faq.md)
 * [Use Cases](spec/use-cases.md)
 * [OpenAPI spec](https://github.com/dunglas/mercure/blob/master/spec/openapi.yaml)
-* [Upgrade to newest versions](UPGRADE.md)
 
-## Hub
+## Mercure.rocks Hub
 
-* [Installing the Hub](hub/install.md)
+* [Installing the Mercure.rocks Hub](hub/install.md)
 * [Configuration](hub/config.md)
-* [Creating a cluster of Hubs](hub/cluster.md)
+* [Creating a cluster of Mercure.rocks Hubs](hub/cluster.md)
 * [Cookbooks](hub/cookbooks.md)
 * [Troubleshooting](hub/troubleshooting.md)
 * [Upgrade to newest versions](UPGRADE.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,10 +4,10 @@
 
 ## Starting the Hub
 
-The easiest way to get started is to [install the official Mercure Hub](hub/install.md). When it's done, go directly to the next step.
-Also, keep in mind that the hub is entirely optional. By the specification, your app can implement the Mercure protocol directly (take a look to the [libraries implementing Mercure](ecosystem/awesome.md#hubs-and-server-libraries)).
+The easiest way to get started is to [install the official Mercure.rocks
+Hub](hub/install.md). When it's done, go directly to the next step. There are also other unofficial [libraries implementing Mercure](ecosystem/awesome.md#hubs-and-server-libraries). In the rest of this tutorial, we'll assume that the hub is running on `http://localhost:3000` and that the `JWT_KEY` is `!ChangeMe!`.
 
-In the rest of this tutorial, we'll assume that the hub is running on `http://localhost:3000` and that the `JWT_KEY` is `!ChangeMe!`.
+Please note that the hub is entirely optional when using the Mercure protocol. Your app can also implement the Mercure protocol directly.
 
 ## Subscribing
 

--- a/docs/hub/cluster.md
+++ b/docs/hub/cluster.md
@@ -1,28 +1,28 @@
 # Using Multiple Nodes
 
-The free version of the Mercure Hub is shipped with transports (BoltDB and local) that can only run on a single node.
-However, the Mercure Hub has been designed from the ground up to support clusters.
+The free version of the Mercure.rocks Hub is shipped with transports (BoltDB and local) that can only run on a single node.
+However, the Mercure.rocks Hub has been designed from the ground up to support clusters.
 
-Both [the managed (starting from the Pro plan) and the High Availability (HA) versions of the Mercure Hub](https://mercure.rocks/pricing) natively run on multiple nodes.
+Both [the managed (starting from the Pro plan) and the High Availability (HA) versions of the Mercure.rocks Hub](https://mercure.rocks/pricing) natively run on multiple nodes.
 These versions are designed for fault tolerance and can support very high loads.
 
 Both versions work by providing extra transports supporting synchronization of several nodes.
 They support all features of the free Hub.
 
-If you don't want to purchase a managed or an On Premise version of the Mercure Hub, you can also create your custom build of Mercure [using a custom transport](https://github.com/dunglas/mercure/blob/master/hub/transport.go#L13-L22).
+If you don't want to purchase a managed or an On Premise version of the Mercure.rocks Hub, you can also create your custom build of Mercure.rocks [using a custom transport](https://github.com/dunglas/mercure/blob/master/hub/transport.go#L13-L22).
 
 ## Managed Version
 
 [The managed version](https://mercure.rocks/pricing) is hosted on our own High Availability infrastructure (built on top of Kubernetes). This service is 100% hosted and managed: you have nothing to do!
 
-The managed version of the Mercure Hub can be purchased [directly online](https://mercure.rocks/pricing).
+The managed version of the Mercure.rocks Hub can be purchased [directly online](https://mercure.rocks/pricing).
 After the purchase, a production-ready Hub is instantly deployed.
 
 To use it, just configure your custom domain name (if any) and your secret JWT key from the administration panel, that's all!
 
 ## High Availability Version
 
-The High Availability Mercure Hub is a drop-in replacement for the free Hub which allows to spread the load accros as many servers as you want. It is designed to run on your own servers and is fault tolerant by default.
+The High Availability Mercure.rocks Hub is a drop-in replacement for the free Hub which allows to spread the load accros as many servers as you want. It is designed to run on your own servers and is fault tolerant by default.
 
 The HA version is shipped with transports having node synchronization capabilities.
 These transports can rely on:
@@ -41,13 +41,13 @@ For more details (and a benchmark), [refer to the case study presented by the iG
 
 ### Purchasing
 
-To purchase the On Premise version of the Mercure Hub, drop us a mail: [kevin+mercure@dunglas.fr](mailto:kevin+mercure@dunglas.fr?subject=I%27m%20interested%20in%20Mercure%20on%20premise)
+To purchase the On Premise version of the Mercure.rocks Hub, drop us a mail: [kevin+mercure@dunglas.fr](mailto:kevin+mercure@dunglas.fr?subject=I%27m%20interested%20in%20Mercure%20on%20premise)
 
 ### Setting the License
 
-A license key is provided when you purchase the High Availability version of the Mercure Hub.
+A license key is provided when you purchase the High Availability version of the Mercure.rocks Hub.
 This key must be set in a configuration parameter named `license`.
-All configuration formats supported by the Mercure hub are supported (YAML, environment variables...).
+All configuration formats supported by the Mercure.rocks hub are supported (YAML, environment variables...).
 
 Ex:
 
@@ -61,7 +61,7 @@ If you use the Helm chart, set the `license` value and change the Docker image t
 
 ### Transports
 
-The clustered mode of the Mercure Hub requires a transport to work.
+The clustered mode of the Mercure.rocks Hub requires a transport to work.
 Supported transports are Apache Pulsar, Apache Kafka and PostgreSQL.
 
 #### Redis Transport
@@ -80,7 +80,7 @@ Most Cloud Computing platforms also provide managed versions of Redis.
 
 ##### Configuration
 
-All the configuration parameters, and formats, supported by the free Mercure Hub are also available.
+All the configuration parameters, and formats, supported by the free Mercure.rocks Hub are also available.
 See https://mercure.rocks/docs/hub/config.
 
 To use Redis, the `transport_url` configuration parameter must be set like in this example:
@@ -105,7 +105,7 @@ The following options can be passed as query parameters of the URL set in `trans
 #### PostgreSQL Transport
 
 The PostgreSQL Transport allows to store permanently the event and to query them using the full power of SQL.
-It is mostly useful when using the Mercure Hub as an event store, or as a primary data store.
+It is mostly useful when using the Mercure.rocks Hub as an event store, or as a primary data store.
 
 To install PostgreSQL, [read the documentation](https://www.postgresql.org/docs/12/tutorial-install.html).
 Most Cloud Computing platforms also provide managed versions of PostgreSQL.
@@ -118,7 +118,7 @@ Most Cloud Computing platforms also provide managed versions of PostgreSQL.
 
 ##### Configuration
 
-All the configuration parameters, and formats, supported by the free Mercure Hub are also available.
+All the configuration parameters, and formats, supported by the free Mercure.rocks Hub are also available.
 See https://mercure.rocks/docs/hub/config.
 
 To use PostgreSQL `LISTEN`/`NOTIFY`, the `transport_url` configuration parameter must be set like in this example:
@@ -141,7 +141,7 @@ The Kafka transport should only be used when Pulsar is already part of your stac
 To install Apache Kafka, [read the quickstart guide](https://kafka.apache.org/quickstart).
 
 Most Cloud Computing platforms also provide managed versions of Kafka.
-The Mercure hub has been tested with:
+The Mercure.rocks hub has been tested with:
 
 * Bitnami's Kafka Docker images (Kubernetes and the like)
 * Amazon Managed Streaming for Apache Kafka (Amazon MSK)
@@ -156,7 +156,7 @@ The Mercure hub has been tested with:
 
 ##### Configuration
 
-All the configuration parameters, and formats, supported by the free Mercure Hub are also available.
+All the configuration parameters, and formats, supported by the free Mercure.rocks Hub are also available.
 See https://mercure.rocks/docs/hub/config.
 
 To use Kafka, the `transport_url` configuration parameter must be set like in this example:
@@ -175,8 +175,8 @@ The following options can be passed as query parameters of the URL set in `trans
 | Parameter        | Description                                                                                                                                 |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | `addr`           | addresses of the Kafka servers, you can pass several `addr` parameters to use several Kafka servers (ex: `addr=host1:9092&addr=host2:9092`) |
-| `topic`          | the name of the Kafka topic to use (ex: `topic=mercure-ha`), **all Mercure hub instances must use the same topic**                          |
-| `consumer_group` | consumer group, **must be different for every instance of the Mercure hub** (ex: `consumer_group=<random-string>`)                          |
+| `topic`          | the name of the Kafka topic to use (ex: `topic=mercure-ha`), **all Mercure.rocks hub instances must use the same topic**                          |
+| `consumer_group` | consumer group, **must be different for every instance of the Mercure.rocks hub** (ex: `consumer_group=<random-string>`)                          |
 | `user`           | Kafka SASL user (optional, ex: `user=kevin`)                                                                                                |
 | `password`       | Kafka SASL password (optional, ex: `password=maman`)                                                                                        |
 | `tls`            | Set to `1` to enable TLS (ex: `tls=1`)                                                                                                      |
@@ -195,7 +195,7 @@ To install Apache Pulsar, [read the documentation](https://pulsar.apache.org/doc
 
 ##### Configuration
 
-All the configuration parameters, and formats, supported by the free Mercure Hub are also available.
+All the configuration parameters, and formats, supported by the free Mercure.rocks Hub are also available.
 See https://mercure.rocks/docs/hub/config.
 
 To use Pulsar, the `transport_url` configuration parameter must be set like in this example:
@@ -213,8 +213,8 @@ The following options can be passed as query parameters of the URL set in `trans
 
 | Parameters          | Description                                                                                                                                |   |
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------|---|
-| `topic`             | the name of the Pulsar topic to use (ex: `topic=mercure`), **all Mercure hub instances must use the same topic**                           |   |
-| `subscription_name` | the subscription name for this node, **must be different for every instance of the Mercure hub** (ex: `subscription_name=<random-string>`) |   |
+| `topic`             | the name of the Pulsar topic to use (ex: `topic=mercure`), **all Mercure.rocks hub instances must use the same topic**                           |   |
+| `subscription_name` | the subscription name for this node, **must be different for every instance of the Mercure.rocks hub** (ex: `subscription_name=<random-string>`) |   |
 
 ### Docker Images and Kubernetes Chart
 
@@ -223,4 +223,4 @@ Contact us if you need help to use them.
 
 ### Updates
 
-New releases of the High Availability Mercure Hub are automatically available available in the Amazon S3 bucket containing the binary and on the Docker registry.
+New releases of the High Availability Mercure.rocks Hub are automatically available available in the Amazon S3 bucket containing the binary and on the Docker registry.

--- a/docs/hub/config.md
+++ b/docs/hub/config.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The Mercure Hub is configurable using [environment variables](https://en.wikipedia.org/wiki/Environment_variable) (recommended in production, [twelve-factor app methodology](https://12factor.net/)), command line flags and configuration files (JSON, TOML, YAML, HCL, envfile and Java properties files are supported).
+The Mercure.rocks Hub is configurable using [environment variables](https://en.wikipedia.org/wiki/Environment_variable) (recommended in production, [twelve-factor app methodology](https://12factor.net/)), command line flags and configuration files (JSON, TOML, YAML, HCL, envfile and Java properties files are supported).
 
 Environment variables must be the name of the configuration parameter in uppercase.
 Run `./mercure -h` to see all available command line flags.

--- a/docs/hub/cookbooks.md
+++ b/docs/hub/cookbooks.md
@@ -14,7 +14,7 @@ To reproduce the problem, we provide [a load test](load-test.md) that you can us
 
 ## Monitoring the Hub Using Supervisor
 
-Use the following file as a template to run the Mercure hub with [Supervisor](http://supervisord.org):
+Use the following file as a template to run the Mercure.rocks hub with [Supervisor](http://supervisord.org):
 
 ```ini
 [program:mercure]
@@ -36,7 +36,7 @@ stderr_logfile=/path/to/logs/mercure.error.log
 ```
 
 Save this file to `/etc/supervisor/conf.d/mercure.conf`.
-Run `supervisorctl reread` and `supervisorctl update` to activate and start the Mercure hub.
+Run `supervisorctl reread` and `supervisorctl update` to activate and start the Mercure.rocks hub.
 
 ## Using NGINX as an HTTP/2 Reverse Proxy in Front of the Hub
 

--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -1,8 +1,8 @@
-# Install
+# Install the Mercure.rocks hub
 
 ## Managed and HA Versions
 
-[Managed and High Availability versions of Mercure](https://mercure.rocks/pricing) are available, give them a try!
+[Managed and High Availability versions of Mercure.rocks](https://mercure.rocks/pricing) are available, give them a try!
 
 ## Prebuilt Binary
 
@@ -23,7 +23,7 @@ Allow it for both public and private networks. If you use an antivirus, or anoth
 
 The server is now available on `http://localhost:3000`, with the demo mode enabled. Because the `allow_anonymous` option is enabled, anonymous subscribers are allowed.
 
-To run it in production mode, and generate automatically a Let's Encrypt TLS certificate, just run the following command as root:
+To run it in production mode, and generate automatically a Let's Encrypt TLS certificate, run the following command as root:
 
     JWT_KEY='!ChangeMe!' ACME_HOSTS='example.com' ./mercure
 
@@ -38,7 +38,7 @@ When the server is up and running, the following endpoints are available:
 * `POST https://example.com/.well-known/mercure`: to publish updates
 * `GET https://example.com/.well-known/mercure`: to subscribe to updates
 
-See [the protocol](spec/mercure.md) for further informations.
+See [the protocol](spec/mercure.md) for more details about these endpoints.
 
 To compile the development version and register the demo page, see [https://github.com/dunglas/mercure/blob/master/CONTRIBUTING.md](CONTRIBUTING.md#hub).
 
@@ -64,13 +64,13 @@ Be sure to update the value of `ACME_HOSTS` to match your domain name(s), a Let'
 
 ## Kubernetes
 
-To install Mercure in a [Kubernetes](https://kubernetes.io) cluster, use the official [Helm Chart](https://hub.helm.sh/charts/stable/mercure):
+To install Mercure.rocks in a [Kubernetes](https://kubernetes.io) cluster, use the official [Helm Chart](https://hub.helm.sh/charts/stable/mercure):
 
     helm install stable/mercure
 
 ## Arch Linux
 
-Mercure is available [on the AUR](https://aur.archlinux.org/packages/mercure), you can install it with your favorite AUR wrapper:
+Mercure.rocks is available [on the AUR](https://aur.archlinux.org/packages/mercure), you can install it with your favorite AUR wrapper:
 
     yay -S mercure
 

--- a/docs/hub/load-test.md
+++ b/docs/hub/load-test.md
@@ -1,7 +1,7 @@
 # Load Test
 
-According to a benchmark made by Glory4Gamers, the open source version of the Mercure hub is able to 40k concurrent connections on a single EC2 t3.micro instance.
-It's even possible to handle way more connections by using [the HA version of the Mercure Hub](cluster.md).
+According to a benchmark made by Glory4Gamers, the open source version of the Mercure.rocks hub is able to 40k concurrent connections on a single EC2 t3.micro instance.
+It's even possible to handle way more connections by using [the HA version of the Mercure.rocks Hub](cluster.md).
 
 To test your own infrastructure, we provide a [Gatling](https://gatling.io)-based load test. It allows to test any implementation of the protocol, including the open source Hub.
 

--- a/docs/mercure.md
+++ b/docs/mercure.md
@@ -1,5 +1,7 @@
 # Mercure in a Few Words
 
+The Mercure protocol:
+
 * native browser support, no lib nor SDK required (built on top of HTTP and [server-sent events](https://www.smashingmagazine.com/2018/02/sse-websockets-data-flow-http2/))
 * compatible with all existing servers, even those who don't support persistent connections (serverless architecture, PHP, FastCGI...)
 * built-in connection re-establishment and state reconciliation
@@ -11,7 +13,7 @@
 * can work with old browsers (IE7+) using an `EventSource` polyfill
 * [connection-less push](https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource-push) in controlled environments (e.g. browsers on mobile handsets tied to specific carriers)
 
-The reference hub implementation:
+The mercure.rocks hub implementation:
 
 * Fast, written in Go
 * Works everywhere: static binaries and Docker images available

--- a/docs/mercure.md
+++ b/docs/mercure.md
@@ -13,7 +13,7 @@ The Mercure protocol:
 * can work with old browsers (IE7+) using an `EventSource` polyfill
 * [connection-less push](https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource-push) in controlled environments (e.g. browsers on mobile handsets tied to specific carriers)
 
-The mercure.rocks hub implementation:
+The Mercure.rocks hub implementation:
 
 * Fast, written in Go
 * Works everywhere: static binaries and Docker images available


### PR DESCRIPTION
There was quite some confusion in the Symfony Slack about Mercure yesterday. I was completely confused as well and I'm happy things are clarified now, thank you for your time @dunglas! To give something back for the great OSS protocol and hub, I wanted to see whether the docs can be more clear to hopefully avoid some confusion.

This PR changes 3 things. I'm happy to revert things if you disagree, we're just about getting started with Mercure.

1. Explicitly call the hub "Mercure.rocks hub" instead of "Mercure", "Mercure Hub", or just "Hub". To be more explicit about what is talking about the hub in a generic (protocol-based) sense and what is talking about the Go hub;
2. Changed the wordings in the "Starting the Hub" section of the Getting Started guide. This is probably the most read guide for beginners, it's important to clarify the different entities (Protocol, Go hub, etc) and their meaning;
3. Removed "Upgrade to newest versions" from the Protocol Specification. It seems a changelog for the hub (when looking at the first sentence of this doc).

I recommend some other changes, which don't live in this repository:

* The purchasing information about the on-premise HA version is hidden [far deep in the docs](https://mercure.rocks/docs/hub/cluster#purchasing). I recommend adding this info on the "Pricing" page as well. I only found this information while working on this PR (and this is the option I'm interested in, so I had been looking for it).
* The AGPL license is in a list of licenses that most people are afraid of (I have to discuss it with my COO before I'm allowed to use AGPL software). I recommend adding something about the implications of this license in the docs. As I understand, you should not be afraid of the AGPL license if you use the Hub, but that's only after you posted it on Slack.