### PR TITLE
perf!: use topic selector store in subscriber

### DIFF
--- a/bolt_transport_test.go
+++ b/bolt_transport_test.go
@@ -35,7 +35,7 @@ func TestBoltTransportHistory(t *testing.T) {
 		})
 	}
 
-	s := NewSubscriber("8", transport.logger)
+	s := NewSubscriber("8", transport.logger, &TopicSelectorStore{})
 	s.SetTopics(topics, nil)
 
 	require.NoError(t, transport.AddSubscriber(s))
@@ -68,7 +68,7 @@ func TestBoltTransportLogsBogusLastEventID(t *testing.T) {
 		Topics: topics,
 	})
 
-	s := NewSubscriber("711131", logger)
+	s := NewSubscriber("711131", logger, &TopicSelectorStore{})
 	s.SetTopics(topics, nil)
 
 	require.NoError(t, transport.AddSubscriber(s))
@@ -87,7 +87,7 @@ func TestBoltTopicSelectorHistory(t *testing.T) {
 	transport.Dispatch(&Update{Topics: []string{"http://example.com/subscribed-public-only"}, Private: true, Event: Event{ID: "3"}})
 	transport.Dispatch(&Update{Topics: []string{"http://example.com/subscribed-public-only"}, Event: Event{ID: "4"}})
 
-	s := NewSubscriber(EarliestLastEventID, transport.logger)
+	s := NewSubscriber(EarliestLastEventID, transport.logger, &TopicSelectorStore{})
 	s.SetTopics([]string{"http://example.com/subscribed", "http://example.com/subscribed-public-only"}, []string{"http://example.com/subscribed"})
 
 	require.NoError(t, transport.AddSubscriber(s))
@@ -109,7 +109,7 @@ func TestBoltTransportRetrieveAllHistory(t *testing.T) {
 		})
 	}
 
-	s := NewSubscriber(EarliestLastEventID, transport.logger)
+	s := NewSubscriber(EarliestLastEventID, transport.logger, &TopicSelectorStore{})
 	s.SetTopics(topics, nil)
 	require.NoError(t, transport.AddSubscriber(s))
 
@@ -139,7 +139,7 @@ func TestBoltTransportHistoryAndLive(t *testing.T) {
 		})
 	}
 
-	s := NewSubscriber("8", transport.logger)
+	s := NewSubscriber("8", transport.logger, &TopicSelectorStore{})
 	s.SetTopics(topics, nil)
 	require.NoError(t, transport.AddSubscriber(s))
 
@@ -221,7 +221,7 @@ func TestBoltTransportDoNotDispatchUntilListen(t *testing.T) {
 	defer os.Remove("test.db")
 	assert.Implements(t, (*Transport)(nil), transport)
 
-	s := NewSubscriber("", transport.logger)
+	s := NewSubscriber("", transport.logger, &TopicSelectorStore{})
 	require.NoError(t, transport.AddSubscriber(s))
 
 	var wg sync.WaitGroup
@@ -245,7 +245,7 @@ func TestBoltTransportDispatch(t *testing.T) {
 	defer os.Remove("test.db")
 	assert.Implements(t, (*Transport)(nil), transport)
 
-	s := NewSubscriber("", transport.logger)
+	s := NewSubscriber("", transport.logger, &TopicSelectorStore{})
 	s.SetTopics([]string{"https://example.com/foo", "https://example.com/private"}, []string{"https://example.com/private"})
 
 	require.NoError(t, transport.AddSubscriber(s))
@@ -274,7 +274,7 @@ func TestBoltTransportClosed(t *testing.T) {
 	defer os.Remove("test.db")
 	assert.Implements(t, (*Transport)(nil), transport)
 
-	s := NewSubscriber("", transport.logger)
+	s := NewSubscriber("", transport.logger, &TopicSelectorStore{})
 	s.SetTopics([]string{"https://example.com/foo"}, nil)
 	require.NoError(t, transport.AddSubscriber(s))
 
@@ -293,11 +293,11 @@ func TestBoltCleanDisconnectedSubscribers(t *testing.T) {
 	defer transport.Close()
 	defer os.Remove("test.db")
 
-	s1 := NewSubscriber("", transport.logger)
+	s1 := NewSubscriber("", transport.logger, &TopicSelectorStore{})
 	s1.SetTopics([]string{"foo"}, []string{})
 	require.NoError(t, transport.AddSubscriber(s1))
 
-	s2 := NewSubscriber("", transport.logger)
+	s2 := NewSubscriber("", transport.logger, &TopicSelectorStore{})
 	s2.SetTopics([]string{"foo"}, []string{})
 	require.NoError(t, transport.AddSubscriber(s2))
 
@@ -318,10 +318,10 @@ func TestBoltGetSubscribers(t *testing.T) {
 	defer transport.Close()
 	defer os.Remove("test.db")
 
-	s1 := NewSubscriber("", transport.logger)
+	s1 := NewSubscriber("", transport.logger, &TopicSelectorStore{})
 	require.NoError(t, transport.AddSubscriber(s1))
 
-	s2 := NewSubscriber("", transport.logger)
+	s2 := NewSubscriber("", transport.logger, &TopicSelectorStore{})
 	require.NoError(t, transport.AddSubscriber(s2))
 
 	lastEventID, subscribers, err := transport.GetSubscribers()

--- a/local_transport_bench_test.go
+++ b/local_transport_bench_test.go
@@ -39,8 +39,9 @@ func subBenchLocalTransport(b *testing.B, topics, concurrency, matchPct int, tes
 		}
 	}
 	out := make(chan *Update, 50000)
+	tss := &TopicSelectorStore{}
 	for i := 0; i < concurrency; i++ {
-		s := NewSubscriber("", zap.NewNop())
+		s := NewSubscriber("", zap.NewNop(), tss)
 		if i%100 < matchPct {
 			s.SetTopics(tsMatch, nil)
 		} else {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -12,12 +12,15 @@ import (
 func TestNumberOfRunningSubscribers(t *testing.T) {
 	m := NewPrometheusMetrics(nil)
 
-	s1 := NewSubscriber("", zap.NewNop())
+	logger := zap.NewNop()
+	tss := &TopicSelectorStore{}
+
+	s1 := NewSubscriber("", logger, tss)
 	s1.SetTopics([]string{"topic1", "topic2"}, nil)
 	m.SubscriberConnected(s1)
 	assertGaugeValue(t, 1.0, m.subscribers)
 
-	s2 := NewSubscriber("", zap.NewNop())
+	s2 := NewSubscriber("", logger, tss)
 	s2.SetTopics([]string{"topic2"}, nil)
 	m.SubscriberConnected(s2)
 	assertGaugeValue(t, 2.0, m.subscribers)
@@ -32,12 +35,15 @@ func TestNumberOfRunningSubscribers(t *testing.T) {
 func TestTotalNumberOfHandledSubscribers(t *testing.T) {
 	m := NewPrometheusMetrics(nil)
 
-	s1 := NewSubscriber("", zap.NewNop())
+	logger := zap.NewNop()
+	tss := &TopicSelectorStore{}
+
+	s1 := NewSubscriber("", logger, tss)
 	s1.SetTopics([]string{"topic1", "topic2"}, nil)
 	m.SubscriberConnected(s1)
 	assertCounterValue(t, 1.0, m.subscribersTotal)
 
-	s2 := NewSubscriber("", zap.NewNop())
+	s2 := NewSubscriber("", logger, tss)
 	s2.SetTopics([]string{"topic2"}, nil)
 	m.SubscriberConnected(s2)
 	assertCounterValue(t, 2.0, m.subscribersTotal)

--- a/publish_test.go
+++ b/publish_test.go
@@ -174,7 +174,7 @@ func TestPublishOK(t *testing.T) {
 	hub := createDummy()
 
 	topics := []string{"http://example.com/books/1"}
-	s := NewSubscriber("", zap.NewNop())
+	s := NewSubscriber("", zap.NewNop(), &TopicSelectorStore{})
 	s.SetTopics(topics, topics)
 	s.Claims = &claims{Mercure: mercureClaim{Subscribe: topics}}
 
@@ -238,7 +238,7 @@ func TestPublishNoData(t *testing.T) {
 func TestPublishGenerateUUID(t *testing.T) {
 	h := createDummy()
 
-	s := NewSubscriber("", zap.NewNop())
+	s := NewSubscriber("", zap.NewNop(), &TopicSelectorStore{})
 	s.SetTopics([]string{"http://example.com/books/1"}, s.SubscribedTopics)
 
 	require.NoError(t, h.transport.AddSubscriber(s))

--- a/subscribe.go
+++ b/subscribe.go
@@ -156,7 +156,8 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 
 // registerSubscriber initializes the connection.
 func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) (*Subscriber, *responseController) {
-	s := NewSubscriber(retrieveLastEventID(r, h.opt, h.logger), h.logger)
+	s := NewSubscriber(retrieveLastEventID(r, h.opt, h.logger), h.logger, &TopicSelectorStore{})
+	s.topicSelectorStore = h.topicSelectorStore
 	s.Debug = h.debug
 	s.RemoteAddr = r.RemoteAddr
 	var privateTopics []string

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -3,6 +3,7 @@ package mercure
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -56,8 +57,13 @@ func (rt *responseTester) Write(buf []byte) (int, error) {
 	if rt.body == rt.expectedBody {
 		rt.cancel()
 	} else if !strings.HasPrefix(rt.expectedBody, rt.body) {
-		rt.t.Errorf(`Received body "%s" doesn't match expected body "%s"`, rt.body, rt.expectedBody)
-		rt.cancel()
+		defer rt.cancel()
+
+		mess := fmt.Sprintf(`Received body "%s" doesn't match expected body "%s"`, rt.body, rt.expectedBody)
+		if rt.t == nil {
+			panic(mess)
+		}
+		rt.t.Error(mess)
 	}
 
 	return len(buf), nil

--- a/subscriber.go
+++ b/subscriber.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -144,20 +145,22 @@ func (s *Subscriber) SetTopics(subscribedTopics, allowedPrivateTopics []string) 
 	s.SubscribedTopics = subscribedTopics
 	s.SubscribedTopicRegexps = make([]*regexp.Regexp, len(subscribedTopics))
 	for i, ts := range subscribedTopics {
-		var r *regexp.Regexp
-		if tpl, err := uritemplate.New(ts); err == nil {
-			r = tpl.Regexp()
+		if !strings.Contains(ts, "{") {
+			continue
 		}
-		s.SubscribedTopicRegexps[i] = r
+		if tpl, err := uritemplate.New(ts); err == nil {
+			s.SubscribedTopicRegexps[i] = tpl.Regexp()
+		}
 	}
 	s.AllowedPrivateTopics = allowedPrivateTopics
 	s.AllowedPrivateRegexps = make([]*regexp.Regexp, len(allowedPrivateTopics))
 	for i, ts := range allowedPrivateTopics {
-		var r *regexp.Regexp
-		if tpl, err := uritemplate.New(ts); err == nil {
-			r = tpl.Regexp()
+		if !strings.Contains(ts, "{") {
+			continue
 		}
-		s.AllowedPrivateRegexps[i] = r
+		if tpl, err := uritemplate.New(ts); err == nil {
+			s.AllowedPrivateRegexps[i] = tpl.Regexp()
+		}
 	}
 	s.EscapedTopics = escapeTopics(subscribedTopics)
 }

--- a/subscriber_bench_test.go
+++ b/subscriber_bench_test.go
@@ -85,7 +85,7 @@ func strInt(s string) int {
 func subBenchSubscriber(b *testing.B, topics, concurrency, matchPct int, testName string) {
 	b.Helper()
 
-	s := NewSubscriber("0e249241-6432-4ce1-b9b9-5d170163c253", zap.NewNop())
+	s := NewSubscriber("0e249241-6432-4ce1-b9b9-5d170163c253", zap.NewNop(), &TopicSelectorStore{})
 	ts := make([]string, topics)
 	tsMatch := make([]string, topics)
 	tsNoMatch := make([]string, topics)

--- a/subscriber_list_test.go
+++ b/subscriber_list_test.go
@@ -22,10 +22,11 @@ func TestDecode(t *testing.T) {
 
 func BenchmarkSubscriberList(b *testing.B) {
 	logger := zap.NewNop()
+	tss := &TopicSelectorStore{}
 
 	l := NewSubscriberList(100)
 	for i := 0; i < 100; i++ {
-		s := NewSubscriber("", logger)
+		s := NewSubscriber("", logger, tss)
 		t := fmt.Sprintf("https://example.com/%d", (i % 10))
 		s.SetTopics([]string{"https://example.org/foo", t}, []string{"https://example.net/bar", t})
 

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDispatch(t *testing.T) {
-	s := NewSubscriber("1", zap.NewNop())
+	s := NewSubscriber("1", zap.NewNop(), &TopicSelectorStore{})
 	s.SubscribedTopics = []string{"http://example.com"}
 	s.SubscribedTopics = []string{"http://example.com"}
 	defer s.Disconnect()
@@ -32,7 +32,7 @@ func TestDispatch(t *testing.T) {
 }
 
 func TestDisconnect(t *testing.T) {
-	s := NewSubscriber("", zap.NewNop())
+	s := NewSubscriber("", zap.NewNop(), &TopicSelectorStore{})
 	s.Disconnect()
 	// can be called two times without crashing
 	s.Disconnect()
@@ -44,7 +44,7 @@ func TestLogSubscriber(t *testing.T) {
 	sink, logger := newTestLogger(t)
 	defer sink.Reset()
 
-	s := NewSubscriber("123", logger)
+	s := NewSubscriber("123", logger, &TopicSelectorStore{})
 	s.RemoteAddr = "127.0.0.1"
 	s.SetTopics([]string{"https://example.com/bar"}, []string{"https://example.com/foo"})
 
@@ -59,7 +59,7 @@ func TestLogSubscriber(t *testing.T) {
 }
 
 func TestMatchTopic(t *testing.T) {
-	s := NewSubscriber("", zap.NewNop())
+	s := NewSubscriber("", zap.NewNop(), &TopicSelectorStore{})
 	s.SetTopics([]string{"https://example.com/no-match", "https://example.com/books/{id}"}, []string{"https://example.com/users/foo/{?topic}"})
 
 	assert.False(t, s.Match(&Update{Topics: []string{"https://example.com/not-subscribed"}}))
@@ -73,7 +73,7 @@ func TestMatchTopic(t *testing.T) {
 }
 
 func TestSubscriberDoesNotBlockWhenChanIsFull(t *testing.T) {
-	s := NewSubscriber("", zap.NewNop())
+	s := NewSubscriber("", zap.NewNop(), &TopicSelectorStore{})
 	s.Ready()
 
 	for i := 0; i <= outBufferLength; i++ {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -82,13 +82,16 @@ func TestSubscriptionHandlersETag(t *testing.T) {
 }
 
 func TestSubscriptionsHandler(t *testing.T) {
-	hub := createDummy()
+	logger := zap.NewNop()
 
-	s1 := NewSubscriber("", zap.NewNop())
+	hub := createDummy(WithLogger(logger))
+	tss := &TopicSelectorStore{}
+
+	s1 := NewSubscriber("", logger, tss)
 	s1.SetTopics([]string{"http://example.com/foo"}, nil)
 	require.NoError(t, hub.transport.AddSubscriber(s1))
 
-	s2 := NewSubscriber("", zap.NewNop())
+	s2 := NewSubscriber("", logger, tss)
 	s2.SetTopics([]string{"http://example.com/bar"}, nil)
 	require.NoError(t, hub.transport.AddSubscriber(s2))
 
@@ -121,13 +124,15 @@ func TestSubscriptionsHandler(t *testing.T) {
 }
 
 func TestSubscriptionsHandlerForTopic(t *testing.T) {
-	hub := createDummy()
+	logger := zap.NewNop()
+	hub := createDummy(WithLogger(logger))
+	tss := &TopicSelectorStore{}
 
-	s1 := NewSubscriber("", zap.NewNop())
+	s1 := NewSubscriber("", logger, tss)
 	s1.SetTopics([]string{"http://example.com/foo"}, nil)
 	require.NoError(t, hub.transport.AddSubscriber(s1))
 
-	s2 := NewSubscriber("", zap.NewNop())
+	s2 := NewSubscriber("", logger, tss)
 	s2.SetTopics([]string{"http://example.com/bar"}, nil)
 	require.NoError(t, hub.transport.AddSubscriber(s2))
 
@@ -166,13 +171,15 @@ func TestSubscriptionsHandlerForTopic(t *testing.T) {
 }
 
 func TestSubscriptionHandler(t *testing.T) {
-	hub := createDummy()
+	logger := zap.NewNop()
+	hub := createDummy(WithLogger(logger))
+	tss := &TopicSelectorStore{}
 
-	otherS := NewSubscriber("", zap.NewNop())
+	otherS := NewSubscriber("", logger, tss)
 	otherS.SetTopics([]string{"http://example.com/other"}, nil)
 	require.NoError(t, hub.transport.AddSubscriber(otherS))
 
-	s := NewSubscriber("", zap.NewNop())
+	s := NewSubscriber("", logger, tss)
 	s.SetTopics([]string{"http://example.com/other", "http://example.com/{foo}"}, nil)
 	require.NoError(t, hub.transport.AddSubscriber(s))
 


### PR DESCRIPTION
~~If the string doesn't contain a `{`, we can consider that it's a plain string.~~

Better: use the TopicSelectorStore that has this optimization and a cache.