### PR TITLE
docs: Update docker compose healthcheck

### DIFF
--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -127,7 +127,7 @@ services:
     # Uncomment the following line to enable the development mode
     #command: /usr/bin/caddy run --config /etc/caddy/dev.Caddyfile
     healthcheck:
-      test: ["CMD", "curl", "-f", "https://localhost/healthz"]
+      test: ["CMD", "wget", "-q", "--spider", "https://localhost/healthz"]
       timeout: 5s
       retries: 5
       start_period: 60s


### PR DESCRIPTION
I replaced `curl` by `wget` in the healthcheck of `docker-compose.yml`, because curl is not available in the image `dunglas/mercure`.

The arguments :
- `-q` : quiet
- `--spider` : don't download anything

If there is no error `wget` returns 0, else 1