### PR TITLE
fix: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,7 +54,7 @@ upx:
     goos: [linux]
     compress: best
 archives:
-  - builds:
+  - ids:
       - caddy
     name_template: >-
       {{ .ProjectName }}_
@@ -73,7 +73,7 @@ archives:
       - goos: windows
         formats: [ zip ]
   - id: legacy
-    builds:
+    ids:
       - legacy
     name_template: >-
       {{ .ProjectName }}-legacy_
@@ -149,7 +149,7 @@ nfpms:
   - id: linux_packages
     package_name: mercure
     file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}.{{ .Format }}"
-    builds:
+    ids:
       - caddy
     formats:
       - apk


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings which you can find in the [CI logs](https://github.com/dunglas/mercure/actions/runs/15404433351/job/43344188809#step:7:30): 
```
DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
DEPRECATED: nfpms.builds should not be used anymore, check https://goreleaser.com/deprecations#nfpmsbuilds for more info
```