### PR TITLE
docs: add proxy_buffering off to Nginx example for SSL proxy compatibility

### DIFF
--- a/docs/hub/nginx.md
+++ b/docs/hub/nginx.md
@@ -16,6 +16,9 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
 
+        # Enable fast reply in SSE
+        proxy_buffering off;
+
         ## Be sure to set USE_FORWARDED_HEADERS=1 to allow the hub to use those headers ##
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
This PR updates the documentation to include `proxy_buffering off;` in the Nginx configuration example for Mercure. This change improves compatibility when using Mercure behind an SSL-enabled Nginx proxy.  

### Problem  
When Mercure is behind a Nginx reverse proxy with SSL, Nginx buffers responses by default. This can cause issues with long-lived SSE connections, leading to delayed message delivery and unexpected behavior for subscribers.  

### Solution  
Disabling Nginx buffering with the following directive ensures that SSE messages are forwarded immediately to clients:  

```nginx
proxy_buffering off;
```

### Changes  
- **Docs:** Updated the Nginx configuration example to include `proxy_buffering off;`  
- **Notes:** Added a brief explanation of why this directive is necessary when using SSL proxies.  

### Testing  
- Tested with Mercure behind an Nginx SSL proxy.  
- Observed that after adding `proxy_buffering off;`, SSE messages are delivered in real-time without delays.  

### Related issues
#854 #843 #857 #986 
