### PR TITLE
refactor: more memory efficient algorithm for SubscriberList

### DIFF
--- a/subscriber_list_test.go
+++ b/subscriber_list_test.go
@@ -8,6 +8,18 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestEncode(t *testing.T) {
+	e := encode([]string{"Foo\x00\x01Bar\x00Baz\x01", "\x01bar"}, true)
+	assert.Equal(t, "1\x01\x00\x01bar\x01Foo\x00\x00\x00\x01Bar\x00\x00Baz\x00\x01", e)
+}
+
+func TestDecode(t *testing.T) {
+	topics, private := decode("1\x01\x00\x01bar\x01Foo\x00\x00\x00\x01Bar\x00\x00Baz\x00\x01")
+
+	assert.Equal(t, []string{"\x01bar", "Foo\x00\x01Bar\x00Baz\x01"}, topics)
+	assert.True(t, private)
+}
+
 func BenchmarkSubscriberList(b *testing.B) {
 	logger := zap.NewNop()
 


### PR DESCRIPTION
Follows #694. This ad hoc algorithm uses less memory and is easier to debug.

Comparative benchmark:

New algo:

```
BenchmarkSubscriberList-8   	  153007	      6932 ns/op	   20152 B/op	      61 allocs/op
PASS
ok  	github.com/dunglas/mercure	1.303s
```

ASCII 85 algo:

```
BenchmarkSubscriberList-8   	  152517	      7456 ns/op	   20160 B/op	      61 allocs/op
PASS
ok  	github.com/dunglas/mercure	1.359s
```
