### PR TITLE
docs: Mention dev.Caddyfile file change in docs

### DIFF
--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -67,6 +67,7 @@ docker run \
     -p 443:443 \
     dunglas/mercure caddy run --config /etc/caddy/dev.Caddyfile
 ```
+_Note:_ Docker images before tag v0.16.2 use **Caddyfile.dev** instead of dev.Caddyfile
 
 The server is then available on `https://localhost`. Anonymous subscribers are allowed and the debugger UI is available on `https://localhost/.well-known/mercure/ui/`.
 


### PR DESCRIPTION
Users on Docker images older than v0.16.2 may be confused when they run the container, as the file `dev.Caddyfile` doesn't exist on those containers (v0.16.2 changed it from `Caddyfile.dev` to `dev.Caddyfile`)

<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->
