### PR TITLE
docs: Fix command example in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Go to `https://localhost` and enjoy!
 To test the legacy server:
 
     $ cd cmd/mercure
-    $ go go run main.go
+    $ go run main.go
 
 Go to `http://localhost:3000` and enjoy!
 


### PR DESCRIPTION
Hi! This PR fixes a typo in the contribution docs. The `go` part is duplicated