### PR TITLE
Fix hanging goroutines when closing a transport

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -168,6 +168,8 @@ func (s *Subscriber) HistoryDispatched(responseLastEventID string) {
 func (s *Subscriber) Disconnect() {
 	s.disconnectedOnce.Do(func() {
 		close(s.disconnected)
+		close(s.live.in)
+		close(s.out)
 	})
 }
 


### PR DESCRIPTION
When closing a tranport via `Close()`, the `Subscriber::start()` and `Subscribe::SubscribeHandler()` goroutines hang. Closing `live.in` and `out` allows to end these goroutines properly.

<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->