### PR TITLE
fix: log in JSON in prod mode

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,7 +10,8 @@
 {$SERVER_NAME:localhost} {
 	log {
 		format filter {
-			wrap console
+			# Defaults to json while waiting for https://github.com/caddyserver/caddy/pull/5980
+			wrap json
 			fields {
 				uri query {
 					replace authorization REDACTED
@@ -43,6 +44,10 @@
 	<h1>Welcome to Mercure</h1>
 	<p>The URL of your hub is <code>/.well-known/mercure</code>.
 	Read the documentation on <a href="https://mercure.rocks">Mercure.rocks, real-time apps made easy</a>.`
+
+	skip_log /healthz
+	skip_log /favicon.ico
+	skip_log /robots.txt
 
 	respond /healthz 200
 	respond "Not Found" 404

--- a/Caddyfile.dev
+++ b/Caddyfile.dev
@@ -10,6 +10,7 @@
 {$SERVER_NAME:localhost} {
 	log {
 		format filter {
+			# Defaults to console while waiting for https://github.com/caddyserver/caddy/pull/5980
 			wrap console
 			fields {
 				uri query {
@@ -41,6 +42,7 @@
 	{$CADDY_SERVER_EXTRA_DIRECTIVES}
 
 	redir / /.well-known/mercure/ui/
+
 	respond /healthz 200
 	respond "Not Found" 404
 }


### PR DESCRIPTION
Closes https://github.com/dunglas/mercure/issues/859.

While waiting for https://github.com/caddyserver/caddy/pull/5980, use JSON logs in prod.

Also, disable logs for `/healthz`, `/favicon.ico` and `/robots.txt`.