### PR TITLE
Fix Panic when claims is nil

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -182,7 +182,7 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) (*Subsc
 
 	if c := h.logger.Check(zap.InfoLevel, "New subscriber"); c != nil {
 		fields := []LogField{zap.Object("subscriber", s)}
-		if h.logger.Level() == zap.DebugLevel {
+		if claims != nil && h.logger.Level() == zap.DebugLevel {
 			fields = append(fields, zap.Reflect("payload", claims.Mercure.Payload))
 		}
 


### PR DESCRIPTION
Since #779 when subscribing anonymously, the server trigers a panic error, with the following stack trace

```
2023/08/06 14:37:07.781 DEBUG   http.stdlib     http: panic serving 127.0.0.1:35622: runtime error: invalid memory address or nil pointer dereference
goroutine 75 [running]:                                                                                                                                                                        
net/http.(*conn).serve.func1()                                                                                                                                                                 
        /usr/lib/go-1.20/src/net/http/server.go:1854 +0xbf                                                                                                                                     
panic({0x193b840, 0x2d59440})                                                                                                                                                                  
        /usr/lib/go-1.20/src/runtime/panic.go:890 +0x263                                                                                                                                       
github.com/dunglas/mercure.(*Hub).registerSubscriber(0xc000697110, {0x20743d0, 0xc000035180}, 0xc0002dd600)                       
        /home/jderusse/go/pkg/mod/github.com/dunglas/mercure@v0.15.1/subscribe.go:186 +0x643                                                                                                   
```

Because we try to log the payload stored in the claim, whereas the claim is nil.

Relevant line:

https://github.com/dunglas/mercure/blob/da6ea841ec3cc220502b0cda0b88f02877b4253a/subscribe.go#L186

This PR does not add a field Payload when the claim is nil