### PR TITLE
ci: test building the caddy module to catch dep conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
           sed '1d' profile.cov >> ../profile.cov
         working-directory: ./caddy
 
+      - name: Test building the Caddy module
+        run: |
+          go build
+        working-directory: ./caddy
+
       - name: Upload coverage results
         uses: shogo82148/actions-goveralls@v1
         with:


### PR DESCRIPTION
The report in caddyserver/caddy#5888 shows inadvertent upgrade of a Caddy dependency may cause build failures with mercure. To ensure this is caught, adding a throwaway build should catch failures.

P.S.: the replaces listed in the `./caddy/go.mod` don't propagate downstream. Meaning, if someone builds with `xcaddy` or using our website, the replaces are not applied. See this paragraph in the _replace directive_ section in [Go Modules Reference](https://go.dev/ref/mod#go-mod-file-replace):
> replace directives only apply in the main module’s go.mod file and are ignored in other modules. See [Minimal version selection](https://go.dev/ref/mod#minimal-version-selection) for details.