### PR TITLE
feat(hub): add metadata to new subscriber log

### DIFF
--- a/hub_test.go
+++ b/hub_test.go
@@ -212,12 +212,9 @@ func createAnonymousDummy(options ...Option) *Hub {
 }
 
 func createDummyAuthorizedJWT(h *Hub, r role, topics []string) string {
-	var payload struct {
+	return createDummyAuthorizedJWTWithPayload(h, r, topics, struct {
 		Foo string `json:"foo"`
-	}
-	payload.Foo = "bar"
-
-	return createDummyAuthorizedJWTWithPayload(h, r, topics, payload)
+	}{Foo: "bar"})
 }
 
 func createDummyAuthorizedJWTWithPayload(h *Hub, r role, topics []string, payload interface{}) string {

--- a/hub_test.go
+++ b/hub_test.go
@@ -216,6 +216,7 @@ func createDummyAuthorizedJWT(h *Hub, r role, topics []string) string {
 		Foo string `json:"foo"`
 	}
 	payload.Foo = "bar"
+
 	return createDummyAuthorizedJWTWithPayload(h, r, topics, payload)
 }
 

--- a/hub_test.go
+++ b/hub_test.go
@@ -212,6 +212,14 @@ func createAnonymousDummy(options ...Option) *Hub {
 }
 
 func createDummyAuthorizedJWT(h *Hub, r role, topics []string) string {
+	var payload struct {
+		Foo string `json:"foo"`
+	}
+	payload.Foo = "bar"
+	return createDummyAuthorizedJWTWithPayload(h, r, topics, payload)
+}
+
+func createDummyAuthorizedJWTWithPayload(h *Hub, r role, topics []string, payload interface{}) string {
 	token := jwt.New(jwt.SigningMethodHS256)
 
 	var key []byte
@@ -221,10 +229,6 @@ func createDummyAuthorizedJWT(h *Hub, r role, topics []string) string {
 		key = h.publisherJWT.key
 
 	case roleSubscriber:
-		var payload struct {
-			Foo string `json:"foo"`
-		}
-		payload.Foo = "bar"
 		token.Claims = &claims{
 			Mercure: mercureClaim{
 				Subscribe: topics,

--- a/log.go
+++ b/log.go
@@ -28,4 +28,5 @@ type Logger interface {
 	Info(msg string, fields ...LogField)
 	Error(msg string, fields ...LogField)
 	Check(Level, string) *CheckedEntry
+	Level() Level
 }

--- a/server_test.go
+++ b/server_test.go
@@ -52,7 +52,7 @@ func TestForwardedHeaders(t *testing.T) {
 	require.Nil(t, err)
 	defer resp2.Body.Close()
 
-	assert.True(t, logs.FilterField(zap.String("remote_addr", "192.0.2.1")).Len() == 1)
+	assert.Equal(t, 1, logs.FilterField(zap.String("remote_addr", "192.0.2.1")).Len())
 
 	h.server.Shutdown(context.Background())
 }

--- a/subscribe.go
+++ b/subscribe.go
@@ -137,7 +137,7 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) *Subscr
 	sendHeaders(w, s)
 
 	if c := h.logger.Check(zap.InfoLevel, "New subscriber"); c != nil {
-		if h.debug {
+		if h.logger.Level() == zap.DebugLevel {
 			c.Write(zap.Object("subscriber", s), zap.Reflect("payload", claims.Mercure.Payload))
 		} else {
 			c.Write(zap.Object("subscriber", s))

--- a/subscribe.go
+++ b/subscribe.go
@@ -96,9 +96,11 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) *Subscr
 	s.Debug = h.debug
 	s.RemoteAddr = r.RemoteAddr
 	var privateTopics []string
+	var claims *claims
 
 	if h.subscriberJWT != nil {
-		claims, err := authorize(r, h.subscriberJWT, nil, h.cookieName)
+		var err error
+		claims, err = authorize(r, h.subscriberJWT, nil, h.cookieName)
 		if claims != nil {
 			s.Claims = claims
 			privateTopics = claims.Mercure.Subscribe
@@ -135,7 +137,7 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) *Subscr
 	sendHeaders(w, s)
 
 	if c := h.logger.Check(zap.InfoLevel, "New subscriber"); c != nil {
-		c.Write(zap.Object("subscriber", s))
+		c.Write(zap.Object("subscriber", s), zap.Reflect("payload", claims.Mercure.Payload))
 	}
 	h.metrics.SubscriberConnected(s)
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -137,11 +137,12 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) *Subscr
 	sendHeaders(w, s)
 
 	if c := h.logger.Check(zap.InfoLevel, "New subscriber"); c != nil {
+		fields := []LogField{zap.Object("subscriber", s)}
 		if h.logger.Level() == zap.DebugLevel {
-			c.Write(zap.Object("subscriber", s), zap.Reflect("payload", claims.Mercure.Payload))
-		} else {
-			c.Write(zap.Object("subscriber", s))
+			fields = append(fields, zap.Reflect("payload", claims.Mercure.Payload))
 		}
+
+		c.Write(fields...)
 	}
 	h.metrics.SubscriberConnected(s)
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -137,7 +137,11 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) *Subscr
 	sendHeaders(w, s)
 
 	if c := h.logger.Check(zap.InfoLevel, "New subscriber"); c != nil {
-		c.Write(zap.Object("subscriber", s), zap.Reflect("payload", claims.Mercure.Payload))
+		if h.debug {
+			c.Write(zap.Object("subscriber", s), zap.Reflect("payload", claims.Mercure.Payload))
+		} else {
+			c.Write(zap.Object("subscriber", s))
+		}
 	}
 	h.metrics.SubscriberConnected(s)
 

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -290,7 +290,9 @@ func TestSubscribeWithLogLevelDebug(t *testing.T) {
 		WithLogger(zap.New(core)),
 	), payload)
 
-	assert.Equal(t, 1, logs.FilterMessage("New subscriber").FilterField(zap.Reflect("payload", payload)).Len())
+	assert.Equal(t, 1, logs.FilterMessage("New subscriber").FilterField(
+		zap.Reflect("payload", payload)).Len(),
+	)
 }
 
 func TestSubscribeLogLevelInfo(t *testing.T) {

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -2,8 +2,8 @@ package mercure
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -282,22 +282,14 @@ func testSubscribeLogs(t *testing.T, hub *Hub, payload interface{}) {
 
 func TestSubscribeWithDebug(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
-	var payload struct {
-		Foo string `json:"foo"`
-		Bar string `json:"bar"`
-	}
-	payload.Foo = "bar"
-	payload.Bar = "baz"
+	var payload interface{}
+	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
 
 	testSubscribeLogs(t, createDummy(
 		WithDebug(),
 		WithLogger(zap.New(core)),
 	), payload)
 
-	fmt.Print(
-		logs.FilterMessage("New subscriber").FilterFieldKey("payload"),
-		zap.Reflect("payload", payload),
-	)
 	assert.True(t, logs.FilterMessage("New subscriber").FilterField(zap.Reflect("payload", payload)).Len() == 1)
 }
 

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -280,26 +280,22 @@ func testSubscribeLogs(t *testing.T, hub *Hub, payload interface{}) {
 	hub.SubscribeHandler(w, req)
 }
 
-func TestSubscribeWithDebug(t *testing.T) {
+func TestSubscribeWithLogLevelDebug(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
 	var payload interface{}
 	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
 
 	testSubscribeLogs(t, createDummy(
-		WithDebug(),
 		WithLogger(zap.New(core)),
 	), payload)
 
 	assert.True(t, logs.FilterMessage("New subscriber").FilterField(zap.Reflect("payload", payload)).Len() == 1)
 }
 
-func TestSubscribeWithoutDebug(t *testing.T) {
-	core, logs := observer.New(zapcore.DebugLevel)
-
-	var payload struct {
-		Bar string `json:"bar"`
-	}
-	payload.Bar = "baz"
+func TestSubscribeLogLevelInfo(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	var payload interface{}
+	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
 
 	testSubscribeLogs(t, createDummy(
 		WithLogger(zap.New(core)),

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -2,6 +2,7 @@ package mercure
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -281,13 +282,8 @@ func testSubscribeLogs(t *testing.T, hub *Hub, payload interface{}) {
 
 func TestSubscribeWithLogLevelDebug(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
-	// var payload interface{}
-	// json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
-
-	payload := struct {
-		Bar string `json:"bar"`
-		Foo string `json:"foo"`
-	}{Bar: "baz", Foo: "bar"}
+	var payload interface{}
+	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
 
 	testSubscribeLogs(t, createDummy(
 		WithLogger(zap.New(core)),
@@ -298,10 +294,8 @@ func TestSubscribeWithLogLevelDebug(t *testing.T) {
 
 func TestSubscribeLogLevelInfo(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
-
-	payload := struct {
-		Bar string `json:"bar"`
-	}{Bar: "baz"}
+	var payload interface{}
+	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
 
 	testSubscribeLogs(t, createDummy(
 		WithLogger(zap.New(core)),

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -2,7 +2,6 @@ package mercure
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -282,8 +281,13 @@ func testSubscribeLogs(t *testing.T, hub *Hub, payload interface{}) {
 
 func TestSubscribeWithLogLevelDebug(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
-	var payload interface{}
-	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
+	// var payload interface{}
+	// json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
+
+	payload := struct {
+		Bar string `json:"bar"`
+		Foo string `json:"foo"`
+	}{Bar: "baz", Foo: "bar"}
 
 	testSubscribeLogs(t, createDummy(
 		WithLogger(zap.New(core)),
@@ -294,8 +298,10 @@ func TestSubscribeWithLogLevelDebug(t *testing.T) {
 
 func TestSubscribeLogLevelInfo(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
-	var payload interface{}
-	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
+
+	payload := struct {
+		Bar string `json:"bar"`
+	}{Bar: "baz"}
 
 	testSubscribeLogs(t, createDummy(
 		WithLogger(zap.New(core)),

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -263,6 +263,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 func testSubscribeLogs(t *testing.T, hub *Hub) {
+	t.Helper()
 	s, _ := hub.transport.(*LocalTransport)
 
 	go func() {
@@ -300,26 +301,19 @@ func testSubscribeLogs(t *testing.T, hub *Hub) {
 }
 
 func TestSubscribeWithDebug(t *testing.T) {
-
 	core, logs := observer.New(zapcore.DebugLevel)
-	hub := createDummy(
+	testSubscribeLogs(t, createDummy(
 		WithDebug(),
 		WithLogger(zap.New(core)),
-	)
-
-	testSubscribeLogs(t, hub)
-
+	))
 	assert.True(t, logs.FilterMessage("New subscriber").FilterFieldKey("payload").Len() == 1)
 }
+
 func TestSubscribeWithoutDebug(t *testing.T) {
-
 	core, logs := observer.New(zapcore.DebugLevel)
-	hub := createDummy(
+	testSubscribeLogs(t, createDummy(
 		WithLogger(zap.New(core)),
-	)
-
-	testSubscribeLogs(t, hub)
-
+	))
 	assert.True(t, logs.FilterMessage("New subscriber").FilterFieldKey("payload").Len() == 0)
 }
 

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -289,7 +289,7 @@ func TestSubscribeWithLogLevelDebug(t *testing.T) {
 		WithLogger(zap.New(core)),
 	), payload)
 
-	assert.True(t, logs.FilterMessage("New subscriber").FilterField(zap.Reflect("payload", payload)).Len() == 1)
+	assert.Equal(t, 1, logs.FilterMessage("New subscriber").FilterField(zap.Reflect("payload", payload)).Len())
 }
 
 func TestSubscribeLogLevelInfo(t *testing.T) {
@@ -301,7 +301,7 @@ func TestSubscribeLogLevelInfo(t *testing.T) {
 		WithLogger(zap.New(core)),
 	), payload)
 
-	assert.True(t, logs.FilterMessage("New subscriber").FilterFieldKey("payload").Len() == 0)
+	assert.Equal(t, 0, logs.FilterMessage("New subscriber").FilterFieldKey("payload").Len())
 }
 
 func TestUnsubscribe(t *testing.T) {

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -2,7 +2,6 @@ package mercure
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -282,8 +281,10 @@ func testSubscribeLogs(t *testing.T, hub *Hub, payload interface{}) {
 
 func TestSubscribeWithLogLevelDebug(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
-	var payload interface{}
-	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
+	payload := map[string]interface{}{
+		"bar": "baz",
+		"foo": "bar",
+	}
 
 	testSubscribeLogs(t, createDummy(
 		WithLogger(zap.New(core)),
@@ -294,9 +295,10 @@ func TestSubscribeWithLogLevelDebug(t *testing.T) {
 
 func TestSubscribeLogLevelInfo(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
-	var payload interface{}
-	json.Unmarshal([]byte("{\"bar\": \"baz\", \"foo\": \"bar\"}"), payload)
-
+	payload := map[string]interface{}{
+		"bar": "baz",
+		"foo": "bar",
+	}
 	testSubscribeLogs(t, createDummy(
 		WithLogger(zap.New(core)),
 	), payload)


### PR DESCRIPTION
Ref: #546

Add the content of the payload from jwt token when a new subscription occures.
