### PR TITLE
docs: Add Rust `mercure` crate to list of client libraries

### DIFF
--- a/docs/ecosystem/awesome.md
+++ b/docs/ecosystem/awesome.md
@@ -32,6 +32,7 @@
 - [Dart (publish and subscribe)](https://github.com/wallforfry/dart_mercure)
 - [Amphp (publish)](https://github.com/eislambey/amp-mercure-publisher)
 - [Java (publish)](https://github.com/vitorluis/java-mercure)
+- [Rust (publish)](https://github.com/teohhanhui/mercure-rs)
 
 ## Frameworks and Services Integrations
 


### PR DESCRIPTION
Repository: https://github.com/teohhanhui/mercure-rs
crates.io: https://crates.io/crates/mercure
Documentation: https://docs.rs/mercure