### PR TITLE
fix!: don't partition the Prometheus metrics per topic to prevent a memory leak

### DIFF
--- a/metrics_test.go
+++ b/metrics_test.go
@@ -16,22 +16,18 @@ func TestNumberOfRunningSubscribers(t *testing.T) {
 	s1 := NewSubscriber("", zap.NewNop(), tss)
 	s1.Topics = []string{"topic1", "topic2"}
 	m.SubscriberConnected(s1)
-	assertGaugeLabelValue(t, 1.0, m.subscribers, "topic1")
-	assertGaugeLabelValue(t, 1.0, m.subscribers, "topic2")
+	assertGaugeValue(t, 1.0, m.subscribers)
 
 	s2 := NewSubscriber("", zap.NewNop(), tss)
 	s2.Topics = []string{"topic2"}
 	m.SubscriberConnected(s2)
-	assertGaugeLabelValue(t, 1.0, m.subscribers, "topic1")
-	assertGaugeLabelValue(t, 2.0, m.subscribers, "topic2")
+	assertGaugeValue(t, 2.0, m.subscribers)
 
 	m.SubscriberDisconnected(s1)
-	assertGaugeLabelValue(t, 0.0, m.subscribers, "topic1")
-	assertGaugeLabelValue(t, 1.0, m.subscribers, "topic2")
+	assertGaugeValue(t, 1.0, m.subscribers)
 
 	m.SubscriberDisconnected(s2)
-	assertGaugeLabelValue(t, 0.0, m.subscribers, "topic1")
-	assertGaugeLabelValue(t, 0.0, m.subscribers, "topic2")
+	assertGaugeValue(t, 0.0, m.subscribers)
 }
 
 func TestTotalNumberOfHandledSubscribers(t *testing.T) {
@@ -41,20 +37,17 @@ func TestTotalNumberOfHandledSubscribers(t *testing.T) {
 	s1 := NewSubscriber("", zap.NewNop(), tss)
 	s1.Topics = []string{"topic1", "topic2"}
 	m.SubscriberConnected(s1)
-	assertCounterValue(t, 1.0, m.subscribersTotal, "topic1")
-	assertCounterValue(t, 1.0, m.subscribersTotal, "topic2")
+	assertCounterValue(t, 1.0, m.subscribersTotal)
 
 	s2 := NewSubscriber("", zap.NewNop(), tss)
 	s2.Topics = []string{"topic2"}
 	m.SubscriberConnected(s2)
-	assertCounterValue(t, 1.0, m.subscribersTotal, "topic1")
-	assertCounterValue(t, 2.0, m.subscribersTotal, "topic2")
+	assertCounterValue(t, 2.0, m.subscribersTotal)
 
 	m.SubscriberDisconnected(s1)
 	m.SubscriberDisconnected(s2)
 
-	assertCounterValue(t, 1.0, m.subscribersTotal, "topic1")
-	assertCounterValue(t, 2.0, m.subscribersTotal, "topic2")
+	assertCounterValue(t, 2.0, m.subscribersTotal)
 }
 
 func TestTotalOfHandledUpdates(t *testing.T) {
@@ -73,41 +66,25 @@ func TestTotalOfHandledUpdates(t *testing.T) {
 		Topics: []string{"topic3"},
 	})
 
-	assertCounterValue(t, 1.0, m.updatesTotal, "topic1")
-	assertCounterValue(t, 3.0, m.updatesTotal, "topic2")
-	assertCounterValue(t, 2.0, m.updatesTotal, "topic3")
+	assertCounterValue(t, 4.0, m.updatesTotal)
 }
 
-func assertGaugeLabelValue(t *testing.T, v float64, g *prometheus.GaugeVec, l string) {
+func assertGaugeValue(t *testing.T, v float64, g prometheus.Gauge) {
 	t.Helper()
 
 	var metricOut dto.Metric
-
-	m, err := g.GetMetricWithLabelValues(l)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = m.Write(&metricOut)
-	if err != nil {
+	if err := g.Write(&metricOut); err != nil {
 		t.Fatal(err)
 	}
 
 	assert.Equal(t, v, *metricOut.Gauge.Value)
 }
 
-func assertCounterValue(t *testing.T, v float64, c *prometheus.CounterVec, l string) {
+func assertCounterValue(t *testing.T, v float64, c prometheus.Counter) {
 	t.Helper()
 
 	var metricOut dto.Metric
-
-	m, err := c.GetMetricWithLabelValues(l)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = m.Write(&metricOut)
-	if err != nil {
+	if err := c.Write(&metricOut); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -336,12 +336,9 @@ func TestMetricsCollect(t *testing.T) {
 	body = url.Values{"topic": {"http://example.com/foo/1"}, "data": {"second hello"}, "id": {"second"}}
 	server.publish(body)
 
-	server.assertMetric("mercure_subscribers{topic=\"http://example.com/foo/1\"} 1")
-	server.assertMetric("mercure_subscribers{topic=\"http://example.com/alt/1\"} 2")
-	server.assertMetric("mercure_subscribers_total{topic=\"http://example.com/foo/1\"} 1")
-	server.assertMetric("mercure_subscribers_total{topic=\"http://example.com/alt/1\"} 3")
-	server.assertMetric("mercure_updates_total{topic=\"http://example.com/foo/1\"} 2")
-	server.assertMetric("mercure_updates_total{topic=\"http://example.com/alt/1\"} 1")
+	server.assertMetric("mercure_subscribers 3")
+	server.assertMetric("mercure_subscribers_total 4")
+	server.assertMetric("mercure_updates_total 2")
 }
 
 func TestMetricsVersionIsAccessible(t *testing.T) {


### PR DESCRIPTION
Closes #463.

As the number of topics is not known in advance, partitioning the Prometheus metrics introduces a memory leak: the number of gauge and counter can grow forever, and quickly.

According to https://github.com/prometheus/client_golang/issues/791#issuecomment-673538744, Prometheus cannot/shouldn't be used for this kind of metrics, and the user should rely on log analysis instead.

@divine could you try is this patch fixes your issue with the Caddy version please?
@jdecool @sagikazarmark as you contributed the Prometheus support, could you take a look if this patch is legit?

Thank you both!