### PR TITLE
Fix description of Transport.RemoveSubscriber

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -44,7 +44,7 @@ type Transport interface {
 	// AddSubscriber adds a new subscriber to the transport.
 	AddSubscriber(s *Subscriber) error
 
-	// RemoveSubscriber removes a new subscriber from the transport.
+	// RemoveSubscriber removes a subscriber from the transport.
 	RemoveSubscriber(s *Subscriber) error
 
 	// Close closes the Transport.


### PR DESCRIPTION
There is a small copy/paste issue in the description of `Transport.RemoveSubscriber`.