### PR TITLE
Test : subscriber auth for load tests

### DIFF
--- a/docs/hub/load-test.md
+++ b/docs/hub/load-test.md
@@ -17,6 +17,7 @@ Available environment variables (all are optional):
 
  * `HUB_URL`: the URL of the hub to test
  * `JWT`: the JWT to use for authenticating the publisher
+ * `SUBSCRIBER_JWT`: the JWT to use for authenticating the subsribers
  * `INITIAL_SUBSCRIBERS`: the number of concurrent subscribers initially connected
  * `SUBSCRIBERS_RATE_FROM`: minimum rate (per second) of additional subscribers to connect
  * `SUBSCRIBERS_RATE_TO`: maximum rate (per second) of additional subscribers to connect


### PR DESCRIPTION
This PR goal is to add JWT authentication support for **subscribers** in load tests.
I had the need to test a Mercure infrastructure which support authenticated subscribers only.

I am not very happy with [this diff](https://github.com/dunglas/mercure/compare/master...rneuter:test/subscriberAuthForLoadTests?expand=1#diff-07d4e3a1d6f87c8dd0a9caeb2a995444R66) because it implies that Authorization is always send, but empty when **SUBSCRIBER_JWT** environment variable is not setup. What do you think about it ? I had struggle to condition it, 1st time reading and writing Scala...

Thank you for considering these modifications.