### PR TITLE
fix: dispatch_timeout and heartbeat

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -63,7 +63,7 @@ type Mercure struct {
 	// Maximum duration before closing the connection, defaults to 600s, set to 0 to disable.
 	WriteTimeout *caddy.Duration `json:"write_timeout,omitempty"`
 
-	// Maximum dispatch duration of an update.
+	// Maximum dispatch duration of an update, defaults to 5s.
 	DispatchTimeout *caddy.Duration `json:"dispatch_timeout,omitempty"`
 
 	// Frequency of the heartbeat, defaults to 40s.

--- a/hub.go
+++ b/hub.go
@@ -284,7 +284,11 @@ type Hub struct {
 
 // NewHub creates a new Hub instance.
 func NewHub(options ...Option) (*Hub, error) {
-	opt := &opt{writeTimeout: 600 * time.Second}
+	opt := &opt{
+		writeTimeout:    600 * time.Second,
+		dispatchTimeout: 5 * time.Second,
+		heartbeat:       40 * time.Second,
+	}
 
 	for _, o := range options {
 		if err := o(opt); err != nil {

--- a/hub_test.go
+++ b/hub_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/spf13/viper"
@@ -25,6 +26,12 @@ func TestNewHub(t *testing.T) {
 	h := createDummy()
 
 	assert.IsType(t, &viper.Viper{}, h.config)
+
+	assert.False(t, h.opt.anonymous)
+	assert.Equal(t, defaultCookieName, h.opt.cookieName)
+	assert.Equal(t, 40*time.Second, h.opt.heartbeat)
+	assert.Equal(t, 5*time.Second, h.opt.dispatchTimeout)
+	assert.Equal(t, 600*time.Second, h.opt.writeTimeout)
 }
 
 func TestNewHubWithConfig(t *testing.T) {


### PR DESCRIPTION
As reported by @mxmp210 in #758, a default value for `dispatch_timeout` is documented but is actually not set.
It was also the case for `heartbeat`.

This patch fixes the problem.