### PR TITLE
Allow passing existing secret in helm chart values

### DIFF
--- a/charts/mercure/templates/_helpers.tpl
+++ b/charts/mercure/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the secret name.
+*/}}
+{{- define "mercure.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{- printf "%s" (tpl .Values.existingSecret $) -}}
+{{- else -}}
+{{- printf "%s" (include "mercure.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -50,17 +50,17 @@ spec:
             - name: EXTRA_DIRECTIVES
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mercure.fullname" . }}
+                  name: {{ include "mercure.secretName" . }}
                   key: caddy-extra-directives
             - name: MERCURE_TRANSPORT_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mercure.fullname" . }}
+                  name: {{ include "mercure.secretName" . }}
                   key: transport-url
             - name: MERCURE_PUBLISHER_JWT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mercure.fullname" . }}
+                  name: {{ include "mercure.secretName" . }}
                   key: publisher-jwt-key
             - name: MERCURE_PUBLISHER_JWT_ALG
               valueFrom:
@@ -70,7 +70,7 @@ spec:
             - name: MERCURE_SUBSCRIBER_JWT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mercure.fullname" . }}
+                  name: {{ include "mercure.secretName" . }}
                   key: subscriber-jwt-key
             - name: MERCURE_SUBSCRIBER_JWT_ALG
               valueFrom:
@@ -80,12 +80,12 @@ spec:
             - name: MERCURE_EXTRA_DIRECTIVES
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mercure.fullname" . }}
+                  name: {{ include "mercure.secretName" . }}
                   key: extra-directives
             - name: MERCURE_LICENSE
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mercure.fullname" . }}
+                  name: {{ include "mercure.secretName" . }}
                   key: license
           {{- if .Values.persistence.enabled }}
           volumeMounts:

--- a/charts/mercure/templates/secrets.yaml
+++ b/charts/mercure/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   extra-directives: {{ .Values.extraDirectives | b64enc | quote }}
   license: {{ .Values.license | b64enc | quote }}
   caddy-extra-directives: {{ .Values.caddyExtraDirectives | b64enc | quote }}
+{{- end}}

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -23,6 +23,16 @@ subscriberJwtKey: ""
 # -- The JWT algorithm to use for subscribers.
 subscriberJwtAlg: HS256
 
+# -- Allows to pass an existing secret name, the above values will be used if empty.
+existingSecret: ""
+# These keys must exist in the provided secret:
+# -  transport-url
+# -  publisher-jwt-key
+# -  subscriber-jwt-key
+# -  extra-directives:
+# -  license:
+# -  caddy-extra-directives:
+
 # -- The license key for [the High Availability version](https://mercure.rocks/docs/hub/cluster) (not necessary is you use the FOSS version).
 license: ""
 


### PR DESCRIPTION
Hello 👋
This pull request will allow passing an existing secret name into the helm chart values.
This is useful when using the GitOps approach, where values need to be committed to a git repository.

**Related issues:**
- https://github.com/dunglas/mercure/issues/771