### PR TITLE
Fix typo in sample command in install.md

### DIFF
--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -17,7 +17,7 @@ Then, to start the Mercure.rocks Hub in development mode on Linux and macOS, run
 ```console
 MERCURE_PUBLISHER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
 MERCURE_SUBSCRIBER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
-./m`rcure run --config Caddyfile.dev
+./mercure run --config Caddyfile.dev
 ```
 
 On Windows, start PowerShell, go into the extracted directory and run:


### PR DESCRIPTION
fix: trivial typo in sample command to start mercure.