### PR TITLE
feat(caddy): allow passing the context to the transport

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -148,7 +148,7 @@ func (m *Mercure) populateJWTConfig() error {
 	return nil
 }
 
-func (m *Mercure) Provision(ctx caddy.Context) error { //nolint:funlen,gocognit
+func (m *Mercure) Provision(ctx caddy.Context) error { //nolint:funlen,gocognit,gocyclo
 	if err := m.populateJWTConfig(); err != nil {
 		return err
 	}
@@ -194,6 +194,14 @@ func (m *Mercure) Provision(ctx caddy.Context) error { //nolint:funlen,gocognit
 	})
 	if err != nil {
 		return err //nolint:wrapcheck
+	}
+
+	if t, ok := destructor.(*transportDestructor).transport.(ContextAwareTransport); ok {
+		// Give a chance to the transport to access the Caddy context,
+		// this can be useful to retrieve other modules such as storages.
+		if err := t.SetContext(ctx); err != nil {
+			return err //nolint:wrapcheck
+		}
 	}
 
 	opts := []mercure.Option{

--- a/caddy/transport.go
+++ b/caddy/transport.go
@@ -1,0 +1,8 @@
+package caddy
+
+import "github.com/caddyserver/caddy/v2"
+
+// ContextAwareTransport can be implemented by transports to access the Caddy context.
+type ContextAwareTransport interface {
+	SetContext(ctx caddy.Context) error
+}


### PR DESCRIPTION
A better solution would be to create a Caddy module per transport.