### PR TITLE
fix: Add default shutdown grace period

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,6 @@
 # Learn how to configure the Mercure.rocks Hub on https://mercure.rocks/docs/hub/config
 {
+	grace_period 1s
 	{$GLOBAL_OPTIONS}
 }
 


### PR DESCRIPTION
<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->

As per #986, adds a default grace period of 1s. If the same global option has been set using the $GLOBAL_OPTIONS it wil override the default one.