### PR TITLE
WIP: cache canDispatch result

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/kr/text v0.2.0 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -55,3 +55,19 @@ func TestLogSubscriber(t *testing.T) {
 	assert.Contains(t, log, `"topic_selectors":["https://example.com/foo"]`)
 	assert.Contains(t, log, `"topics":["https://example.com/bar"]`)
 }
+
+func BenchmarkDispatch(b *testing.B) {
+	s := NewSubscriber("1", zap.NewNop(), &TopicSelectorStore{})
+	s.Topics = []string{"http://example.com"}
+	go s.start()
+
+	for n := 0; n < b.N; n++ {
+		// Dispatch must be non-blocking
+		// Messages coming from the history can be sent after live messages, but must be received first
+		s.CanDispatch(&Update{Topics: s.Topics})
+		s.CanDispatch(&Update{Topics: s.Topics})
+		s.CanDispatch(&Update{Topics: s.Topics})
+		s.CanDispatch(&Update{Topics: s.Topics})
+	}
+}
+


### PR DESCRIPTION
Still trying to learn Go so accept my apologies for any mistake made here.

Basically, if we cache `canReceive` & `canDispatch` results then Mercure could handle a little bit faster updates:


Before:
```
BenchmarkDispatch
BenchmarkDispatch-8   	 2490588	       478.6 ns/op
PASS
```


After:

```
BenchmarkDispatch
BenchmarkDispatch-8   	  259165	      4017 ns/op
PASS
```

Why use `github.com/mitchellh/hashstructure/v2` to get the hash and process it faster.