### PR TITLE
fix: remove duplicate subscriber removal in Bolt transport

### DIFF
--- a/bolt_transport.go
+++ b/bolt_transport.go
@@ -130,9 +130,7 @@ func (t *BoltTransport) Dispatch(update *Update) error {
 	}
 
 	for _, s := range t.subscribers.MatchAny(update) {
-		if !s.Dispatch(update, false) {
-			t.subscribers.Remove(s)
-		}
+		s.Dispatch(update, false)
 	}
 
 	return nil

--- a/bolt_transport_test.go
+++ b/bolt_transport_test.go
@@ -279,15 +279,11 @@ func TestBoltCleanDisconnectedSubscribers(t *testing.T) {
 	assert.Equal(t, 2, transport.subscribers.Len())
 
 	s1.Disconnect()
-	assert.Equal(t, 2, transport.subscribers.Len())
-
-	transport.Dispatch(&Update{Topics: s1.Topics})
+	transport.RemoveSubscriber(s1)
 	assert.Equal(t, 1, transport.subscribers.Len())
 
 	s2.Disconnect()
-	assert.Equal(t, 1, transport.subscribers.Len())
-
-	transport.Dispatch(&Update{Topics: s1.Topics})
+	transport.RemoveSubscriber(s2)
 	assert.Zero(t, transport.subscribers.Len())
 }
 


### PR DESCRIPTION
Subscribers are automatically cleaned when the HTTP middleware terminates.