### PR TITLE
feat: add an option to specify UI's assets path

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -6,7 +6,7 @@
     experimental_http3
 }
 
-:80
+localhost
 
 log
 

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -50,7 +50,7 @@ type Mercure struct {
 	Anonymous bool `json:"anonymous,omitempty"`
 
 	// Enable the demo.
-	Demo bool `json:"demo,omitempty"`
+	Demo string `json:"demo,omitempty"`
 
 	// Dispatch updates when subscriptions are created or terminated
 	Subscriptions bool `json:"subscriptions,omitempty"`
@@ -145,8 +145,8 @@ func (m *Mercure) Provision(ctx caddy.Context) error { //nolint:funlen
 	if m.Anonymous {
 		opts = append(opts, mercure.WithAnonymous())
 	}
-	if m.Demo {
-		opts = append(opts, mercure.WithDemo())
+	if m.Demo != "" {
+		opts = append(opts, mercure.WithDemo(m.Demo))
 	}
 	if m.Subscriptions {
 		opts = append(opts, mercure.WithSubscriptions())
@@ -202,7 +202,11 @@ func (m *Mercure) UnmarshalCaddyfile(d *caddyfile.Dispenser) error { //nolint:fu
 				m.Anonymous = true
 
 			case "demo":
-				m.Demo = true
+				if d.NextArg() {
+					m.Demo = d.Val()
+				} else {
+					m.Demo = "public/"
+				}
 
 			case "subscriptions":
 				m.Subscriptions = true

--- a/config.go
+++ b/config.go
@@ -173,7 +173,7 @@ func NewHubFromViper(v *viper.Viper) (*Hub, error) { //nolint:funlen
 		options = append(options, WithAnonymous())
 	}
 	if v.GetBool("demo") {
-		options = append(options, WithDemo())
+		options = append(options, WithDemo(""))
 	}
 	if d := v.GetDuration("write_timeout"); d != 600*time.Second {
 		options = append(options, WithWriteTimeout(d))

--- a/docs/hub/config.md
+++ b/docs/hub/config.md
@@ -41,7 +41,7 @@ The following Mercure-specific directives are available:
 | `transport_url <url>`                | URL representation of the transport to use. Use `local://local` to disabled history, (example `bolt:///var/run/mercure.db?size=100&cleanup_frequency=0.4`), see also [the cluster mode](cluster.md)                                            | `bolt://mercure.db` |
 | `dispatch_timeout <duration>`        | maximum duration of the dispatch of a single update, set to `0s` disable                                                                                                                                                                       | `5s`                |
 | `write_timeout <duration>`           | maximum duration before closing the connection, set to `0s` disable                                                                                                                                                                            | `600s`              |
-| `demo`                               | enabled the demo mode and the UI                                                                                                                                                                                                               |                     |
+| `demo [<assets-path>]`               | enabled the demo mode and the UI                                                                                                                                                                                                               |                     |
 
 See also [the list of built-in Caddyfile directives](https://caddyserver.com/docs/caddyfile/directives).
 

--- a/handler.go
+++ b/handler.go
@@ -27,9 +27,9 @@ func (h *Hub) initHandler() {
 	router.SkipClean(true)
 
 	csp := "default-src 'self'"
-	if h.debug || h.demo {
+	if h.uiPath != "" {
 		router.PathPrefix(defaultDemoURL).HandlerFunc(Demo).Methods("GET", "HEAD")
-		router.PathPrefix(defaultUIURL).Handler(http.StripPrefix(defaultUIURL, http.FileServer(http.Dir("public"))))
+		router.PathPrefix(defaultUIURL).Handler(http.StripPrefix(defaultUIURL, http.FileServer(http.Dir(h.uiPath))))
 
 		csp += " mercure.rocks cdn.jsdelivr.net"
 	}
@@ -175,9 +175,9 @@ func (h *Hub) chainHandlers() http.Handler {
 	r.HandleFunc(defaultHubURL, h.PublishHandler).Methods("POST")
 
 	csp := "default-src 'self'"
-	if h.debug || h.demo {
+	if h.uiPath != "" {
 		r.PathPrefix("/demo").HandlerFunc(Demo).Methods("GET", "HEAD")
-		r.PathPrefix("/").Handler(http.FileServer(http.Dir("public")))
+		r.PathPrefix("/").Handler(http.FileServer(http.Dir(h.uiPath)))
 		csp += " mercure.rocks cdn.jsdelivr.net"
 	} else {
 		r.HandleFunc("/", welcomeHandler).Methods("GET", "HEAD")

--- a/hub.go
+++ b/hub.go
@@ -32,9 +32,13 @@ func WithDebug() Option {
 }
 
 // WithDemo enables the demo.
-func WithDemo() Option {
+func WithDemo(uiPath string) Option {
 	return func(o *opt) error {
-		o.demo = true
+		if uiPath == "" {
+			o.uiPath = "public/"
+		} else {
+			o.uiPath = uiPath
+		}
 
 		return nil
 	}
@@ -176,8 +180,8 @@ type opt struct {
 	transport       Transport
 	anonymous       bool
 	debug           bool
-	demo            bool
 	subscriptions   bool
+	uiPath          string
 	logger          Logger
 	writeTimeout    time.Duration
 	dispatchTimeout time.Duration

--- a/server_test.go
+++ b/server_test.go
@@ -59,7 +59,7 @@ func TestForwardedHeaders(t *testing.T) {
 }
 
 func TestSecurityOptions(t *testing.T) {
-	h := createAnonymousDummy(WithSubscriptions(), WithDemo(), WithCORSOrigins([]string{"*"}))
+	h := createAnonymousDummy(WithSubscriptions(), WithDemo(""), WithCORSOrigins([]string{"*"}))
 	h.config.Set("cert_file", "fixtures/tls/server.crt")
 	h.config.Set("key_file", "fixtures/tls/server.key")
 	h.config.Set("compress", true)


### PR DESCRIPTION
<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->