### PR TITLE
refactor: use gob instead of ascii85 in SubscriberList (not useful) 

### DIFF
--- a/subscriber_list_test.go
+++ b/subscriber_list_test.go
@@ -1,0 +1,31 @@
+package mercure
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func BenchmarkSubscriberList(b *testing.B) {
+	logger := zap.NewNop()
+
+	l := NewSubscriberList(100)
+	for i := 0; i < 100; i++ {
+		""
+		s := NewSubscriber("", logger)
+		t := fmt.Sprintf("https://example.com/%d", (i % 10))
+		s.SetTopics([]string{"https://example.org/foo", t}, []string{"https://example.net/bar", t})
+
+		l.Add(s)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		assert.NotEmpty(b, l.MatchAny(&Update{Topics: []string{"https://example.org/foo"}}))
+		assert.Empty(b, l.MatchAny(&Update{Topics: []string{"https://example.org/baz"}}))
+		assert.NotEmpty(b, l.MatchAny(&Update{Topics: []string{"https://example.com/8"}, Private: false}))
+	}
+}

--- a/subscriber_list_test.go
+++ b/subscriber_list_test.go
@@ -13,7 +13,6 @@ func BenchmarkSubscriberList(b *testing.B) {
 
 	l := NewSubscriberList(100)
 	for i := 0; i < 100; i++ {
-		""
 		s := NewSubscriber("", logger)
 		t := fmt.Sprintf("https://example.com/%d", (i % 10))
 		s.SetTopics([]string{"https://example.org/foo", t}, []string{"https://example.net/bar", t})


### PR DESCRIPTION
Following #689, I tried using Go's gob encoding instead of my ad hoc ascii85-based encoding, but it proved to be less efficient.

ad hoc encoding:

```
BenchmarkSubscriberList-8   	   91510	     11821 ns/op	   24199 B/op	     124 allocs/op
PASS
ok  	github.com/dunglas/mercure	1.547s
```


gob:

```
BenchmarkSubscriberList-8   	  152517	      7456 ns/op	   20160 B/op	      61 allocs/op
PASS
ok  	github.com/dunglas/mercure	1.359s
```

This PR will be closed, I opened it for the record.