### PR TITLE
fix: Mercure container port can be modified

### DIFF
--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -50,6 +50,7 @@ To install the chart with the release name `my-release`, run the following comma
 | securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 | service.annotations | object | `{}` |  |
 | service.port | int | `80` | Service port. |
+| service.targetPort | int | `80` | Service target port. |
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: SERVER_NAME
-              value: :80
+              value: :{{ .Values.service.targetPort }}
             - name: GLOBAL_OPTIONS
               valueFrom:
                 configMapKeyRef:
@@ -94,7 +94,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/mercure/templates/service.yaml
+++ b/charts/mercure/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -58,12 +58,14 @@ podAnnotations: {}
 
 # -- Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details.
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -76,6 +78,8 @@ service:
   type: ClusterIP
   # -- Service port.
   port: 80
+  # -- Service target port.
+  targetPort: 80
   annotations: {}
 
 ingress:
@@ -84,7 +88,8 @@ ingress:
   # -- Ingress [class name](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class).
   className: ""
   # -- Annotations to be added to the ingress.
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # -- Ingress host configuration.
@@ -92,8 +97,8 @@ ingress:
   hosts:
     - host: mercure-example.local
       paths:
-      - path: /
-        pathType: ImplementationSpecific
+        - path: /
+          pathType: ImplementationSpecific
   # -- Ingress TLS configuration.
   # @default -- See [values.yaml](values.yaml).
   tls: []
@@ -104,7 +109,8 @@ ingress:
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
 # @default -- No requests or limits.
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -88,8 +88,7 @@ ingress:
   # -- Ingress [class name](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class).
   className: ""
   # -- Annotations to be added to the ingress.
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # -- Ingress host configuration.
@@ -97,8 +96,8 @@ ingress:
   hosts:
     - host: mercure-example.local
       paths:
-        - path: /
-          pathType: ImplementationSpecific
+      - path: /
+        pathType: ImplementationSpecific
   # -- Ingress TLS configuration.
   # @default -- See [values.yaml](values.yaml).
   tls: []
@@ -109,8 +108,7 @@ ingress:
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
 # @default -- No requests or limits.
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -58,14 +58,12 @@ podAnnotations: {}
 
 # -- Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details.
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL


### PR DESCRIPTION
Due to [Openshift requirements](https://docs.openshift.com/acs/3.72/operating/default-security-policies.html), containers can not be exposed on ports < 1024. The mercure container is mapped on port 80.