### PR TITLE
docs: replace curl with wget in healthcheck example

### DIFF
--- a/docs/hub/config.md
+++ b/docs/hub/config.md
@@ -89,7 +89,7 @@ services:
   mercure:
     # ...
     healthcheck:
-      test: ["CMD", "curl", "-f", "https://localhost/healthz"]
+      test: ["CMD", "wget", "-O-", "https://localhost/healthz"]
       timeout: 5s
       retries: 5
       start_period: 60s


### PR DESCRIPTION
<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->

`mercure:v0.16.3` does not provide curl utility so the healthcheck config in doc won't work. Luckly, wget is installed and can be used instead.

Example command : 
`docker run --rm --health-cmd "curl https://localhost/healthz" -e MERCURE_PUBLISHER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' -e MERCURE_SUBSCRIBER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' --name health-mercure dunglas/mercure:v0.16.3`

Healthcheck status : 
`docker inspect health-mercure`

```json
{
// ...
        "State": {
            "Status": "running",
            "Running": true,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 198683,
            "ExitCode": 0,
            "Error": "",
            "StartedAt": "2024-09-30T08:59:48.603645337Z",
            "FinishedAt": "0001-01-01T00:00:00Z",
            "Health": {
                "Status": "starting",
                "FailingStreak": 2,
                "Log": [
                    {
                        "Start": "2024-09-30T11:00:18.727767037+02:00",
                        "End": "2024-09-30T11:00:18.784756446+02:00",
                        "ExitCode": 127,
                        "Output": "/bin/sh: curl: not found\n"
                    },
                    {
                        "Start": "2024-09-30T11:00:48.794090367+02:00",
                        "End": "2024-09-30T11:00:48.842858301+02:00",
                        "ExitCode": 127,
                        "Output": "/bin/sh: curl: not found\n"
                    }
                ]
            }
        },
// ...
}