### PR TITLE
fix: storageClassName indent

### DIFF
--- a/charts/mercure/templates/pvc.yaml
+++ b/charts/mercure/templates/pvc.yaml
@@ -12,6 +12,6 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
   {{- if .Values.persistence.storageClass }}
-      storageClassName: {{ if (eq "-" .Values.persistence.storageClass) -}}""{{ else }}{{ .Values.persistence.storageClass | quote }}{{ end -}}
+  storageClassName: {{ if (eq "-" .Values.persistence.storageClass) -}}""{{ else }}{{ .Values.persistence.storageClass | quote }}{{ end -}}
   {{- end -}}
 {{- end }}


### PR DESCRIPTION
Fixed the storageClassName indentation

see https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims