### PR TITLE
fix: update secret key ref to use existing secret

### DIFF
--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: CADDY_EXTRA_CONFIG
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mercure.fullname" . }}
+                  name: {{ include "mercure.secretName" . }}
                   key: caddy-extra-config
             - name: CADDY_SERVER_EXTRA_DIRECTIVES
               valueFrom:


### PR DESCRIPTION
The `CADDY_EXTRA_CONFIG` secret in the `deployment.yaml` of the helm chart references the wrong secret name when `existingSecret` is set in the `values.yaml`. 

Currently it is using `{{ include "mercure.fullname" . }}`, correct would be `{{ include "mercure.secretName" . }}`.