### PR TITLE
docs: revalidate webpages when updating the corresponding MD files

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -1,0 +1,23 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Revalidate changed pages
+        run: |
+          shopt -s globstar
+          FILES=$(git --no-pager diff --name-only HEAD~1 -- docs/**/*.md | awk 'BEGIN{RS="\n"} {printf "%s%s",sep,$0; sep="&files="}')
+          curl --silent --fail-with-body "https://mercure.rocks/api/revalidate?secret=${{ secrets.REVALIDATE_TOKEN }}&files=$FILES"


### PR DESCRIPTION
Trigger our NextJS cache invalidation API when the documentation is updated.