### PR TITLE
ci: disable deprecated golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,11 @@ linters:
     - cyclop
     - forcetypeassert
 
+    # deprecated
+    - interfacer
+    - maligned
+    - scopelint
+
 issues:
   exclude-rules:
     - path: _test\.go


### PR DESCRIPTION
<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->