### PR TITLE
fix: auto-recreate pod when changing secrets or cm

### DIFF
--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Hi,

When we are adding or changing some values that are stored in the configmap or secret, pods are not automatically recreated.

To fix this, I propose to add checksum on these two files like suggested in the official Helm doc [here](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)