### PR TITLE
fix: redact the authorization query parameter from logs

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,10 +10,8 @@
 {$SERVER_NAME:localhost} {
 	log {
 		format filter {
-			# Defaults to json while waiting for https://github.com/caddyserver/caddy/pull/5980
-			wrap json
 			fields {
-				uri query {
+				request>uri query {
 					replace authorization REDACTED
 				}
 			}

--- a/Caddyfile.dev
+++ b/Caddyfile.dev
@@ -10,10 +10,8 @@
 {$SERVER_NAME:localhost} {
 	log {
 		format filter {
-			# Defaults to console while waiting for https://github.com/caddyserver/caddy/pull/5980
-			wrap console
 			fields {
-				uri query {
+				request>uri query {
 					replace authorization REDACTED
 				}
 			}


### PR DESCRIPTION
The `authorization` filter has never been redacted because the field selector was bad.

I hesitated to open a CVE for this, but I think it's not necessary because the field has never been redacted, and it's not documented as such.

This patch also leverages https://github.com/caddyserver/caddy/pull/5980.