### PR TITLE
fix: tweak log levels on the hot path

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -175,7 +175,7 @@ func canDispatch(s *TopicSelectorStore, topics, topicSelectors []string) bool {
 
 func (h *Hub) httpAuthorizationError(w http.ResponseWriter, r *http.Request, err error) {
 	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-	if c := h.logger.Check(zap.InfoLevel, "Topic selectors not matched, not provided or authorization error"); c != nil {
+	if c := h.logger.Check(zap.DebugLevel, "Topic selectors not matched, not provided or authorization error"); c != nil {
 		c.Write(zap.String("remote_addr", r.RemoteAddr), zap.Error(err))
 	}
 }

--- a/publish.go
+++ b/publish.go
@@ -76,7 +76,7 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	io.WriteString(w, u.ID)
-	if c := h.logger.Check(zap.InfoLevel, "Update published"); c != nil {
+	if c := h.logger.Check(zap.DebugLevel, "Update published"); c != nil {
 		c.Write(zap.Object("update", u), zap.String("remote_addr", r.RemoteAddr))
 	}
 	h.metrics.UpdatePublished(u)

--- a/subscribe.go
+++ b/subscribe.go
@@ -147,7 +147,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				heartbeatTimer.Reset(h.heartbeat)
 			}
-			if c := h.logger.Check(zap.InfoLevel, "Update sent"); c != nil {
+			if c := h.logger.Check(zap.DebugLevel, "Update sent"); c != nil {
 				c.Write(zap.Object("subscriber", s), zap.Object("update", update))
 			}
 		}
@@ -171,7 +171,7 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) (*Subsc
 		}
 		if err != nil || (claims == nil && !h.anonymous) {
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-			if c := h.logger.Check(zap.InfoLevel, "Subscriber unauthorized"); c != nil {
+			if c := h.logger.Check(zap.DebugLevel, "Subscriber unauthorized"); c != nil {
 				c.Write(zap.Object("subscriber", s), zap.Error(err))
 			}
 


### PR DESCRIPTION
Writing logs can be very costly in term of performance and resource usage on the hot path, let's reduce the logs level of some message written very often under high loads.