### PR TITLE
fix: update metrics registry

### DIFF
--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -20,7 +20,6 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/dunglas/mercure"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -29,7 +28,6 @@ const defaultHubURL = "/.well-known/mercure"
 
 var (
 	ErrCompatibility = errors.New("compatibility mode only supports protocol version 7")
-	metrics          = mercure.NewPrometheusMetrics(prometheus.DefaultRegisterer) //nolint:gochecknoglobals
 
 	// Deprecated: use transports Caddy modules.
 	transports = caddy.NewUsagePool() //nolint:gochecknoglobals
@@ -189,6 +187,8 @@ func createTransportLegacy(m *Mercure) (mercure.Transport, error) {
 
 //nolint:wrapcheck
 func (m *Mercure) Provision(ctx caddy.Context) error { //nolint:funlen,gocognit
+	metrics := mercure.NewPrometheusMetrics(ctx.GetMetricsRegistry())
+
 	if err := m.populateJWTConfig(); err != nil {
 		return err
 	}


### PR DESCRIPTION
update Caddy metrics registry
as of Caddy v2.9 (https://github.com/caddyserver/caddy/commit/41f5dd56e1b93ec815daa98dd1f1caa7f2087312) it changed the flow to get the metrics registry