### PR TITLE
feat!: use Caddy modules for transports

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -19,8 +19,6 @@
 	encode zstd gzip
 
 	mercure {
-		# Transport to use (default to Bolt)
-		transport_url {$MERCURE_TRANSPORT_URL:bolt://mercure.db}
 		# Publisher JWT key
 		publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
 		# Subscriber JWT key

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ LABEL org.opencontainers.image.source=https://github.com/dunglas/mercure
 LABEL org.opencontainers.image.licenses=AGPL-3.0-or-later
 LABEL org.opencontainers.image.vendor="Kévin Dunglas"
 
-ENV MERCURE_TRANSPORT_URL=bolt:///data/mercure.db
-
 COPY mercure /usr/bin/caddy
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY dev.Caddyfile /etc/caddy/dev.Caddyfile

--- a/bolt_transport_test.go
+++ b/bolt_transport_test.go
@@ -17,7 +17,7 @@ import (
 
 func createBoltTransport(dsn string) *BoltTransport {
 	u, _ := url.Parse(dsn)
-	transport, _ := NewBoltTransport(u, zap.NewNop())
+	transport, _ := DeprecatedNewBoltTransport(u, zap.NewNop())
 
 	return transport.(*BoltTransport)
 }
@@ -57,7 +57,7 @@ func TestBoltTransportLogsBogusLastEventID(t *testing.T) {
 	defer sink.Reset()
 
 	u, _ := url.Parse("bolt://test.db")
-	transport, _ := NewBoltTransport(u, logger)
+	transport, _ := DeprecatedNewBoltTransport(u, logger)
 	defer transport.Close()
 	defer os.Remove("test.db")
 
@@ -191,27 +191,27 @@ func TestBoltTransportPurgeHistory(t *testing.T) {
 
 func TestNewBoltTransport(t *testing.T) {
 	u, _ := url.Parse("bolt://test.db?bucket_name=demo")
-	transport, err := NewBoltTransport(u, zap.NewNop())
+	transport, err := DeprecatedNewBoltTransport(u, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, transport)
 	transport.Close()
 
 	u, _ = url.Parse("bolt://")
-	_, err = NewBoltTransport(u, zap.NewNop())
+	_, err = DeprecatedNewBoltTransport(u, zap.NewNop())
 	require.EqualError(t, err, `"bolt:": invalid transport: missing path`)
 
 	u, _ = url.Parse("bolt:///test.db")
-	_, err = NewBoltTransport(u, zap.NewNop())
+	_, err = DeprecatedNewBoltTransport(u, zap.NewNop())
 
 	// The exact error message depends of the OS
 	assert.Contains(t, err.Error(), "open /test.db:")
 
 	u, _ = url.Parse("bolt://test.db?cleanup_frequency=invalid")
-	_, err = NewBoltTransport(u, zap.NewNop())
+	_, err = DeprecatedNewBoltTransport(u, zap.NewNop())
 	require.EqualError(t, err, `"bolt://test.db?cleanup_frequency=invalid": invalid "cleanup_frequency" parameter "invalid": invalid transport: strconv.ParseFloat: parsing "invalid": invalid syntax`)
 
 	u, _ = url.Parse("bolt://test.db?size=invalid")
-	_, err = NewBoltTransport(u, zap.NewNop())
+	_, err = DeprecatedNewBoltTransport(u, zap.NewNop())
 	require.EqualError(t, err, `"bolt://test.db?size=invalid": invalid "size" parameter "invalid": invalid transport: strconv.ParseUint: parsing "invalid": invalid syntax`)
 }
 

--- a/caddy/bolt_transport.go
+++ b/caddy/bolt_transport.go
@@ -1,0 +1,128 @@
+package caddy
+
+import (
+	"bytes"
+	"encoding/gob"
+	"strconv"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/dunglas/mercure"
+)
+
+func init() { //nolint:gochecknoinits
+	caddy.RegisterModule(Bolt{})
+}
+
+type Bolt struct {
+	Path             string  `json:"path,omitempty"`
+	BucketName       string  `json:"bucket_name,omitempty"`
+	Size             uint64  `json:"size,omitempty"`
+	CleanupFrequency float64 `json:"cleanup_frequency,omitempty"`
+
+	transport    *mercure.BoltTransport
+	transportKey string
+}
+
+// CaddyModule returns the Caddy module information.
+func (Bolt) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.handlers.mercure.bolt",
+		New: func() caddy.Module { return new(Bolt) },
+	}
+}
+
+func (b *Bolt) GetTransport() mercure.Transport { //nolint:ireturn
+	return b.transport
+}
+
+// Provision provisions b's configuration.
+//
+//nolint:wrapcheck
+func (b *Bolt) Provision(ctx caddy.Context) error {
+	var key bytes.Buffer
+	if err := gob.NewEncoder(&key).Encode(b); err != nil {
+		return err
+	}
+	b.transportKey = key.String()
+
+	destructor, _, err := transport.LoadOrNew(b.transportKey, func() (caddy.Destructor, error) {
+		t, err := mercure.NewBoltTransport(ctx.Logger(), b.Path, b.BucketName, b.Size, b.CleanupFrequency)
+		if err != nil {
+			return nil, err
+		}
+
+		return transportDestructor[*mercure.BoltTransport]{transport: t}, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	b.transport = destructor.(transportDestructor[*mercure.BoltTransport]).transport
+
+	return nil
+}
+
+//nolint:wrapcheck
+func (b *Bolt) Cleanup() error {
+	_, err := transport.Delete(b.transportKey)
+
+	return err
+}
+
+// UnmarshalCaddyfile sets up the handler from Caddyfile tokens.
+//
+//nolint:wrapcheck
+func (b *Bolt) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		for d.NextBlock(0) {
+			switch d.Val() {
+			case "path":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+
+				b.Path = d.Val()
+
+			case "bucket_name":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+
+				b.BucketName = d.Val()
+
+			case "cleanup_frequency":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+
+				f, e := strconv.ParseFloat(d.Val(), 64)
+				if e != nil {
+					return e
+				}
+
+				b.CleanupFrequency = f
+
+			case "size":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+
+				s, e := strconv.ParseUint(d.Val(), 10, 64)
+				if e != nil {
+					return e
+				}
+
+				b.Size = s
+			}
+		}
+	}
+
+	return nil
+}
+
+var (
+	_ caddy.Provisioner     = (*Bolt)(nil)
+	_ caddy.CleanerUpper    = (*Bolt)(nil)
+	_ caddyfile.Unmarshaler = (*Bolt)(nil)
+)

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -153,7 +154,7 @@ func (m *Mercure) populateJWTConfig() error {
 //
 //nolint:wrapcheck,ireturn
 func createTransportLegacy(m *Mercure) (mercure.Transport, error) {
-	m.logger.Warn(`Setting transport_url is deprecated, use the "transport" directive instead`)
+	m.logger.Warn(`Setting the transport_url or the MERCURE_TRANSPORT_URL environment variable is deprecated, use the "transport" directive instead`)
 
 	destructor, _, err := transports.LoadOrNew(m.TransportURL, func() (caddy.Destructor, error) {
 		u, err := url.Parse(m.TransportURL)
@@ -487,6 +488,15 @@ func (m *Mercure) UnmarshalCaddyfile(d *caddyfile.Dispenser) error { //nolint:fu
 
 				m.ProtocolVersionCompatibility = v
 			}
+		}
+	}
+
+	// BC layer with old versions of the built-in Caddyfile
+	if m.TransportRaw == nil && m.TransportURL == "" {
+		deprecatedTransportURL := os.Getenv("MERCURE_TRANSPORT_URL")
+
+		if deprecatedTransportURL != "" {
+			m.TransportURL = deprecatedTransportURL
 		}
 	}
 

--- a/caddy/local_transport.go
+++ b/caddy/local_transport.go
@@ -1,0 +1,60 @@
+package caddy
+
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/dunglas/mercure"
+)
+
+type localTransportKeyStruct struct{}
+
+var localTransportKey = localTransportKeyStruct{} //nolint:gochecknoglobals
+
+func init() { //nolint:gochecknoinits
+	caddy.RegisterModule(Local{})
+}
+
+type Local struct {
+	transport *mercure.LocalTransport
+}
+
+// CaddyModule returns the Caddy module information.
+func (Local) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "http.handlers.mercure.local",
+		New: func() caddy.Module { return new(Local) },
+	}
+}
+
+func (l *Local) GetTransport() mercure.Transport { //nolint:ireturn
+	return l.transport
+}
+
+// Provision provisions b's configuration.
+func (l *Local) Provision(_ caddy.Context) error {
+	destructor, _, _ := transport.LoadOrNew(localTransportKey, func() (caddy.Destructor, error) {
+		return transportDestructor[*mercure.LocalTransport]{transport: mercure.NewLocalTransport()}, nil
+	})
+
+	l.transport = destructor.(transportDestructor[*mercure.LocalTransport]).transport
+
+	return nil
+}
+
+//nolint:wrapcheck
+func (l *Local) Cleanup() error {
+	_, err := transport.Delete(localTransportKey)
+
+	return err
+}
+
+// UnmarshalCaddyfile sets up the handler from Caddyfile tokens.
+func (l *Local) UnmarshalCaddyfile(_ *caddyfile.Dispenser) error {
+	return nil
+}
+
+var (
+	_ caddy.Provisioner     = (*Bolt)(nil)
+	_ caddy.CleanerUpper    = (*Bolt)(nil)
+	_ caddyfile.Unmarshaler = (*Bolt)(nil)
+)

--- a/caddy/transport.go
+++ b/caddy/transport.go
@@ -1,0 +1,20 @@
+package caddy
+
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/dunglas/mercure"
+)
+
+var transport = caddy.NewUsagePool() //nolint:gochecknoglobals
+
+type Transport interface {
+	GetTransport() mercure.Transport
+}
+
+type transportDestructor[T mercure.Transport] struct {
+	transport T
+}
+
+func (d transportDestructor[T]) Destruct() error {
+	return d.transport.Close() //nolint:wrapcheck
+}

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -57,11 +57,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "mercure.secretName" . }}
                   key: caddy-extra-directives
+            {{- if .Values.transportUrl }}
             - name: MERCURE_TRANSPORT_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mercure.secretName" . }}
                   key: transport-url
+            {{- end }}
             - name: MERCURE_PUBLISHER_JWT_KEY
               valueFrom:
                 secretKeyRef:
@@ -92,6 +94,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "mercure.secretName" . }}
                   key: license
+          {{- if .Values.extraEnvs }}
+            {{- toYaml .Values.extraEnvs | nindent 12 }}
+          {{- end }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - mountPath: /data

--- a/charts/mercure/templates/secrets.yaml
+++ b/charts/mercure/templates/secrets.yaml
@@ -7,7 +7,9 @@ metadata:
     {{- include "mercure.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Values.transportUrl }}
   transport-url: {{ .Values.transportUrl | b64enc | quote }}
+  {{- end }}
   publisher-jwt-key: {{ .Values.publisherJwtKey | default (randAlphaNum 40) | b64enc | quote }}
   subscriber-jwt-key: {{ .Values.subscriberJwtKey | default (randAlphaNum 40) | b64enc | quote }}
   extra-directives: {{ .Values.extraDirectives | b64enc | quote }}

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -8,8 +8,8 @@ globalOptions: ""
 caddyExtraConfig: ""
 # -- Enable the development mode, including the debug UI and the demo.
 dev: false
-# -- The URL representation of the transport to use.
-transportUrl: bolt:///data/mercure.db
+# -- Deprecated: The URL representation of the transport to use.
+transportUrl: ""
 # -- Inject extra Mercure directives in the Caddyfile.
 extraDirectives: ""
 # -- Inject extra Caddy directives in the Caddyfile.
@@ -25,10 +25,18 @@ subscriberJwtKey: ""
 # -- The JWT algorithm to use for subscribers.
 subscriberJwtAlg: HS256
 
+# -- Additional environment variables to set
+extraEnvs: []
+# extraEnvs:
+#   - name: FOO
+#     valueFrom:
+#       secretKeyRef:
+#         key: FOO
+#         name: secret-resource
+
 # -- Allows to pass an existing secret name, the above values will be used if empty.
 existingSecret: ""
 # These keys must exist in the provided secret:
-# -  transport-url
 # -  publisher-jwt-key
 # -  subscriber-jwt-key
 # -  extra-directives:

--- a/dev.Caddyfile
+++ b/dev.Caddyfile
@@ -19,8 +19,6 @@
 	encode zstd gzip
 
 	mercure {
-		# Transport to use (default to Bolt)
-		transport_url {$MERCURE_TRANSPORT_URL:bolt://mercure.db}
 		# Publisher JWT key
 		publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
 		# Subscriber JWT key

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,5 +1,30 @@
 # Upgrade
 
+## 0.17
+
+The `TRANSPORT_URL` environment variable has been removed and the `transport_url` directive has been deprecated.
+Use the new `transport` directive instead.
+
+Before:
+
+```caddyfile
+transport_url bolt://mercure.db?cleanup_frequency=0.2
+```
+
+After:
+
+```caddyfile
+transport bolt {
+  cleanup_frequency 0.2
+}
+```
+
+To configure the transport using an environment variable, append the `transport directive` to the `MERCURE_EXTRA_DIRECTIVES` environment variable.
+
+To prevent security issues, be sure to not pass credentials such as API tokens or password in `MERCURE_EXTRA_DIRECTIVES` (ex: when using transports [provided by the paid version](hub/cluster.md) such as Redis).
+
+To pass credentials security, create a custom `Caddyfile` an use the `{env.MY_ENV_VAR}` syntax, which is interpreted at runtime.
+
 ## 0.16.2
 
 The `Caddyfile.dev` file has been renamed `dev.Caddyfile` to match new Caddy best practices

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -2,8 +2,15 @@
 
 ## 0.17
 
-The `TRANSPORT_URL` environment variable has been removed and the `transport_url` directive has been deprecated.
+The `MERCURE_TRANSPORT_URL` environment variable and the `transport_url` directive have been deprecated.
 Use the new `transport` directive instead.
+
+The `MERCURE_TRANSPORT_URL` environement variable has been removed from the default `Caddyfile`s,
+but a backward compatibility layer is provided.
+
+If both the `transport` and the deprecated `transport_url` are not explicitly set
+and the `MERCURE_TRANSPORT_URL` environement variable is set, the `transport_url` will be automatically populated.
+To disable this behavior, unset `MERCURE_TRANSPORT_URL` or set it to an empty string.
 
 Before:
 

--- a/docs/hub/config.md
+++ b/docs/hub/config.md
@@ -38,25 +38,26 @@ Note that HTTPS is automatically disabled if you set the server port to 80.
 
 The following Mercure-specific directives are available:
 
-| Directive                            | Description                                                                                                                                                                                                                                    | Default                |
-|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| `publisher_jwt <key> [<algorithm>]`  | the JWT key and algorithm to use for publishers, can contain [placeholders](https://caddyserver.com/docs/conventions#placeholders)                                                                                                             |                        |
-| `subscriber_jwt <key> [<algorithm>]` | the JWT key and algorithm to use for subscribers, can contain [placeholders](https://caddyserver.com/docs/conventions#placeholders)                                                                                                            |                        |
-| `publisher_jwks_url`                 | the URL of the JSON Web Key Set (JWK Set) URL (provided by identity providers such as Keycloak or AWS Cognito) to use for validating publishers JWT (take precedence over `publisher_jwt`)                                                     |                        |
-| `subscriber_jwks_url`                | the URL of the JSON Web Key Set (JWK Set) URL to use for validating publishers JWT (take precedence over `publisher_jwt`)                                                                                                                      |                        |
-| `anonymous`                          | allow subscribers with no valid JWT to connect                                                                                                                                                                                                 | `false`                |
-| `publish_origins <origins...>`       | a list of origins allowed publishing, can be `*` for all (only applicable when using cookie-based auth)                                                                                                                                        |                        |
-| `cors_origins <origin...>`           | a list of allowed CORS origins, ([troubleshoot CORS issues](troubleshooting.md#cors-issues))                                                                                                                                                   |                        |
-| `cookie_name <name>`                 | the name of the cookie to use for the authorization mechanism                                                                                                                                                                                  | `mercureAuthorization` |
-| `subscriptions`                      | expose the subscription web API and dispatch private updates when a subscription between the Hub and a subscriber is established or closed. The topic follows the template `/.well-known/mercure/subscriptions/{topicSelector}/{subscriberID}` |                        |
-| `heartbeat`                          | interval between heartbeats (useful with some proxies, and old browsers), set to `0s` disable                                                                                                                                                  | `40s`                  |
-| `transport_url <url>`                | URL representation of the transport to use. Use `local://local` to disabled history, (example `bolt:///var/run/mercure.db?size=100&cleanup_frequency=0.4`), see also [the cluster mode](cluster.md)                                            | `bolt://mercure.db`    |
-| `dispatch_timeout <duration>`        | maximum duration of the dispatch of a single update, set to `0s` disable                                                                                                                                                                       | `5s`                   |
-| `write_timeout <duration>`           | maximum duration before closing the connection, set to `0s` disable                                                                                                                                                                            | `600s`                 |
-| `protocol_version_compatibility`     | version of the protocol to be backward compatible with (only version 7 is supported)                                                                                                                                                           | disabled               |
-| `demo`                               | enable the UI and expose demo endpoints                                                                                                                                                                                                        |                        |
-| `ui`                                 | enable the UI but do not expose demo endpoints                                                                                                                                                                                                 |                        |
-| `cache <num-counters> <max-cost>`    | cache configuration (see [Ristretto's docs](https://github.com/dgraph-io/ristretto)), set to -1 to disable the cache                                                                                                                           | `6e7` `1e8` (100MB)    |
+| Directive                             | Description                                                                                                                                                                                                                                     | Default                |
+|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
+| `publisher_jwt <key> [<algorithm>]`   | the JWT key and algorithm to use for publishers, can contain [placeholders](https://caddyserver.com/docs/conventions#placeholders)                                                                                                              |                        |
+| `subscriber_jwt <key> [<algorithm>]`  | the JWT key and algorithm to use for subscribers, can contain [placeholders](https://caddyserver.com/docs/conventions#placeholders)                                                                                                             |                        |
+| `publisher_jwks_url`                  | the URL of the JSON Web Key Set (JWK Set) URL (provided by identity providers such as Keycloak or AWS Cognito) to use for validating publishers JWT (take precedence over `publisher_jwt`)                                                      |                        |
+| `subscriber_jwks_url`                 | the URL of the JSON Web Key Set (JWK Set) URL to use for validating publishers JWT (take precedence over `publisher_jwt`)                                                                                                                       |                        |
+| `anonymous`                           | allow subscribers with no valid JWT to connect                                                                                                                                                                                                  | `false`                |
+| `publish_origins <origins...>`        | a list of origins allowed publishing, can be `*` for all (only applicable when using cookie-based auth)                                                                                                                                         |                        |
+| `cors_origins <origin...>`            | a list of allowed CORS origins, ([troubleshoot CORS issues](troubleshooting.md#cors-issues))                                                                                                                                                    |                        |
+| `cookie_name <name>`                  | the name of the cookie to use for the authorization mechanism                                                                                                                                                                                   | `mercureAuthorization` |
+| `subscriptions`                       | expose the subscription web API and dispatch private updates when a subscription between the Hub and a subscriber is established or closed. The topic follows the template `/.well-known/mercure/subscriptions/{topicSelector}/{subscriberID}`  |                        |
+| `heartbeat`                           | interval between heartbeats (useful with some proxies, and old browsers), set to `0s` disable                                                                                                                                                   | `40s`                  |
+| `transport <name> [{ <options...> }]` | The transport to use. Options are transport-specific. See also [the cluster mode](cluster.md)                                                                                                                                                   | `bolt://mercure.db`    |
+| `dispatch_timeout <duration>`         | maximum duration of the dispatch of a single update, set to `0s` disable                                                                                                                                                                        | `5s`                   |
+| `write_timeout <duration>`            | maximum duration before closing the connection, set to `0s` disable                                                                                                                                                                             | `600s`                 |
+| `protocol_version_compatibility`      | version of the protocol to be backward compatible with (only version 7 is supported)                                                                                                                                                            | disabled               |
+| `demo`                                | enable the UI and expose demo endpoints                                                                                                                                                                                                         |                        |
+| `ui`                                  | enable the UI but do not expose demo endpoints                                                                                                                                                                                                  |                        |
+| `cache <num-counters> <max-cost>`     | cache configuration (see [Ristretto's docs](https://github.com/dgraph-io/ristretto)), set to -1 to disable the cache                                                                                                                            | `6e7` `1e8` (100MB)    |
+| `transport_url <url>`                 | **Deprecated: use `transport` instead.** URL representation of the transport to use. Use `local://local` to disable the history, (example `bolt:///var/run/mercure.db?size=100&cleanup_frequency=0.4`), see also [the cluster mode](cluster.md) | `bolt://mercure.db`    |
 
 See also [the list of built-in Caddyfile directives](https://caddyserver.com/docs/caddyfile/directives).
 
@@ -70,7 +71,6 @@ The provided `Caddyfile` and the Docker image provide convenient environment var
 | `CADDY_EXTRA_CONFIG`           | the [snippet](https://caddyserver.com/docs/caddyfile/concepts#snippets) or the [named-routes](https://caddyserver.com/docs/caddyfile/concepts#named-routes) options block to inject in the `Caddyfile`, one per line |                     |
 | `CADDY_SERVER_EXTRA_DIRECTIVES`| [`Caddyfile` directives](https://caddyserver.com/docs/caddyfile/concepts#directives)                                                                                                                                 |                     |
 | `SERVER_NAME`                  | the server name or address                                                                                                                                                                                           | `localhost`         |
-| `MERCURE_TRANSPORT_URL`        | the value passed to the `transport_url` directive                                                                                                                                                                    | `bolt://mercure.db` |
 | `MERCURE_PUBLISHER_JWT_KEY`    | the JWT key to use for publishers                                                                                                                                                                                    |                     |
 | `MERCURE_PUBLISHER_JWT_ALG`    | the JWT algorithm to use for publishers                                                                                                                                                                              | `HS256`             |
 | `MERCURE_SUBSCRIBER_JWT_KEY`   | the JWT key to use for subscribers                                                                                                                                                                                   |                     |
@@ -126,13 +126,20 @@ MERCURE_SUBSCRIBER_JWT_ALG=RS256 \
 
 ## Bolt Adapter
 
-The [Data Source Name (DSN)](https://en.wikipedia.org/wiki/Data_source_name) specifies the path to the [bolt](https://github.com/etcd-io/bbolt) database as well as options
-
-| Parameter           | Description                                                                                                                                                         |
+| Option              | Description                                                                                                                                                         |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `path`              | path of the database file (default: `mercure.db`)                                                                                                                   |
 | `bucket_name`       | name of the bolt bucket to store events. default to `updates`                                                                                                       |
 | `cleanup_frequency` | chances to trigger history cleanup when an update occurs, must be a number between `0` (never cleanup) and `1` (cleanup after every publication), default to `0.3`. |
 | `size`              | size of the history (to retrieve lost messages using the `Last-Event-ID` header), set to `0` to never remove old events (default)                                   |
+
+You can visualize and edit the content of the database using [boltdbweb](https://github.com/evnix/boltdbweb).
+
+### Legacy URL
+
+**This feature is deprecated: use the new `transport` directive instead**.
+
+The [Data Source Name (DSN)](https://en.wikipedia.org/wiki/Data_source_name) specifies the path to the [bolt](https://github.com/etcd-io/bbolt) database as well as options. All options available as directive except `path` can be passed.
 
 Below are common examples of valid DSNs showing a combination of available values:
 
@@ -146,8 +153,6 @@ transport_url bolt://database.db
 # custom options
 transport_url bolt://database.db?bucket_name=demo&size=1000&cleanup_frequency=0.5
 ```
-
-You can visualize and edit the content of the database using [boltdbweb](https://github.com/evnix/boltdbweb).
 
 ## Legacy Server
 

--- a/hub.go
+++ b/hub.go
@@ -325,7 +325,7 @@ func NewHub(options ...Option) (*Hub, error) {
 	}
 
 	if opt.transport == nil {
-		t, _ := NewLocalTransport(nil, nil)
+		t, _ := DeprecatedNewLocalTransport(nil, nil)
 		opt.transport = t
 	}
 

--- a/local_transport.go
+++ b/local_transport.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() { //nolint:gochecknoinits
-	RegisterTransportFactory("local", NewLocalTransport)
+	RegisterTransportFactory("local", DeprecatedNewLocalTransport)
 }
 
 // LocalTransport implements the TransportInterface without database and simply broadcast the live Updates.
@@ -18,13 +18,20 @@ type LocalTransport struct {
 	closedOnce  sync.Once
 }
 
-// NewLocalTransport create a new LocalTransport.
-func NewLocalTransport(_ *url.URL, _ Logger) (Transport, error) { //nolint:ireturn
+// DeprecatedNewLocalTransport creates a new LocalTransport.
+//
+// Deprecated: use NewLocalTransport() instead.
+func DeprecatedNewLocalTransport(_ *url.URL, _ Logger) (Transport, error) { //nolint:ireturn
+	return NewLocalTransport(), nil
+}
+
+// NewLocalTransport creates a new LocalTransport.
+func NewLocalTransport() *LocalTransport {
 	return &LocalTransport{
 		subscribers: NewSubscriberList(1e5),
 		closed:      make(chan struct{}),
 		lastEventID: EarliestLastEventID,
-	}, nil
+	}
 }
 
 // Dispatch dispatches an update to all subscribers.

--- a/local_transport_bench_test.go
+++ b/local_transport_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkLocalTransport(b *testing.B) {
 func subBenchLocalTransport(b *testing.B, topics, concurrency, matchPct int, testName string) {
 	b.Helper()
 
-	tr, err := NewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
+	tr, err := DeprecatedNewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
 	if err != nil {
 		panic(err)
 	}

--- a/local_transport_test.go
+++ b/local_transport_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLocalTransportDoNotDispatchUntilListen(t *testing.T) {
-	transport, _ := NewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
+	transport, _ := DeprecatedNewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
 	defer transport.Close()
 	assert.Implements(t, (*Transport)(nil), transport)
 
@@ -37,7 +37,7 @@ func TestLocalTransportDoNotDispatchUntilListen(t *testing.T) {
 }
 
 func TestLocalTransportDispatch(t *testing.T) {
-	transport, _ := NewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
+	transport, _ := DeprecatedNewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
 	defer transport.Close()
 	assert.Implements(t, (*Transport)(nil), transport)
 
@@ -51,7 +51,7 @@ func TestLocalTransportDispatch(t *testing.T) {
 }
 
 func TestLocalTransportClosed(t *testing.T) {
-	transport, _ := NewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
+	transport, _ := DeprecatedNewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
 	defer transport.Close()
 	assert.Implements(t, (*Transport)(nil), transport)
 
@@ -66,7 +66,7 @@ func TestLocalTransportClosed(t *testing.T) {
 }
 
 func TestLiveCleanDisconnectedSubscribers(t *testing.T) {
-	tr, _ := NewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
+	tr, _ := DeprecatedNewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
 	transport := tr.(*LocalTransport)
 	defer transport.Close()
 
@@ -88,7 +88,7 @@ func TestLiveCleanDisconnectedSubscribers(t *testing.T) {
 }
 
 func TestLiveReading(t *testing.T) {
-	transport, _ := NewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
+	transport, _ := DeprecatedNewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
 	defer transport.Close()
 	assert.Implements(t, (*Transport)(nil), transport)
 
@@ -104,7 +104,7 @@ func TestLiveReading(t *testing.T) {
 }
 
 func TestLocalTransportGetSubscribers(t *testing.T) {
-	transport, _ := NewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
+	transport, _ := DeprecatedNewLocalTransport(&url.URL{Scheme: "local"}, zap.NewNop())
 	defer transport.Close()
 	require.NotNil(t, transport)
 

--- a/transport.go
+++ b/transport.go
@@ -14,16 +14,19 @@ const EarliestLastEventID = "earliest"
 type TransportFactory = func(u *url.URL, l Logger) (Transport, error)
 
 var (
+	// Deprecated: directly instantiate the transport or use transports Caddy modules.
 	transportFactories   = make(map[string]TransportFactory) //nolint:gochecknoglobals
 	transportFactoriesMu sync.RWMutex                        //nolint:gochecknoglobals
 )
 
+// Deprecated: directly instantiate the transport or use transports Caddy modules.
 func RegisterTransportFactory(scheme string, factory TransportFactory) {
 	transportFactoriesMu.Lock()
 	transportFactories[scheme] = factory
 	transportFactoriesMu.Unlock()
 }
 
+// Deprecated: directly instantiate the transport or use transports Caddy modules.
 func NewTransport(u *url.URL, l Logger) (Transport, error) { //nolint:ireturn
 	transportFactoriesMu.RLock()
 	f, ok := transportFactories[u.Scheme]


### PR DESCRIPTION
**This patch introduces BC breaks described in the `UPGRADE` file**

This patch deprecates the `transport_url` and introduces Caddy modules dedicated to each transport.

This approach has several benefits:

* cleaner configuration: it's now possible to use the full expressivity of the `Caddyfile` syntax instead of relying on embedded URLs in the config
* improved extensibility: transports (including built-in transports, custom transports, and transports provided by the paid version) can now expose a structured config and access config from the main Mercure Caddy module, which was complex before
* improved reliability: transports can hook into Caddy lifecycle events (config change, shutdown...). That wasn't previously possible
