### PR TITLE
docs: remove superfluous `xcaddy` flag

### DIFF
--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -157,7 +157,6 @@ It's also possible to [download Caddy with Mercure and other modules included](h
 
 ```console
 xcaddy build \
-  --with github.com/dunglas/mercure \
   --with github.com/dunglas/mercure/caddy
 ```
 


### PR DESCRIPTION
The Go module `github.com/dunglas/mercure/caddy` imports the Go module `github.com/dunglas/mercure`, which means it's already part of the build.