### PR TITLE
docs: ensure that xcaddy always use the latest version of the Mercure library

### DIFF
--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -126,7 +126,9 @@ Or download the `PKGBUILD` and compile and install it: `makepkg -sri`.
 
 It's also possible to [download Caddy with Mercure and other modules included](https://caddyserver.com/download?package=github.com%2Fdunglas%2Fmercure%2Fcaddy), or to build your own binaries using [`xcaddy`](https://github.com/caddyserver/xcaddy):
 
-    xcaddy build --with github.com/dunglas/mercure/caddy
+    xcaddy build \
+      --with github.com/dunglas/mercure \
+      --with github.com/dunglas/mercure/caddy
 
 ## Integrations in Popular Frameworks
 


### PR DESCRIPTION
Trick the [Minimal Version Selection](https://golang.org/ref/mod#minimal-version-selection) algorithm used by Go modules to always install the latest version of the Mercure library, even if the one referenced in the `go.mod` file of the Caddy module is outdated.