### PR TITLE
ci: build deb, rpm and apk packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -152,6 +152,23 @@ docker_manifests:
     image_templates:
       - dunglas/mercure:latest-amd64
       - dunglas/mercure:latest-arm64v8
+nfpms:
+  - id: linux_packages  # Unique ID for the package configuration
+    package_name: mercure  # Name of the package
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}.{{ .Format }}"
+    builds:
+      - caddy  # Referencing the build ID for the binaries to be packaged
+      - legacy  # Optionally, you can include this if needed
+    formats:
+      - apk
+      - deb
+      - rpm
+    maintainer: "Kévin Dunglas <kevin@dunglas.fr>"
+    description: "Mercure is a protocol enabling real-time updates."
+    license: "AGPL-3.0-or-later"
+    vendor: "Mercure Project"
+    homepage: "https://mercure.rocks"
+    bindir: /usr/bin 
 signs:
   - artifacts: checksum
     args:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -162,10 +162,10 @@ nfpms:
       - apk
       - deb
       - rpm
-    maintainer: "Kévin Dunglas <kevin@dunglas.fr>"
-    description: "Mercure is a protocol enabling real-time updates."
+    maintainer: "Kévin Dunglas <kevin@dunglas.dev>"
+    description: "An open, easy, fast, reliable and battery-efficient solution for real-time communications."
     license: "AGPL-3.0-or-later"
-    vendor: "Mercure Project"
+    vendor: "Dunglas Services SAS"
     homepage: "https://mercure.rocks"
     bindir: /usr/bin 
 signs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -153,12 +153,12 @@ docker_manifests:
       - dunglas/mercure:latest-amd64
       - dunglas/mercure:latest-arm64v8
 nfpms:
-  - id: linux_packages  # Unique ID for the package configuration
-    package_name: mercure  # Name of the package
+  - id: linux_packages
+    package_name: mercure
     file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}.{{ .Format }}"
     builds:
-      - caddy  # Referencing the build ID for the binaries to be packaged
-      - legacy  # Optionally, you can include this if needed
+      - caddy
+      - legacy
     formats:
       - apk
       - deb

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -158,7 +158,6 @@ nfpms:
     file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}.{{ .Format }}"
     builds:
       - caddy
-      - legacy
     formats:
       - apk
       - deb


### PR DESCRIPTION
This pull request adds a new section to the `.goreleaser.yml` file to include Linux package metadata. The changes primarily focus on defining the packaging details for `mercure`.

New Linux package metadata:

* Added `nfpms` section to define Linux package details including `package_name`, `file_name_template`, `builds`, `formats`, `maintainer`, `description`, `license`, `vendor`, `homepage`, and `bindir` to automatically build `deb`, `rpm` and `apk` packages.

* `feat: #972 
* `ci`: CI-related change