### PR TITLE
feat: Add token-level control for public updates 

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
 	"go.uber.org/zap"
@@ -162,8 +163,15 @@ func canDispatch(s *TopicSelectorStore, topics, topicSelectors []string) bool {
 func canDispatchPublic(payload interface{}) bool {
 	if payloadMap, ok := payload.(map[string]interface{}); ok {
 		if publicPublish, exists := payloadMap["allow_public_updates"]; exists {
+			// Check if it's a boolean
 			if isPublicPublish, ok := publicPublish.(bool); ok {
 				return isPublicPublish
+			}
+
+			// Check if it's a string representation
+			if strValue, ok := publicPublish.(string); ok {
+				// Compare lowercased string to handle "false", "False", "FALSE", etc.
+				return strings.ToLower(strValue) != "false"
 			}
 		}
 	}

--- a/authorization.go
+++ b/authorization.go
@@ -157,6 +157,20 @@ func canDispatch(s *TopicSelectorStore, topics, topicSelectors []string) bool {
 	return true
 }
 
+// canDispatchPublic checks if the payload  allow public updates by examining the "allow_public_updates" field in the payload.
+// It returns true if the field is set to true, or if the field is not present (for backward compatibility).
+func canDispatchPublic(payload interface{}) bool {
+	if payloadMap, ok := payload.(map[string]interface{}); ok {
+		if publicPublish, exists := payloadMap["allow_public_updates"]; exists {
+			if isPublicPublish, ok := publicPublish.(bool); ok {
+				return isPublicPublish
+			}
+		}
+	}
+	// Default to true for backward compatibility
+	return true
+}
+
 func (h *Hub) httpAuthorizationError(w http.ResponseWriter, r *http.Request, err error) {
 	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 	if c := h.logger.Check(zap.DebugLevel, "Topic selectors not matched, not provided or authorization error"); c != nil {

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -724,3 +724,40 @@ func TestCanDispatch(t *testing.T) {
 	assert.False(t, canDispatch(tss, []string{"foo", "bar"}, []string{"baz"}))
 	assert.False(t, canDispatch(tss, []string{"foo", "bar"}, []string{"baz", "bat"}))
 }
+func TestCanDispatchPublic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		payload  interface{}
+		expected bool
+	}{
+		{
+			name:     "allow_public_updates is true",
+			payload:  map[string]interface{}{"allow_public_updates": true},
+			expected: true,
+		},
+		{
+			name:     "allow_public_updates is false",
+			payload:  map[string]interface{}{"allow_public_updates": false},
+			expected: false,
+		},
+		{
+			name:     "allow_public_updates is missing",
+			payload:  map[string]interface{}{},
+			expected: true,
+		},
+		{
+			name:     "payload is not a map",
+			payload:  "invalid payload",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := canDispatchPublic(tt.payload)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -738,8 +738,18 @@ func TestCanDispatchPublic(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "allow_public_updates is true as a string",
+			payload:  map[string]interface{}{"allow_public_updates": "true"},
+			expected: true,
+		},
+		{
 			name:     "allow_public_updates is false",
 			payload:  map[string]interface{}{"allow_public_updates": false},
+			expected: false,
+		},
+		{
+			name:     "allow_public_updates is false as a string",
+			payload:  map[string]interface{}{"allow_public_updates": "false"},
 			expected: false,
 		},
 		{

--- a/publish.go
+++ b/publish.go
@@ -63,6 +63,12 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if !private && !canDispatchPublic(claims.Mercure.Payload) {
+		h.logger.Info("Unauthorized: token does not allow public updates, 'allow_public_updates' is set to false")
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+
 	u := &Update{
 		Topics:  topics,
 		Private: private,


### PR DESCRIPTION
**Problem**
Currently, publishers can choose between private and public updates by setting the private parameter in their request. However, this presents a security risk in frontend applications where a malicious user could modify requests to remove the private flag, potentially exposing sensitive information to unauthorized subscribers.

**Solution**

This PR introduces a new JWT claim `allow_public_updates` that can be set to false to restrict tokens to private-only updates. When this claim is present and set to false, any attempt to publish a public update will be rejected with a 401 Unauthorized response, regardless of what's in the request.
This provides a server-enforced security boundary that cannot be bypassed by manipulating requests on the client side.

**Implementation**

Added a new `canDispatchPublic` function that checks for the presence of the claim
Integrated this check into the PublishHandler flow
Added tests to verify the functionality
Maintains backward compatibility by defaulting to allowing public updates when the claim is not present

**Use Case**

This feature is particularly useful for collaborative editing applications where you want to ensure that document updates are only visible to authorized collaborators, regardless of how the frontend code behaves.

