### PR TITLE
fix(helm): topologySpreadConstraints example value

### DIFF
--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -144,7 +144,7 @@ affinity: {}
 #    whenUnsatisfiable: DoNotSchedule
 #    labelSelector:
 #      matchLabels:
-#        {{- include "mercure.selectorLabels" . | nindent 6 }}
+#        {{- include "mercure.selectorLabels" . | nindent 8 }}
 
 # -- Enable persistence using [Persistent Volume Claims](http://kubernetes.io/docs/user-guide/persistent-volumes/), only useful if you the BoltDB transport.
 persistence:


### PR DESCRIPTION
According to my tests, an indentation level is missing in https://github.com/dunglas/mercure/pull/730.
Could you check if it looks ok to you @jfcoz, please?

Also, is it a common practice to include Helm template code as a string in values? The NGINX Ingress is using a plain array instead for instance. WDYT?
This may also be why this value isn't currently automatically documented by `helm-docs` (or because we need to specify this key with a default value).