### PR TITLE
feat(hub): rename the Last-Event-ID query parameter in lastEventID

### DIFF
--- a/examples/chat/static/chat.js
+++ b/examples/chat/static/chat.js
@@ -28,7 +28,7 @@ let userList, es;
 
   const subscribeURL = new URL(hubURL);
   subscribeURL.searchParams.append(
-    "Last-Event-ID",
+    "lastEventID",
     subscriptionCollection.lastEventID
   );
   subscribeURL.searchParams.append("topic", messageURITemplate);

--- a/public/app.js
+++ b/public/app.js
@@ -2,7 +2,6 @@
 
 (function () {
   const origin = window.location.origin;
-  
   const defaultTopic = document.URL + "demo/books/1.jsonld";
   const placeholderTopic = "https://example.com/my-private-topic";
   const defaultJwt =
@@ -115,7 +114,7 @@ foo`;
     const u = new URL($settingsForm.hubUrl.value);
     topicList.forEach((topic) => u.searchParams.append("topic", topic));
     if (lastEventId.value)
-      u.searchParams.append("Last-Event-ID", lastEventId.value);
+      u.searchParams.append("lastEventID", lastEventId.value);
 
     let ol = null;
     if ($settingsForm.authorization.value === "header")
@@ -226,7 +225,7 @@ foo`;
         "topic",
         "/.well-known/mercure/subscriptions{/topic}{/subscriber}"
       );
-      u.searchParams.append("Last-Event-ID", json.lastEventID);
+      u.searchParams.append("lastEventID", json.lastEventID);
 
       if (opt) subscriptionEventSource = new EventSourcePolyfill(u, opt);
       else subscriptionEventSource = new EventSource(u);

--- a/subscribe.go
+++ b/subscribe.go
@@ -76,7 +76,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 
 // registerSubscriber initializes the connection.
 func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) *Subscriber {
-	s := NewSubscriber(retrieveLastEventID(r), h.logger)
+	s := NewSubscriber(retrieveLastEventID(r, h.logger), h.logger)
 	s.Debug = h.debug
 	s.RemoteAddr = r.RemoteAddr
 	var privateTopics []string
@@ -153,12 +153,25 @@ func sendHeaders(w http.ResponseWriter, s *Subscriber) {
 }
 
 // retrieveLastEventID extracts the Last-Event-ID from the corresponding HTTP header with a fallback on the query parameter.
-func retrieveLastEventID(r *http.Request) string {
+func retrieveLastEventID(r *http.Request, logger Logger) string {
 	if id := r.Header.Get("Last-Event-ID"); id != "" {
 		return id
 	}
 
-	return r.URL.Query().Get("Last-Event-ID")
+	query := r.URL.Query()
+	if id := query.Get("lastEventID"); id != "" {
+		return id
+	}
+
+	if legacyEventIDValues, present := query["Last-Event-ID"]; present {
+		logger.Info("deprecation: the 'Last-Event-ID' query parameter is deprecated, use 'lastEventID' instead.")
+
+		if len(legacyEventIDValues) != 0 {
+			return legacyEventIDValues[0]
+		}
+	}
+
+	return ""
 }
 
 // Write sends the given string to the client.

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -483,13 +483,30 @@ func TestSendMissedEvents(t *testing.T) {
 	})
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
 
+	// Using deprecated 'Last-Event-ID' query parameter
 	go func() {
 		defer wg.Done()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&Last-Event-ID=a", nil).WithContext(ctx)
+
+		w := &responseTester{
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       ":\nid: b\ndata: d2\n\n",
+			t:                  t,
+			cancel:             cancel,
+		}
+
+		hub.SubscribeHandler(w, req)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&lastEventID=a", nil).WithContext(ctx)
 
 		w := &responseTester{
 			expectedStatusCode: http.StatusOK,
@@ -550,7 +567,7 @@ func TestSendAllEvents(t *testing.T) {
 		defer wg.Done()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&Last-Event-ID="+EarliestLastEventID, nil).WithContext(ctx)
+		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&lastEventID="+EarliestLastEventID, nil).WithContext(ctx)
 
 		w := &responseTester{
 			header:             http.Header{},
@@ -606,7 +623,7 @@ func TestUnknownLastEventID(t *testing.T) {
 		defer wg.Done()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&Last-Event-ID=unknown", nil).WithContext(ctx)
+		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&lastEventID=unknown", nil).WithContext(ctx)
 
 		w := &responseTester{
 			header:             http.Header{},
@@ -674,7 +691,7 @@ func TestUnknownLastEventIDEmptyHistory(t *testing.T) {
 		defer wg.Done()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&Last-Event-ID=unknown", nil).WithContext(ctx)
+		req := httptest.NewRequest("GET", defaultHubURL+"?topic=http://example.com/foos/{id}&lastEventID=unknown", nil).WithContext(ctx)
 
 		w := &responseTester{
 			header:             http.Header{},


### PR DESCRIPTION
closes https://github.com/dunglas/mercure/issues/613
ref https://github.com/dunglas/mercure/pull/621