### PR TITLE
chore: revert payloads-related changes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,6 @@ linters:
 
     # deprecated
     - execinquery
-    - exportloopref
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
 
     # deprecated
     - execinquery
+    - exportloopref
 
 issues:
   exclude-rules:

--- a/authorization.go
+++ b/authorization.go
@@ -19,11 +19,9 @@ type claims struct {
 }
 
 type mercureClaim struct {
-	Publish   []string `json:"publish"`
-	Subscribe []string `json:"subscribe"`
-	// Deprecated: use the Payloads field instead
-	Payload  interface{}            `json:"payload"`
-	Payloads map[string]interface{} `json:"payloads"`
+	Publish   []string    `json:"publish"`
+	Subscribe []string    `json:"subscribe"`
+	Payload   interface{} `json:"payload"`
 }
 
 type role int

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,34 +1,6 @@
 # Upgrade
 
-## 0.20
-
-The `mercure.payload` JWT key has been deprecated. It is now possible to make topic-specific data
-available in subscriptions events and through the subscription API.
-To make data available in all events and API responses describing subscriptions, use the `*` topic selector.
-
-Before:
-
-```json
-{
-  "mercure": {
-    "payload": { "foo": "bar" }
-  }
-}
-```
-
-After:
-
-```json
-{
-  "mercure": {
-    "payloads": {
-      "*": { "foo": "bar" }
-    }
-  }
-}
-```
-
-[Read the updated specification](../spec/mercure.md#payloads) to learn how to leverage this new feature.
+## 0.17
 
 The `MERCURE_TRANSPORT_URL` environment variable and the `transport_url` directive have been deprecated.
 Use the new `transport` directive instead.

--- a/hub_test.go
+++ b/hub_test.go
@@ -264,13 +264,12 @@ func createAnonymousDummy(options ...Option) *Hub {
 }
 
 func createDummyAuthorizedJWT(r role, topics []string) string {
-	payloads := map[string]interface{}{"*": make(map[string]string)}
-	payloads["*"].(map[string]string)["foo"] = "bar"
-
-	return createDummyAuthorizedJWTWithPayload(r, topics, payloads)
+	return createDummyAuthorizedJWTWithPayload(r, topics, struct {
+		Foo string `json:"foo"`
+	}{Foo: "bar"})
 }
 
-func createDummyAuthorizedJWTWithPayload(r role, topics []string, payloads map[string]interface{}) string {
+func createDummyAuthorizedJWTWithPayload(r role, topics []string, payload interface{}) string {
 	token := jwt.New(jwt.SigningMethodHS256)
 
 	var key []byte
@@ -283,7 +282,7 @@ func createDummyAuthorizedJWTWithPayload(r role, topics []string, payloads map[s
 		token.Claims = &claims{
 			Mercure: mercureClaim{
 				Subscribe: topics,
-				Payloads:  payloads,
+				Payload:   payload,
 			},
 			RegisteredClaims: jwt.RegisteredClaims{},
 		}

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -472,34 +472,14 @@ Consequently, this private update will be received by this subscriber, while oth
 a canonical topic matched by the selector provided in a `topic` query parameter but not matched by
 selectors in the `mercure.subscribe` claim will not.
 
-## Payloads
+## Payload
 
-User-defined data can be attached to subscriptions and made available through the subscription API
-and in subscription events.
-
+The `mercure` claim of the JWS **CAN** also contain user-defined values under the `payload` key.
+This JSON document will be attached to the subscription and made available in subscription events.
 See (#subscription-events).
 
-The `mercure` claim of the JWS **CAN** contain a JSON object under the `payloads` key.
-This JSON document **MUST** have selectors as keys, and user-defined data as values.
-
-The value associated with the first topic selector matching the topic of the subscription
-**MUST** be included under the `payload` key in the JSON object describing a subscription in
-the subscription API and in subscription events.
-
-Example JWT document containing payloads:
-
-~~~ json
-{
-    "subscribe": ["https://example.com/foo", "https://example.com/bar/baz"]
-    "payloads": {
-        "https://example.com/bar/{val}": {"custom": "data only available for subscriptions matching this selector"},
-        "*": {"data": "available for all other topics"}
-    }
-}
-~~~
-
-For instance, payloads can contain the user ID of the subscriber, its username, a list of groups it
-belongs to, or its IP address. Storing data in `mercure.payloads` is a convenient way to share data
+For instance, `mercure.payload` can contain the user ID of the subscriber, a list of groups it
+belongs to, or its IP address. Storing data in `mercure.payload` is a convenient way to share data
 related to one subscriber to other subscribers.
 
 # Reconnection, State Reconciliation and Event Sourcing {#reconciliation}
@@ -595,8 +575,8 @@ least the following properties:
 *   `topic`: the topic selector used of this subscription
 *   `subscriber`: the topic identifier of the subscriber. It **SHOULD** be an IRI.
 *   `active`: `true` when the subscription is active, and `false` when it is terminated
-*   `payload` (optional): content of the `mercure.payloads` in the subscriber's JWS matching the topic
-    (see (#authorization))
+*   `payload` (optional): the content of `mercure.payload` in the subscriber's JWS (see
+    (#authorization))
 
 The JSON-LD document **MAY** contain other properties.
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -182,7 +182,7 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) (*Subsc
 
 	topics := r.URL.Query()["topic"]
 	if len(topics) == 0 {
-		http.Error(w, "Missing \"topic\" parameter.", http.StatusBadRequest)
+		http.Error(w, `Missing "topic" parameter.`, http.StatusBadRequest)
 
 		return nil, nil
 	}

--- a/subscribe.go
+++ b/subscribe.go
@@ -182,7 +182,7 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) (*Subsc
 
 	topics := r.URL.Query()["topic"]
 	if len(topics) == 0 {
-		http.Error(w, `Missing "topic" parameter.`, http.StatusBadRequest)
+		http.Error(w, "Missing \"topic\" parameter.", http.StatusBadRequest)
 
 		return nil, nil
 	}
@@ -203,47 +203,17 @@ func (h *Hub) registerSubscriber(w http.ResponseWriter, r *http.Request) (*Subsc
 	rc := h.newResponseController(w, s)
 	rc.flush()
 
-	h.normalizeClaims(claims)
-	h.logNewSubscriber(claims, s)
+	if c := h.logger.Check(zap.InfoLevel, "New subscriber"); c != nil {
+		fields := []LogField{zap.Object("subscriber", s)}
+		if claims != nil && h.logger.Level() == zap.DebugLevel {
+			fields = append(fields, zap.Reflect("payload", claims.Mercure.Payload))
+		}
+
+		c.Write(fields...)
+	}
 	h.metrics.SubscriberConnected(s)
 
 	return s, rc
-}
-
-func (h *Hub) logNewSubscriber(claims *claims, s *Subscriber) {
-	c := h.logger.Check(zap.InfoLevel, "New subscriber")
-	if c == nil {
-		return
-	}
-
-	fields := []LogField{zap.Object("subscriber", s)}
-	if claims != nil && h.logger.Level() == zap.DebugLevel {
-		if claims.Mercure.Payload != nil && h.opt.isBackwardCompatiblyEnabledWith(8) {
-			fields = append(
-				fields,
-				zap.Reflect("payload", claims.Mercure.Payload),
-			)
-		}
-
-		fields = append(
-			fields,
-			zap.Reflect("payloads", claims.Mercure.Payloads),
-		)
-	}
-
-	c.Write(fields...)
-}
-
-func (h *Hub) normalizeClaims(c *claims) {
-	if c == nil || c.Mercure.Payload == nil {
-		return
-	}
-
-	if h.opt.isBackwardCompatiblyEnabledWith(8) {
-		h.logger.Info(`Deprecated: the "mercure.payload" JWT claim deprecated since the version 8 of the protocol, use "mercure.payloads" claim with a "*" key instead.`)
-	} else {
-		c.Mercure.Payload = nil
-	}
 }
 
 // sendHeaders sends correct HTTP headers to create a keep-alive connection.

--- a/subscriber.go
+++ b/subscriber.go
@@ -209,21 +209,8 @@ func (s *Subscriber) getSubscriptions(topic, context string, active bool) []subs
 			Topic:      t,
 			Active:     active,
 		}
-		if s.Claims != nil { //nolint:nestif
-			if s.Claims.Mercure.Payloads == nil {
-				if s.Claims.Mercure.Payload != nil {
-					subscription.Payload = s.Claims.Mercure.Payload
-				}
-			} else {
-				for k, v := range s.Claims.Mercure.Payloads {
-					if !s.topicSelectorStore.match(t, k) {
-						continue
-					}
-					subscription.Payload = v
-
-					break
-				}
-			}
+		if s.Claims != nil && s.Claims.Mercure.Payload != nil {
+			subscription.Payload = s.Claims.Mercure.Payload
 		}
 
 		subscriptions = append(subscriptions, subscription)


### PR DESCRIPTION
Reverts #945 and #946.

A better approach has been found in #959.