### PR TITLE
spec!: rename the Last-Event-ID query parameter in lastEventID

### DIFF
--- a/examples/chat/static/chat.js
+++ b/examples/chat/static/chat.js
@@ -28,7 +28,7 @@ let userList, es;
 
   const subscribeURL = new URL(hubURL);
   subscribeURL.searchParams.append(
-    "Last-Event-ID",
+    "lastEventID",
     subscriptionCollection.lastEventID
   );
   subscribeURL.searchParams.append("topic", messageURITemplate);

--- a/public/app.js
+++ b/public/app.js
@@ -2,7 +2,7 @@
 
 (function () {
   const origin = window.location.origin;
-  
+
   const defaultTopic = document.URL + "demo/books/1.jsonld";
   const placeholderTopic = "https://example.com/my-private-topic";
   const defaultJwt =
@@ -115,7 +115,7 @@ foo`;
     const u = new URL($settingsForm.hubUrl.value);
     topicList.forEach((topic) => u.searchParams.append("topic", topic));
     if (lastEventId.value)
-      u.searchParams.append("Last-Event-ID", lastEventId.value);
+      u.searchParams.append("lastEventID", lastEventId.value);
 
     let ol = null;
     if ($settingsForm.authorization.value === "header")
@@ -226,7 +226,7 @@ foo`;
         "topic",
         "/.well-known/mercure/subscriptions{/topic}{/subscriber}"
       );
-      u.searchParams.append("Last-Event-ID", json.lastEventID);
+      u.searchParams.append("lastEventID", json.lastEventID);
 
       if (opt) subscriptionEventSource = new EventSourcePolyfill(u, opt);
       else subscriptionEventSource = new EventSource(u);

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -88,7 +88,7 @@ The publisher **MAY** provide the following target attributes in the Link Header
 
 *   `last-event-id`: the identifier of the last event dispatched by the publisher at the time of
     the generation of this resource. If provided, it **MUST** be passed to the hub through a query
-    parameter called `Last-Event-ID` and will be used to ensure that possible updates having been
+    parameter called `lastEventID` and will be used to ensure that possible updates having been
     made between the resource generation by the server and the connection to the hub are not lost.
     See (#reconciliation).
 *   `content-type`: the content type of the updates that will be pushed by the hub. If omitted,
@@ -503,26 +503,28 @@ re-connection, the subscriber **MUST** send the last received event id in a
 
 In order to fetch any update dispatched between the initial resource generation by the publisher and
 the connection to the hub, the subscriber **MUST** send the event id provided during the discovery
-as a `Last-Event-ID` header or query parameter. See (#discovery).
+as a `Last-Event-ID` header or a `lastEventID` query parameter. See (#discovery).
 
 `EventSource` implementations may not allow to set HTTP headers during the first connection (before
 a reconnection) and implementations in web browsers don't allow to set it.
 
 To work around this problem, the hub **MUST** also allow to pass the last event id in a query
-parameter named `Last-Event-ID`.
+parameter named `lastEventID`.
 
-If both the `Last-Event-ID` HTTP header and the query parameter are present, the HTTP header
-**MUST** take precedence.
+If both the `Last-Event-ID` HTTP header and the `lastEventID` query parameter are present,
+the HTTP header **MUST** take precedence.
 
-If the `Last-Event-ID` HTTP header or query parameter exists, the hub **SHOULD** send all events
-published following the one bearing this identifier to the subscriber.
+If the `Last-Event-ID` HTTP header or the `lastEventID` query parameter exists,
+the hub **SHOULD** send all events published following the one bearing this identifier
+to the subscriber.
 
 The reserved value `earliest` can be used to hint the hub to send all updates it has for the
 subscribed topics. According to its own policy, the hub **MAY** or **MAY NOT** fulfil this request.
 
 The hub **MAY** discard some events for operational reasons. When the request contains a
-`Last-Event-ID` HTTP header or query parameter the hub **MUST** set a `Last-Event-ID` header on
-the HTTP response. The value of the `Last-Event-ID` response header **MUST** be the id of the event
+`Last-Event-ID` HTTP header or a `lastEventID` query parameter the hub **MUST** set
+a `Last-Event-ID` header on the HTTP response.
+The value of the `Last-Event-ID` response header **MUST** be the id of the event
 preceding the first one sent to the subscriber, or the reserved value `earliest` if there is no
 preceding event (it happens when the hub history is empty, when the subscriber requests the earliest
 event or when the subscriber requests an event that doesn't exist).
@@ -533,7 +535,7 @@ partial updates in the JSON Patch [@RFC6902] format, or when using the hub as an
 updates lost can cause data lost.
 
 To detect if a data lost ocurred, the subscriber **CAN** compare the value of the `Last-Event-ID`
-response HTTP header with the `Last-Event-ID` it requested. In case of data lost, the subscriber
+response HTTP header with the last event ID it requested. In case of data lost, the subscriber
 **SHOULD** re-fetch the original topic.
 
 Note: Native `EventSource` implementations don't give access to headers associated with the HTTP

--- a/subscribe.go
+++ b/subscribe.go
@@ -76,7 +76,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 
 // registerSubscriber initializes the connection.
 func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) *Subscriber {
-	s := NewSubscriber(retrieveLastEventID(r), h.logger)
+	s := NewSubscriber(retrieveLastEventID(r, h.logger), h.logger)
 	s.Debug = h.debug
 	s.RemoteAddr = r.RemoteAddr
 	var privateTopics []string
@@ -153,12 +153,25 @@ func sendHeaders(w http.ResponseWriter, s *Subscriber) {
 }
 
 // retrieveLastEventID extracts the Last-Event-ID from the corresponding HTTP header with a fallback on the query parameter.
-func retrieveLastEventID(r *http.Request) string {
+func retrieveLastEventID(r *http.Request, logger Logger) string {
 	if id := r.Header.Get("Last-Event-ID"); id != "" {
 		return id
 	}
 
-	return r.URL.Query().Get("Last-Event-ID")
+	query := r.URL.Query()
+	if id := query.Get("lastEventID"); id != "" {
+		return id
+	}
+
+	if legacyEventIDValues, present := query["Last-Event-ID"]; present {
+		logger.Info("deprecation: the 'Last-Event-ID' query parameter is deprecated, use 'lastEventID' instead.")
+
+		if len(legacyEventIDValues) != 0 {
+			return legacyEventIDValues[0]
+		}
+	}
+
+	return ""
 }
 
 // Write sends the given string to the client.

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -483,13 +483,30 @@ func TestSendMissedEvents(t *testing.T) {
 	})
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
 
+	// Using deprecated 'Last-Event-ID' query parameter
 	go func() {
 		defer wg.Done()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&Last-Event-ID=a", nil).WithContext(ctx)
+
+		w := &responseTester{
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       ":\nid: b\ndata: d2\n\n",
+			t:                  t,
+			cancel:             cancel,
+		}
+
+		hub.SubscribeHandler(w, req)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&lastEventID=a", nil).WithContext(ctx)
 
 		w := &responseTester{
 			expectedStatusCode: http.StatusOK,
@@ -550,7 +567,7 @@ func TestSendAllEvents(t *testing.T) {
 		defer wg.Done()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&Last-Event-ID="+EarliestLastEventID, nil).WithContext(ctx)
+		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&lastEventID="+EarliestLastEventID, nil).WithContext(ctx)
 
 		w := &responseTester{
 			header:             http.Header{},
@@ -606,7 +623,7 @@ func TestUnknownLastEventID(t *testing.T) {
 		defer wg.Done()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&Last-Event-ID=unknown", nil).WithContext(ctx)
+		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&lastEventID=unknown", nil).WithContext(ctx)
 
 		w := &responseTester{
 			header:             http.Header{},
@@ -674,7 +691,7 @@ func TestUnknownLastEventIDEmptyHistory(t *testing.T) {
 		defer wg.Done()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&Last-Event-ID=unknown", nil).WithContext(ctx)
+		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&lastEventID=unknown", nil).WithContext(ctx)
 
 		w := &responseTester{
 			header:             http.Header{},


### PR DESCRIPTION
closes #613
closes #621