### PR TITLE
refactor: prepare JWKS support by allowing custom jwt.Keyfunc

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -252,11 +252,6 @@ func WithProtocolVersionCompatibility(protocolVersionCompatibility int) Option {
 	}
 }
 
-type jwtConfig struct {
-	key           []byte
-	signingMethod jwt.SigningMethod
-}
-
 // opt contains the available options.
 //
 // If you change this, also update the Caddy module and the documentation.

--- a/hub_test.go
+++ b/hub_test.go
@@ -155,6 +155,38 @@ func TestWithProtocolVersionCompatibilityVersions(t *testing.T) {
 	}
 }
 
+func TestWithPublisherJWTKeyFunc(t *testing.T) {
+	op := &opt{}
+
+	o := WithPublisherJWTKeyFunc(func(_ *jwt.Token) (interface{}, error) { return []byte{}, nil })
+	require.NoError(t, o(op))
+	require.NotNil(t, op.publisherJWTKeyFunc)
+}
+
+func TestWithSubscriberJWTKeyFunc(t *testing.T) {
+	op := &opt{}
+
+	o := WithSubscriberJWTKeyFunc(func(_ *jwt.Token) (interface{}, error) { return []byte{}, nil })
+	require.NoError(t, o(op))
+	require.NotNil(t, op.subscriberJWTKeyFunc)
+}
+
+func TestWithDebug(t *testing.T) {
+	op := &opt{}
+
+	o := WithDebug()
+	require.NoError(t, o(op))
+	require.True(t, op.debug)
+}
+
+func TestWithUI(t *testing.T) {
+	op := &opt{}
+
+	o := WithUI()
+	require.NoError(t, o(op))
+	require.True(t, op.ui)
+}
+
 func TestOriginsValidator(t *testing.T) {
 	op := &opt{}
 

--- a/hub_test.go
+++ b/hub_test.go
@@ -243,7 +243,7 @@ func createDummyAuthorizedJWTWithPayload(h *Hub, r role, topics []string, payloa
 	switch r {
 	case rolePublisher:
 		token.Claims = &claims{Mercure: mercureClaim{Publish: topics}, RegisteredClaims: jwt.RegisteredClaims{}}
-		key = h.publisherJWT.key
+		key = []byte("publisher")
 
 	case roleSubscriber:
 		token.Claims = &claims{
@@ -254,7 +254,7 @@ func createDummyAuthorizedJWTWithPayload(h *Hub, r role, topics []string, payloa
 			RegisteredClaims: jwt.RegisteredClaims{},
 		}
 
-		key = h.subscriberJWT.key
+		key = []byte("subscriber")
 	}
 
 	tokenString, _ := token.SignedString(key)

--- a/hub_test.go
+++ b/hub_test.go
@@ -230,13 +230,13 @@ func createAnonymousDummy(options ...Option) *Hub {
 	return createDummy(options...)
 }
 
-func createDummyAuthorizedJWT(h *Hub, r role, topics []string) string {
-	return createDummyAuthorizedJWTWithPayload(h, r, topics, struct {
+func createDummyAuthorizedJWT(r role, topics []string) string {
+	return createDummyAuthorizedJWTWithPayload(r, topics, struct {
 		Foo string `json:"foo"`
 	}{Foo: "bar"})
 }
 
-func createDummyAuthorizedJWTWithPayload(h *Hub, r role, topics []string, payload interface{}) string {
+func createDummyAuthorizedJWTWithPayload(r role, topics []string, payload interface{}) string {
 	token := jwt.New(jwt.SigningMethodHS256)
 
 	var key []byte

--- a/jwt_keyfunc.go
+++ b/jwt_keyfunc.go
@@ -1,0 +1,38 @@
+package mercure
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ErrUnexpectedSigningMethod is returned when the signing JWT method is not supported.
+var ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
+
+func createJWTKeyfunc(key []byte, alg string) (jwt.Keyfunc, error) {
+	signingMethod := jwt.GetSigningMethod(alg)
+
+	var k interface{}
+	switch signingMethod.(type) {
+	case *jwt.SigningMethodHMAC:
+		k = key
+	case *jwt.SigningMethodRSA:
+		pub, err := jwt.ParseRSAPublicKeyFromPEM(key)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse RSA public key: %w", err)
+		}
+
+		k = pub
+	default:
+		return nil, fmt.Errorf("%T: %w", signingMethod, ErrUnexpectedSigningMethod)
+	}
+
+	return func(t *jwt.Token) (interface{}, error) {
+		if t.Method != signingMethod {
+			return nil, fmt.Errorf("%T: %w", t.Method, ErrUnexpectedSigningMethod)
+		}
+
+		return k, nil
+	}, nil
+}

--- a/jwt_keyfunc_test.go
+++ b/jwt_keyfunc_test.go
@@ -6,6 +6,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCreateJWTKeyfunc(t *testing.T) {
+	f, err := createJWTKeyfunc(([]byte{}), "invalid")
+	require.Error(t, err)
+	require.Nil(t, f)
+}
+
 func TestAuthorizeAuthorizationHeaderEmptyKeyRsa(t *testing.T) {
 	keyfunc, err := createJWTKeyfunc([]byte{}, "RS256")
 	require.EqualError(t, err, "unable to parse RSA public key: invalid key: Key must be a PEM encoded PKCS1 or PKCS8 key")

--- a/kwt_keyfunc_test.go
+++ b/kwt_keyfunc_test.go
@@ -1,0 +1,19 @@
+package mercure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizeAuthorizationHeaderEmptyKeyRsa(t *testing.T) {
+	keyfunc, err := createJWTKeyfunc([]byte{}, "RS256")
+	require.EqualError(t, err, "unable to parse RSA public key: invalid key: Key must be a PEM encoded PKCS1 or PKCS8 key")
+	require.Nil(t, keyfunc)
+}
+
+func TestAuthorizeAuthorizationHeaderInvalidKeyRsa(t *testing.T) {
+	keyfunc, err := createJWTKeyfunc([]byte(privateKeyRsa), "RS256")
+	require.EqualError(t, err, "unable to parse RSA public key: asn1: structure error: integer too large")
+	require.Nil(t, keyfunc)
+}

--- a/publish.go
+++ b/publish.go
@@ -14,8 +14,8 @@ import (
 func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 	var claims *claims
 	var err error
-	if h.publisherJWT != nil {
-		claims, err = authorize(r, h.publisherJWT, h.publishOrigins, h.cookieName)
+	if h.publisherJWTKeyFunc != nil {
+		claims, err = authorize(r, h.publisherJWTKeyFunc, h.publishOrigins, h.cookieName)
 		if err != nil || claims == nil || claims.Mercure.Publish == nil {
 			h.httpAuthorizationError(w, r, err)
 

--- a/publish_test.go
+++ b/publish_test.go
@@ -63,7 +63,7 @@ func TestPublishBadContentType(t *testing.T) {
 	hub := createDummy()
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, nil)
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, []string{"*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 	req.Header.Add("Content-Type", "text/plain; boundary=")
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -78,7 +78,7 @@ func TestPublishNoTopic(t *testing.T) {
 	hub := createDummy()
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, nil)
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, []string{"*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
 
@@ -99,7 +99,7 @@ func TestPublishInvalidRetry(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, []string{"*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -121,7 +121,7 @@ func TestPublishNotAuthorizedTopicSelector(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, []string{"foo"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"foo"}))
 
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -140,7 +140,7 @@ func TestPublishEmptyTopicSelector(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, []string{}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{}))
 
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -159,7 +159,7 @@ func TestPublishLegacyAuthorization(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, []string{}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{}))
 
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -201,7 +201,7 @@ func TestPublishOK(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, s.SubscribedTopics))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, s.SubscribedTopics))
 
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -224,7 +224,7 @@ func TestPublishNoData(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, []string{"*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -260,7 +260,7 @@ func TestPublishGenerateUUID(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(h, rolePublisher, []string{"*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 
 	w := httptest.NewRecorder()
 	h.PublishHandler(w, req)
@@ -296,7 +296,7 @@ func TestPublishWithErrorInTransport(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, rolePublisher, []string{"foo", "http://example.com/books/1"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"foo", "http://example.com/books/1"}))
 
 	w := httptest.NewRecorder()
 	hub.PublishHandler(w, req)
@@ -311,7 +311,7 @@ func TestPublishWithErrorInTransport(t *testing.T) {
 
 func FuzzPublish(f *testing.F) {
 	hub := createDummy()
-	authorizationHeader := bearerPrefix + createDummyAuthorizedJWT(hub, rolePublisher, []string{"*"})
+	authorizationHeader := bearerPrefix + createDummyAuthorizedJWT(rolePublisher, []string{"*"})
 
 	testCases := [][]interface{}{
 		{"https://localhost/foo/bar", "baz", "", "", "", "", ""},

--- a/server_test.go
+++ b/server_test.go
@@ -49,7 +49,7 @@ func TestForwardedHeaders(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, testURL, strings.NewReader(body.Encode()))
 	req.Header.Add("X-Forwarded-For", "192.0.2.1")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(h, rolePublisher, []string{"*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 
 	resp2, err := client.Do(req)
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestSecurityOptionsWithCorsOrigin(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodOptions, testSecureURL, nil)
 
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(h, roleSubscriber, []string{}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(roleSubscriber, []string{}))
 	req.Header.Add("Content-Type", "text/plain; boundary=")
 	req.Header.Add("Origin", "https://subscriber.com")
 	req.Header.Add("Host", "subscriber.com")
@@ -211,7 +211,7 @@ func TestServe(t *testing.T) {
 	body := url.Values{"topic": {"http://example.com/foo/1", "http://example.com/alt/1"}, "data": {"hello"}, "id": {"first"}}
 	req, _ := http.NewRequest(http.MethodPost, testURL, strings.NewReader(body.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(h, rolePublisher, []string{"*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 
 	resp2, err := client.Do(req)
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestClientClosesThenReconnects(t *testing.T) {
 		req, err := http.NewRequest(http.MethodPost, testURL, strings.NewReader(body.Encode()))
 		require.NoError(t, err)
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-		req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(h, rolePublisher, []string{"*"}))
+		req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 
 		resp, err := client.Do(req)
 		require.NoError(t, err)
@@ -475,7 +475,7 @@ func (s *testServer) newSubscriber(topic string, keepAlive bool) {
 func (s *testServer) publish(body url.Values) {
 	req, _ := http.NewRequest(http.MethodPost, testURL, strings.NewReader(body.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(s.h, rolePublisher, []string{"*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
 
 	resp, err := s.client.Do(req)
 	require.NoError(s.t, err)

--- a/subscribe.go
+++ b/subscribe.go
@@ -162,9 +162,9 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) (*Subsc
 	var privateTopics []string
 	var claims *claims
 
-	if h.subscriberJWT != nil {
+	if h.subscriberJWTKeyFunc != nil {
 		var err error
-		claims, err = authorize(r, h.subscriberJWT, nil, h.cookieName)
+		claims, err = authorize(r, h.subscriberJWTKeyFunc, nil, h.cookieName)
 		if claims != nil {
 			s.Claims = claims
 			privateTopics = claims.Mercure.Subscribe

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -927,7 +927,7 @@ func TestSubscribeExpires(t *testing.T) {
 		RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Second))},
 	}
 
-	jwt, err := token.SignedString(hub.subscriberJWT.key)
+	jwt, err := token.SignedString([]byte("subscriber"))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=foo", nil)

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -331,7 +331,7 @@ func testSubscribeLogs(t *testing.T, hub *Hub, payload interface{}) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=http://example.com/reviews/{id}", nil).WithContext(ctx)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWTWithPayload(hub, roleSubscriber, []string{"http://example.com/reviews/22"}, payload)})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWTWithPayload(roleSubscriber, []string{"http://example.com/reviews/22"}, payload)})
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
@@ -463,7 +463,7 @@ func TestSubscribePrivate(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=http://example.com/reviews/{id}", nil).WithContext(ctx)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"http://example.com/reviews/22", "http://example.com/reviews/23"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"http://example.com/reviews/22", "http://example.com/reviews/23"})})
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
@@ -486,7 +486,7 @@ func TestSubscriptionEvents(t *testing.T) {
 		// Authorized to receive connection events
 		defer wg.Done()
 		req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=/.well-known/mercure/subscriptions/{topic}/{subscriber}", nil).WithContext(ctx1)
-		req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions/{topic}/{subscriber}"})})
+		req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions/{topic}/{subscriber}"})})
 		w := newSubscribeRecorder()
 		hub.SubscribeHandler(w, req)
 
@@ -511,7 +511,7 @@ func TestSubscriptionEvents(t *testing.T) {
 		// Not authorized to receive connection events
 		defer wg.Done()
 		req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=/.well-known/mercure/subscriptions/{topicSelector}/{subscriber}", nil).WithContext(ctx2)
-		req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{})})
+		req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{})})
 		w := newSubscribeRecorder()
 		hub.SubscribeHandler(w, req)
 
@@ -535,7 +535,7 @@ func TestSubscriptionEvents(t *testing.T) {
 
 		ctx, cancelRequest2 := context.WithCancel(context.Background())
 		req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=https://example.com", nil).WithContext(ctx)
-		req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{})})
+		req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{})})
 
 		w := &responseTester{
 			expectedStatusCode: http.StatusOK,
@@ -583,7 +583,7 @@ func TestSubscribeAll(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=http://example.com/reviews/{id}", nil).WithContext(ctx)
-	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(hub, roleSubscriber, []string{"random", "*"}))
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(roleSubscriber, []string{"random", "*"}))
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,

--- a/subscription.go
+++ b/subscription.go
@@ -104,8 +104,8 @@ func (h *Hub) SubscriptionHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Hub) initSubscription(currentURL string, w http.ResponseWriter, r *http.Request) (lastEventID string, subscribers []*Subscriber, ok bool) {
-	if h.subscriberJWT != nil {
-		claims, err := authorize(r, h.subscriberJWT, nil, h.cookieName)
+	if h.subscriberJWTKeyFunc != nil {
+		claims, err := authorize(r, h.subscriberJWTKeyFunc, nil, h.cookieName)
 		if err != nil || claims == nil || claims.Mercure.Subscribe == nil || !canReceive(h.topicSelectorStore, []string{currentURL}, claims.Mercure.Subscribe) {
 			h.httpAuthorizationError(w, r, err)
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -24,7 +24,7 @@ func TestSubscriptionsHandlerAccessDenied(t *testing.T) {
 	res.Body.Close()
 
 	req = httptest.NewRequest(http.MethodGet, subscriptionsURL, nil)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions/foo{/subscriber}"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions/foo{/subscriber}"})})
 	w = httptest.NewRecorder()
 	hub.SubscriptionsHandler(w, req)
 	res = w.Result()
@@ -32,7 +32,7 @@ func TestSubscriptionsHandlerAccessDenied(t *testing.T) {
 	res.Body.Close()
 
 	req = httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath+"/bar", nil)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions/foo{/subscriber}"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions/foo{/subscriber}"})})
 	w = httptest.NewRecorder()
 	hub.SubscriptionsHandler(w, req)
 	res = w.Result()
@@ -51,7 +51,7 @@ func TestSubscriptionHandlerAccessDenied(t *testing.T) {
 	res.Body.Close()
 
 	req = httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath+"/bar/baz", nil)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions/foo{/subscriber}"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions/foo{/subscriber}"})})
 	w = httptest.NewRecorder()
 	hub.SubscriptionHandler(w, req)
 	res = w.Result()
@@ -64,7 +64,7 @@ func TestSubscriptionHandlersETag(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath, nil)
 	req.Header.Add("If-None-Match", EarliestLastEventID)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions"})})
 	w := httptest.NewRecorder()
 	hub.SubscriptionsHandler(w, req)
 	res := w.Result()
@@ -73,7 +73,7 @@ func TestSubscriptionHandlersETag(t *testing.T) {
 
 	req = httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath+"/foo/bar", nil)
 	req.Header.Add("If-None-Match", EarliestLastEventID)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions/foo/bar"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions/foo/bar"})})
 	w = httptest.NewRecorder()
 	hub.SubscriptionHandler(w, req)
 	res = w.Result()
@@ -93,7 +93,7 @@ func TestSubscriptionsHandler(t *testing.T) {
 	require.NoError(t, hub.transport.AddSubscriber(s2))
 
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath, nil)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions"})})
 	w := httptest.NewRecorder()
 	hub.SubscriptionsHandler(w, req)
 	res := w.Result()
@@ -139,7 +139,7 @@ func TestSubscriptionsHandlerForTopic(t *testing.T) {
 	router.HandleFunc(subscriptionsForTopicURL, hub.SubscriptionsHandler)
 
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath+"/"+s2.EscapedTopics[0], nil)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions/" + s2.EscapedTopics[0]})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions/" + s2.EscapedTopics[0]})})
 	w := httptest.NewRecorder()
 	hub.SubscriptionsHandler(w, req)
 	res := w.Result()
@@ -182,7 +182,7 @@ func TestSubscriptionHandler(t *testing.T) {
 	router.HandleFunc(subscriptionURL, hub.SubscriptionHandler)
 
 	req := httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath+"/"+s.EscapedTopics[1]+"/"+s.EscapedID, nil)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions{/topic}{/subscriber}"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions{/topic}{/subscriber}"})})
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	res := w.Result()
@@ -196,7 +196,7 @@ func TestSubscriptionHandler(t *testing.T) {
 	assert.Equal(t, expectedSub, subscription)
 
 	req = httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath+"/notexist/"+s.EscapedID, nil)
-	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(hub, roleSubscriber, []string{"/.well-known/mercure/subscriptions{/topic}{/subscriber}"})})
+	req.AddCookie(&http.Cookie{Name: "mercureAuthorization", Value: createDummyAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions{/topic}{/subscriber}"})})
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	res = w.Result()


### PR DESCRIPTION
Preparation for #813 (cc @broncha): allow using any `jwt.Keyfunc` to validate a JWT.