### PR TITLE
Update hotwire.md

### DIFF
--- a/docs/ecosystem/hotwire.md
+++ b/docs/ecosystem/hotwire.md
@@ -73,7 +73,7 @@ export default class extends Controller {
 ```
 
 ```html
-<div data-controller="stream" data-turbo-stream-url-value="https://example.com/.well-known/mercure?topic=my-stream">
+<div data-controller="turbo-stream" data-turbo-stream-url-value="https://example.com/.well-known/mercure?topic=my-stream">
   <!-- ... -->
 </div>
 ```


### PR DESCRIPTION
Fixing the name of the referred to StimulusJS controller in the Hotwire example docs.