### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -91,7 +91,7 @@ mercure:
         - 443:443
     environment:
         - JWT_KEY=!ChangeMe!
-        - ACMS_HOSTS=example.com
+        - ACME_HOSTS=example.com
 ```
 
 ## Kubernetes


### PR DESCRIPTION
Just a little typo on env variable name.