### PR TITLE
feat: Add Service Annotations to Kubernetes helm chart

### DIFF
--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -50,6 +50,7 @@ To install the chart with the release name `my-release`, run the following comma
 | securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 | service.port | int | `80` | Service port. |
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
+| service.annotations | string | `""` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |

--- a/charts/mercure/templates/service.yaml
+++ b/charts/mercure/templates/service.yaml
@@ -4,6 +4,11 @@ metadata:
   name: {{ include "mercure.fullname" . }}
   labels:
     {{- include "mercure.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -74,6 +74,7 @@ service:
   type: ClusterIP
   # -- Service port.
   port: 80
+  annotations: {}
 
 ingress:
   # -- Enable [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/).


### PR DESCRIPTION
<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->

This change, allows to add annotations to the kubernetes helm chart via the values.yaml file