### PR TITLE
fix(hub): ensure that an update is dispatched if any of its topics is subscribed and allowed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
             "env": {
                 "MERCURE_PUBLISHER_JWT_KEY": "!ChangeMe!",
                 "MERCURE_SUBSCRIBER_JWT_KEY": "!ChangeMe!",
-                "MERCURE_EXTRA_DIRECTIVES": "anonymous"
+                "MERCURE_EXTRA_DIRECTIVES": "anonymous",
+                "GLOBAL_OPTIONS": "debug"
             },
             "args": ["run", "-config", "../../Caddyfile.dev"]
         }

--- a/bolt_transport_test.go
+++ b/bolt_transport_test.go
@@ -231,12 +231,12 @@ func TestBoltTransportDispatch(t *testing.T) {
 	subscribedNotAuthorized := &Update{Topics: []string{"https://example.com/foo"}, Private: true}
 	require.Nil(t, transport.Dispatch(subscribedNotAuthorized))
 
-	public := &Update{Topics: s.Topics}
+	public := &Update{Topics: s.SubscribedTopics}
 	require.Nil(t, transport.Dispatch(public))
 
 	assert.Equal(t, public, <-s.Receive())
 
-	private := &Update{Topics: s.PrivateTopics, Private: true}
+	private := &Update{Topics: s.AllowedPrivateTopics, Private: true}
 	require.Nil(t, transport.Dispatch(private))
 
 	assert.Equal(t, private, <-s.Receive())
@@ -256,7 +256,7 @@ func TestBoltTransportClosed(t *testing.T) {
 	require.Nil(t, transport.Close())
 	require.NotNil(t, transport.AddSubscriber(s))
 
-	assert.Equal(t, transport.Dispatch(&Update{Topics: s.Topics}), ErrClosedTransport)
+	assert.Equal(t, transport.Dispatch(&Update{Topics: s.SubscribedTopics}), ErrClosedTransport)
 
 	_, ok := <-s.out
 	assert.False(t, ok)

--- a/local_transport_test.go
+++ b/local_transport_test.go
@@ -45,7 +45,7 @@ func TestLocalTransportDispatch(t *testing.T) {
 	s.SetTopics([]string{"http://example.com/foo"}, nil)
 	assert.Nil(t, transport.AddSubscriber(s))
 
-	u := &Update{Topics: s.Topics}
+	u := &Update{Topics: s.SubscribedTopics}
 	require.Nil(t, transport.Dispatch(u))
 	assert.Equal(t, u, <-s.Receive())
 }
@@ -97,7 +97,7 @@ func TestLiveReading(t *testing.T) {
 	s.SetTopics([]string{"https://example.com"}, nil)
 	require.Nil(t, transport.AddSubscriber(s))
 
-	u := &Update{Topics: s.Topics}
+	u := &Update{Topics: s.SubscribedTopics}
 	assert.Nil(t, transport.Dispatch(u))
 
 	receivedUpdate := <-s.Receive()

--- a/publish_test.go
+++ b/publish_test.go
@@ -188,7 +188,7 @@ func TestPublishOK(t *testing.T) {
 		assert.True(t, ok)
 		require.NotNil(t, u)
 		assert.Equal(t, "id", u.ID)
-		assert.Equal(t, s.Topics, u.Topics)
+		assert.Equal(t, s.SubscribedTopics, u.Topics)
 		assert.Equal(t, "Hello!", u.Data)
 		assert.True(t, u.Private)
 	}(&wg)
@@ -201,7 +201,7 @@ func TestPublishOK(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", "Bearer "+createDummyAuthorizedJWT(hub, rolePublisher, s.Topics))
+	req.Header.Add("Authorization", "Bearer "+createDummyAuthorizedJWT(hub, rolePublisher, s.SubscribedTopics))
 
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -239,7 +239,7 @@ func TestPublishGenerateUUID(t *testing.T) {
 	h := createDummy()
 
 	s := NewSubscriber("", zap.NewNop())
-	s.SetTopics([]string{"http://example.com/books/1"}, s.Topics)
+	s.SetTopics([]string{"http://example.com/books/1"}, s.SubscribedTopics)
 
 	require.Nil(t, h.transport.AddSubscriber(s))
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -191,7 +191,7 @@ func TestSubscriptionHandler(t *testing.T) {
 
 	var subscription subscription
 	json.Unmarshal(w.Body.Bytes(), &subscription)
-	expectedSub := s.getSubscriptions(s.Topics[1], "https://mercure.rocks/", true)[1]
+	expectedSub := s.getSubscriptions(s.SubscribedTopics[1], "https://mercure.rocks/", true)[1]
 	expectedSub.LastEventID, _, _ = hub.transport.(TransportSubscribers).GetSubscribers()
 	assert.Equal(t, expectedSub, subscription)
 


### PR DESCRIPTION
There is a flaw in the current logic. According to the spec, an update must be dispatched if:

* The subscriber is subscribed to at least one of its topics
* The subscriber is allowed for at least one of its topics (even if it's not the one used to subscribe)

https://mercure.rocks/spec#subscribers

This fixes #651 (thanks @mab05k).

@divine @kevburnsjr, this changes a bit the logic introduced in https://github.com/dunglas/mercure/pull/578.
Would you mean to check it doesn't introduce any performance regression?