### PR TITLE
fix: allow capacitor:// scheme

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var errInvalidOrigin = errors.New(`invalid origin, the URL must ward with "https" or "http"`)
+var errInvalidOrigin = errors.New(`invalid origin, the URL must ward with "https", "http" or "capacitor"`)
 
 // ErrUnsupportedProtocolVersion is returned when the version passed is unsupported.
 var ErrUnsupportedProtocolVersion = errors.New("compatibility mode only supports protocol version 7")
@@ -170,7 +170,7 @@ func validateOrigins(origins []string) error {
 		}
 
 		switch u.Scheme {
-		case "http", "https":
+		case "http", "https", "capacitor":
 		default:
 			return errInvalidOrigin
 		}

--- a/hub_test.go
+++ b/hub_test.go
@@ -140,6 +140,8 @@ func TestOriginsValidator(t *testing.T) {
 		{"https://example.com", "http://example.org"},
 		{"https://example.com", "*"},
 		{"null", "https://example.com:3000"},
+		{"capacitor://"},
+		{"capacitor://www.example.com"},
 	}
 
 	invalidOrigins := [][]string{


### PR DESCRIPTION
The `capacitor://` scheme is used by default in hybrid mobile apps views built with [Capacitor](https://capacitorjs.com).