### PR TITLE
ci: add back support for i386 architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,11 +24,9 @@ builds:
     - darwin
     - windows
   goarch:
-    # 32 bits architectures aren't supported by dgraph-io/badger yet:
-    # https://github.com/dgraph-io/badger/issues/1385
-    #- 386
+    - 386
     - amd64
-    #- arm
+    - arm
     - arm64
   goarm:
     - 5


### PR DESCRIPTION
https://github.com/dgraph-io/badger/issues/1385 has been fixed.