### PR TITLE
ci: fix release condition

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --clean ${{startsWith(github.ref, 'refs/tags/v') && '' || '--snapshot --skip-sign'}}
+          args: release --clean ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot --skip-sign' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ startsWith(github.ref, 'refs/tags/v') && steps.import_gpg.outputs.fingerprint || '' }}
@@ -62,7 +62,7 @@ jobs:
         run: dist/caddy_linux_amd64_v1/mercure version
 
       - name: Upload snapshot
-        if: ${{!startsWith(github.ref, 'refs/tags/v')}}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/upload-artifact@v3
         with:
           name: snapshot


### PR DESCRIPTION
Empty strings evaluate to `false` in GitHub Actions expressions, so we have to invert the test.