### PR TITLE
feat(helm): Make nodePort configurable for NodePort service type

### DIFF
--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -52,6 +52,7 @@ To install the chart with the release name `my-release`, run the following comma
 | securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 | service.annotations | object | `{}` |  |
 | service.port | int | `80` | Service port. |
+| service.nodePort | int | 0 | The exposed nodePort. Required when `service.type` is [`"NodePort"`](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport). |
 | service.targetPort | int | `80` | Service target port. |
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |

--- a/charts/mercure/templates/service.yaml
+++ b/charts/mercure/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "mercure.selectorLabels" . | nindent 4 }}
 ---

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -121,6 +121,8 @@ service:
   port: 80
   # -- Service target port.
   targetPort: 80
+  # -- Set this, to pin the external nodePort in case `service.type` is `NodePort`.
+  nodePort:
   annotations: {}
 
 ingress:


### PR DESCRIPTION
When using `NodePort` as the `service.type` in the helm chart, there is no possibility to fix the port number.

This introduces the conditional for the helm chart.