### PR TITLE
refactor: leverage Go 1.20's http.ResponseController

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
                 "MERCURE_PUBLISHER_JWT_KEY": "!ChangeThisMercureHubJWTSecretKey!",
                 "MERCURE_SUBSCRIBER_JWT_KEY": "!ChangeThisMercureHubJWTSecretKey!",
                 "MERCURE_EXTRA_DIRECTIVES": "anonymous",
-                "GLOBAL_OPTIONS": "debug"
+                "GLOBAL_OPTIONS": "debug",
+                "SERVER_NAME": "localhost, host.docker.internal",
+                "EXTRA_DIRECTIVES": "tls internal"
             },
             "args": ["run", "--config", "../../Caddyfile.dev"]
         }

--- a/hub_test.go
+++ b/hub_test.go
@@ -105,7 +105,7 @@ func TestStop(t *testing.T) {
 			defer wg.Done()
 			req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=http://example.com/foo", nil)
 
-			w := httptest.NewRecorder()
+			w := newSubscribeRecorder()
 			hub.SubscribeHandler(w, req)
 
 			r := w.Result()

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -72,13 +72,77 @@ func (rt *responseTester) WriteHeader(statusCode int) {
 func (rt *responseTester) Flush() {
 }
 
+func (rt *responseTester) SetWriteDeadline(_ time.Time) error {
+	return nil
+}
+
+type subscribeRecorder struct {
+	*httptest.ResponseRecorder
+	writeDeadline time.Time
+}
+
+func newSubscribeRecorder() *subscribeRecorder {
+	return &subscribeRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (r *subscribeRecorder) SetWriteDeadline(deadline time.Time) error {
+	if deadline.After(r.writeDeadline) {
+		r.writeDeadline = deadline
+	}
+
+	return nil
+}
+
+func (r *subscribeRecorder) Write(buf []byte) (int, error) {
+	if time.Now().After(r.writeDeadline) {
+		return 0, os.ErrDeadlineExceeded
+	}
+
+	return r.ResponseRecorder.Write(buf)
+}
+
+func (r *subscribeRecorder) WriteString(str string) (int, error) {
+	if time.Now().After(r.writeDeadline) {
+		return 0, os.ErrDeadlineExceeded
+	}
+
+	return r.ResponseRecorder.WriteString(str)
+}
+
+func (r *subscribeRecorder) FlushError() error {
+	if time.Now().After(r.writeDeadline) {
+		return os.ErrDeadlineExceeded
+	}
+
+	r.ResponseRecorder.Flush()
+
+	return nil
+}
+
 func TestSubscribeNotAFlusher(t *testing.T) {
-	hub := createDummy()
+	hub := createAnonymousDummy()
 
-	req := httptest.NewRequest(http.MethodGet, defaultHubURL, nil)
+	go func() {
+		s := hub.transport.(*LocalTransport)
+		var ready bool
 
-	assert.PanicsWithValue(t, "http.ResponseWriter must be an instance of http.Flusher", func() {
-		hub.SubscribeHandler(&responseWriterMock{}, req)
+		for !ready {
+			s.RLock()
+			ready = s.subscribers.Len() != 0
+			s.RUnlock()
+		}
+
+		hub.transport.Dispatch(&Update{
+			Topics: []string{"http://example.com/foo"},
+			Event:  Event{Data: "Hello World"},
+		})
+	}()
+
+	assert.Panics(t, func() {
+		hub.SubscribeHandler(
+			&responseWriterMock{},
+			httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=http://example.com/foo", nil),
+		)
 	})
 }
 
@@ -320,7 +384,7 @@ func TestUnsubscribe(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=http://example.com/books/1", nil).WithContext(ctx)
-		hub.SubscribeHandler(httptest.NewRecorder(), req)
+		hub.SubscribeHandler(newSubscribeRecorder(), req)
 		assert.Equal(t, 0, s.subscribers.Len())
 		s.subscribers.Walk(0, func(s *Subscriber) bool {
 			_, ok := <-s.out
@@ -403,7 +467,7 @@ func TestSubscriptionEvents(t *testing.T) {
 		defer wg.Done()
 		req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=/.well-known/mercure/subscriptions/{topic}/{subscriber}", nil).WithContext(ctx1)
 		req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions/{topic}/{subscriber}"})})
-		w := httptest.NewRecorder()
+		w := newSubscribeRecorder()
 		hub.SubscribeHandler(w, req)
 
 		resp := w.Result()
@@ -428,7 +492,7 @@ func TestSubscriptionEvents(t *testing.T) {
 		defer wg.Done()
 		req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=/.well-known/mercure/subscriptions/{topicSelector}/{subscriber}", nil).WithContext(ctx2)
 		req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{})})
-		w := httptest.NewRecorder()
+		w := newSubscribeRecorder()
 		hub.SubscribeHandler(w, req)
 
 		resp := w.Result()
@@ -436,7 +500,7 @@ func TestSubscriptionEvents(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, ":\n", string(body))
+		assert.Equal(t, "", string(body))
 	}()
 
 	go func() {
@@ -833,7 +897,7 @@ func TestSubscribeHeartbeat(t *testing.T) {
 }
 
 func TestSubscribeExpires(t *testing.T) {
-	hub := createAnonymousDummy()
+	hub := createAnonymousDummy(WithWriteTimeout(0), WithDispatchTimeout(0), WithHeartbeat(500*time.Millisecond))
 	token := jwt.New(jwt.SigningMethodHS256)
 
 	token.Claims = &claims{
@@ -849,13 +913,14 @@ func TestSubscribeExpires(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=foo", nil)
 	req.Header.Add("Authorization", "Bearer "+jwt)
 
-	w := httptest.NewRecorder()
+	w := newSubscribeRecorder()
 	hub.SubscribeHandler(w, req)
 
 	resp := w.Result()
 	defer resp.Body.Close()
 
 	assert.Equal(t, 200, resp.StatusCode)
+	assert.True(t, time.Now().After(token.Claims.(*claims).ExpiresAt.Time))
 }
 
 func BenchmarkSubscribe(b *testing.B) {


### PR DESCRIPTION
Leverage the new `"net/http".ResponseController` type introduced in Go 1.20 to improve and simplify timeout management.

These 2 PRs are needed for tests to be green:

* [x] https://github.com/caddyserver/caddy/pull/5509
* [x] https://github.com/quic-go/quic-go/pull/3790
