### PR TITLE
fix(metrics)!: rename mercure_subscribers to mercure_subscribers_connected

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -37,7 +37,7 @@ We still provide standalone binaries, but it's now a custom build of Caddy inclu
 
 Builds of the legacy server are also available to ease the transition, but starting with version 0.12 only the Caddy-based builds will be provided (they have the `legacy` prefix).
 
-Relying on Caddy allows to use the Mercure.rocks Hub as a [reverse proxy](https://caddyserver.com/docs/quick-starts/reverse-proxy) for your website or API that also adds the Mercure well-known URL (`/.well-known/mercure`). Thanks to this new feature, the well-known URL can be on the same domain as your website or API, so you don't need to deal with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
+Relying on Caddy allows to use the Mercure.rocks Hub as a [reverse proxy](https://caddyserver.com/docs/quick-starts/reverse-proxy) for your site or API that also adds the Mercure well-known URL (`/.well-known/mercure`). Thanks to this new feature, the well-known URL can be on the same domain as your site or API, so you don't need to deal with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
 
 All features provided by Caddy are also supported by this custom build: [HTTP/3 and h2c support](https://caddyserver.com/docs/json/apps/http/servers/#experimental_http3), [compression](https://caddyserver.com/docs/caddyfile/directives/encode), [Prometheus metrics](https://caddyserver.com/docs/metrics) (with additional Mercure-specific metrics), profiler (`/debug/pprof/`)...
 

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade
 
+## 0.14.2
+
+The `mercure_subscribers` field of the Prometheus endpoint has been renamed `mercure_subscribers_connected` for better interoperability (including with Datadog).
+
 ## 0.14.1
 
 The default dev key changed from `!ChangeMe!` to `!ChangeThisMercureHubJWTSecretKey!` to respect the specification (they key must longer than 256 bits).

--- a/metrics.go
+++ b/metrics.go
@@ -48,7 +48,7 @@ func NewPrometheusMetrics(registry prometheus.Registerer) *PrometheusMetrics {
 		),
 		subscribers: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "mercure_subscribers",
+				Name: "mercure_subscribers_connected",
 				Help: "The current number of running subscribers",
 			},
 		),

--- a/server_test.go
+++ b/server_test.go
@@ -382,7 +382,7 @@ func TestMetricsCollect(t *testing.T) {
 	body = url.Values{"topic": {"http://example.com/foo/1"}, "data": {"second hello"}, "id": {"second"}}
 	server.publish(body)
 
-	server.assertMetric("mercure_subscribers 3")
+	server.assertMetric("mercure_subscribers_connected 3")
 	server.assertMetric("mercure_subscribers_total 4")
 	server.assertMetric("mercure_updates_total 2")
 }


### PR DESCRIPTION
This change allow Datadog agent to fetch all metrics starting with mercure_subscribers
- mercure_subscribers_gauge (previously mercure_subscribers)
- mercure_subscribers_total

See https://github.com/dunglas/mercure/issues/720 issue for more information