### PR TITLE
fix: homepage Content-Type

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -32,6 +32,7 @@ route {
 		{$MERCURE_EXTRA_DIRECTIVES}
 	}
 
+    header / Content-Type "text/html; charset=utf-8"
     respond / `<!DOCTYPE html>
 <html lang=en>
 <meta charset="utf-8">

--- a/Caddyfile
+++ b/Caddyfile
@@ -32,15 +32,16 @@ route {
 		{$MERCURE_EXTRA_DIRECTIVES}
 	}
 
-    header / Content-Type "text/html; charset=utf-8"
-    respond / `<!DOCTYPE html>
-<html lang=en>
-<meta charset="utf-8">
-<meta name="robots" content="noindex">
-<title>Welcome to Mercure</title>
-<h1>Welcome to Mercure</h1>
-<p>The URL of your hub is <code>/.well-known/mercure</code>.
-Read the documentation on <a href="https://mercure.rocks">Mercure.rocks, real-time apps made easy</a>.`
+	header / Content-Type "text/html; charset=utf-8"
+	respond / `<!DOCTYPE html>
+	<html lang=en>
+	<meta charset="utf-8">
+	<meta name="robots" content="noindex">
+	<title>Welcome to Mercure</title>
+	<h1>Welcome to Mercure</h1>
+	<p>The URL of your hub is <code>/.well-known/mercure</code>.
+	Read the documentation on <a href="https://mercure.rocks">Mercure.rocks, real-time apps made easy</a>.`
+
 	respond /healthz 200
 	respond "Not Found" 404
 }


### PR DESCRIPTION
The default `Content-Type` is `text/plain`, which prevents the correct rendering of the HTML. This patch fixes the issue.