### PR TITLE
fix: clean the HTTP connection properly before write deadline

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "env": {
                 "MERCURE_PUBLISHER_JWT_KEY": "!ChangeThisMercureHubJWTSecretKey!",
                 "MERCURE_SUBSCRIBER_JWT_KEY": "!ChangeThisMercureHubJWTSecretKey!",
-                "MERCURE_EXTRA_DIRECTIVES": "anonymous",
+                "MERCURE_EXTRA_DIRECTIVES": "anonymous\nwrite_timeout 10s",
                 "GLOBAL_OPTIONS": "debug",
                 "SERVER_NAME": "localhost, host.docker.internal",
                 "EXTRA_DIRECTIVES": "tls internal"

--- a/public/app.js
+++ b/public/app.js
@@ -16,12 +16,15 @@
   const $subscriptionsForm = document.forms.subscriptions;
 
   const error = (e) => {
-    console.log(e);
-
-    if (e.error?.message?.includes?.('Reconnecting')) {
+    if (!e.error || e.error.message?.includes?.('Reconnecting')) {
       // Silent reconnecting messages from the polyfill
+
+      console.log("Connection closed, reconnecting...", e);
+
       return;
     }
+
+    console.log(e);
 
     if (e.toString !== Object.prototype.toString) {
       // Display relevant error message


### PR DESCRIPTION
Closes #810.

When the deadline set with Go's `ResponseController.SetWriteDeadline()` occurs, the underlying TCP or UDP connection is abruptly closed.
With this patch, Mercure will cleanly close the HTTP connection before the write deadline.

This prevents browsers from logging non-aesthetic in their consoles.