### PR TITLE
fix: support autoscaling/v2

### DIFF
--- a/charts/mercure/templates/hpa.yaml
+++ b/charts/mercure/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "mercure.fullname" . }}


### PR DESCRIPTION
autoscaling/v2beta1 isn't supported on Kubernetes v1.25.

See:
https://kubernetes.io/docs/reference/using-api/deprecation-guide/