### PR TITLE
Authorization: add code examples

### DIFF
--- a/docs/spec/faq.md
+++ b/docs/spec/faq.md
@@ -51,12 +51,12 @@ To unsubscribe, the client just calls `EventSource.close()`.
 
 Also, Mercure can easily be integrated with Apollo GraphQL by creating [a dedicated transport](https://github.com/apollographql/graphql-subscriptions).
 
-## How to send authorization to Mercure?
+## How to Send the Authorization Cookie to the Hub?
 
-Cookies are automatically sent by the browsers when opening an `EventSource` connection if the `withCredentials` attribute is set to `true`:
+Cookies are automatically sent by the browser when opening an `EventSource` connection if the `withCredentials` property is set to `true`:
 
 ```javascript
-const eventSource = new EventSource(hub, {
+const eventSource = new EventSource('https://example.com/.well-known/mercure?topic=foo', {
     withCredentials: true
 });
 ```

--- a/docs/spec/faq.md
+++ b/docs/spec/faq.md
@@ -50,3 +50,13 @@ Updates for the given subscription can then be sent from the GraphQL server to t
 To unsubscribe, the client just calls `EventSource.close()`.
 
 Also, Mercure can easily be integrated with Apollo GraphQL by creating [a dedicated transport](https://github.com/apollographql/graphql-subscriptions).
+
+## How to send authorization to Mercure?
+
+Cookies are automatically sent by the browsers when opening an `EventSource` connection if the `withCredentials` attribute is set to `true`:
+
+```javascript
+const eventSource = new EventSource(hub, {
+    withCredentials: true
+});
+```


### PR DESCRIPTION
I took examples from Symfony's documentation: https://symfony.com/doc/4.4/mercure.html#authorization