### PR TITLE
spec!: force the publisher JWT to contain the allowed topics

### DIFF
--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -417,12 +417,17 @@ To be allowed to publish an update, the JWS presented by the publisher **MUST** 
 called `mercure`, and this claim **MUST** contain a `publish` key. `mercure.publish` contains an
 array of topic selectors. See (#topic-selectors).
 
+<<<<<<< HEAD
 If `mercure.publish`:
 
 *   is not defined, then the publisher **MUST NOT** be authorized to dispatch any update
 *   contains an empty array, the publisher **MUST NOT** be authorized to publish private updates,
     but can publish public updates for all topics.
 
+=======
+If `mercure.publish` is not defined, then the publisher **MUST NOT** be authorized
+to dispatch any update.
+>>>>>>> 7703207 (spec!: force the publisher JWT to contain the allowed topics)
 Otherwise, the hub **MUST** check that every topics of the update to dispatch matches at least one
 of the topic selectors contained in `mercure.publish`.
 

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -417,17 +417,8 @@ To be allowed to publish an update, the JWS presented by the publisher **MUST** 
 called `mercure`, and this claim **MUST** contain a `publish` key. `mercure.publish` contains an
 array of topic selectors. See (#topic-selectors).
 
-<<<<<<< HEAD
-If `mercure.publish`:
-
-*   is not defined, then the publisher **MUST NOT** be authorized to dispatch any update
-*   contains an empty array, the publisher **MUST NOT** be authorized to publish private updates,
-    but can publish public updates for all topics.
-
-=======
-If `mercure.publish` is not defined, then the publisher **MUST NOT** be authorized
-to dispatch any update.
->>>>>>> 7703207 (spec!: force the publisher JWT to contain the allowed topics)
+If `mercure.publish` is not defined, or contains an empty array, then the publisher **MUST NOT**
+be authorized to dispatch any update.
 Otherwise, the hub **MUST** check that every topics of the update to dispatch matches at least one
 of the topic selectors contained in `mercure.publish`.
 


### PR DESCRIPTION
Closes #579.

This is a BC break, but it improves the security of the protocol.
To allow a publisher to publish to all topics, a star (`*`) can be used.