### PR TITLE
ci: more descriptive release name for the Helm chart

### DIFF
--- a/.github/workflows/cd-chart.yml
+++ b/.github/workflows/cd-chart.yml
@@ -1,4 +1,4 @@
-name: Release Charts
+name: Release Chart
 
 on:
   push:
@@ -30,3 +30,4 @@ jobs:
           charts_repo_url: https://charts.mercure.rocks
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CD
+name: Release Hub
 
 on:
   push:

--- a/.github/workflows/ci-chart.yml
+++ b/.github/workflows/ci-chart.yml
@@ -1,4 +1,4 @@
-name: Lint and Test Charts
+name: Lint and Test Chart
 
 on: pull_request
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Lint and Test Hub
 
 on:
   push:

--- a/charts/mercure/Chart.yaml
+++ b/charts/mercure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mercure
-description: The Mercure hub allows to push data updates using the Mercure protocol to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way
+description: A Helm chart to install a Mercure Hub in a Kubernetes cluster. Mercure is a protocol to push data updates to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way.
 home: https://mercure.rocks
 icon: https://mercure.rocks/static/logo.svg
 sources:


### PR DESCRIPTION
Currently, it's unfortunately impossible to use the release created by GoReleaser to store the Helm chart. This PR changes the name of the release used to store the chart to reduce confusion.

Related to https://github.com/helm/chart-releaser/issues/122 and https://github.com/helm/chart-releaser-action/issues/70.