### PR TITLE
fix: subscriber list cache size

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -80,11 +80,12 @@ func DeprecatedNewBoltTransport(u *url.URL, l Logger) (Transport, error) { //nol
 		return nil, &TransportError{u.Redacted(), "missing path", err}
 	}
 
-	return NewBoltTransport(l, path, bucketName, size, cleanupFrequency)
+	return NewBoltTransport(NewSubscriberList(DefaultSubscriberListCacheSize), l, path, bucketName, size, cleanupFrequency)
 }
 
 // NewBoltTransport creates a new BoltTransport.
 func NewBoltTransport(
+	subscriberList *SubscriberList,
 	logger Logger,
 	path string,
 	bucketName string,
@@ -115,10 +116,9 @@ func NewBoltTransport(
 		bucketName:       bucketName,
 		size:             size,
 		cleanupFrequency: cleanupFrequency,
-
-		subscribers: NewSubscriberList(),
-		closed:      make(chan struct{}),
-		lastEventID: lastEventID,
+		subscribers:      subscriberList,
+		closed:           make(chan struct{}),
+		lastEventID:      lastEventID,
 	}, nil
 }
 

--- a/bolt_test.go
+++ b/bolt_test.go
@@ -23,7 +23,7 @@ func createBoltTransport(t *testing.T, size uint64, cleanupFrequency float64) *B
 	}
 
 	path := "test-" + t.Name() + ".db"
-	transport, err := NewBoltTransport(zap.NewNop(), path, defaultBoltBucketName, size, cleanupFrequency)
+	transport, err := NewBoltTransport(NewSubscriberList(0), zap.NewNop(), path, defaultBoltBucketName, size, cleanupFrequency)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/caddy/bolt.go
+++ b/caddy/bolt.go
@@ -47,7 +47,14 @@ func (b *Bolt) Provision(ctx caddy.Context) error {
 	b.transportKey = key.String()
 
 	destructor, _, err := TransportUsagePool.LoadOrNew(b.transportKey, func() (caddy.Destructor, error) {
-		t, err := mercure.NewBoltTransport(ctx.Logger(), b.Path, b.BucketName, b.Size, b.CleanupFrequency)
+		t, err := mercure.NewBoltTransport(
+			mercure.NewSubscriberList(ctx.Value(SubscriberListCacheSizeContextKey).(int)),
+			ctx.Logger(),
+			b.Path,
+			b.BucketName,
+			b.Size,
+			b.CleanupFrequency,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/caddy/local.go
+++ b/caddy/local.go
@@ -31,9 +31,13 @@ func (l *Local) GetTransport() mercure.Transport { //nolint:ireturn
 }
 
 // Provision provisions l's configuration.
-func (l *Local) Provision(_ caddy.Context) error {
+func (l *Local) Provision(ctx caddy.Context) error {
 	destructor, _, _ := TransportUsagePool.LoadOrNew(localTransportKey, func() (caddy.Destructor, error) {
-		return TransportDestructor[*mercure.LocalTransport]{Transport: mercure.NewLocalTransport()}, nil
+		return TransportDestructor[*mercure.LocalTransport]{
+			Transport: mercure.NewLocalTransport(
+				mercure.NewSubscriberList(ctx.Value(SubscriberListCacheSizeContextKey).(int)),
+			),
+		}, nil
 	})
 
 	l.transport = destructor.(TransportDestructor[*mercure.LocalTransport]).Transport

--- a/caddy/transport.go
+++ b/caddy/transport.go
@@ -20,11 +20,13 @@ func (d TransportDestructor[T]) Destruct() error {
 }
 
 type (
-	subscriptionsKeyType struct{}
-	writeTimeoutKeyType  struct{}
+	subscriptionsKeyType        struct{}
+	writeTimeoutKeyType         struct{}
+	subscriberListCacheSizeType struct{}
 )
 
 var (
-	SubscriptionsContextKey = subscriptionsKeyType{} //nolint:gochecknoglobals
-	WriteTimeoutContextKey  = writeTimeoutKeyType{}  //nolint:gochecknoglobals
+	SubscriptionsContextKey           = subscriptionsKeyType{}        //nolint:gochecknoglobals
+	WriteTimeoutContextKey            = writeTimeoutKeyType{}         //nolint:gochecknoglobals
+	SubscriberListCacheSizeContextKey = subscriberListCacheSizeType{} //nolint:gochecknoglobals
 )

--- a/hub.go
+++ b/hub.go
@@ -335,7 +335,7 @@ func NewHub(options ...Option) (*Hub, error) {
 	}
 
 	if opt.transport == nil {
-		opt.transport = NewLocalTransport()
+		opt.transport = NewLocalTransport(NewSubscriberList(DefaultSubscriberListCacheSize))
 	}
 
 	if ttss, ok := opt.transport.(TransportTopicSelectorStore); ok {

--- a/local.go
+++ b/local.go
@@ -23,13 +23,13 @@ type LocalTransport struct {
 //
 // Deprecated: use NewLocalTransport() instead.
 func DeprecatedNewLocalTransport(_ *url.URL, _ Logger) (Transport, error) { //nolint:ireturn
-	return NewLocalTransport(), nil
+	return NewLocalTransport(NewSubscriberList(DefaultSubscriberListCacheSize)), nil
 }
 
 // NewLocalTransport creates a new LocalTransport.
-func NewLocalTransport() *LocalTransport {
+func NewLocalTransport(sl *SubscriberList) *LocalTransport {
 	return &LocalTransport{
-		subscribers: NewSubscriberList(),
+		subscribers: sl,
 		closed:      make(chan struct{}),
 		lastEventID: EarliestLastEventID,
 	}

--- a/local_bench_test.go
+++ b/local_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkLocalTransport(b *testing.B) {
 func subBenchLocalTransport(b *testing.B, topics, concurrency, matchPct int, testName string) {
 	b.Helper()
 
-	tr := NewLocalTransport()
+	tr := NewLocalTransport(NewSubscriberList(1_000))
 
 	b.Cleanup(func() {
 		assert.NoError(b, tr.Close())

--- a/local_test.go
+++ b/local_test.go
@@ -12,7 +12,7 @@ import (
 func TestLocalTransportDoNotDispatchUntilListen(t *testing.T) {
 	t.Parallel()
 
-	transport := NewLocalTransport()
+	transport := NewLocalTransport(NewSubscriberList(0))
 
 	t.Cleanup(func() {
 		assert.NoError(t, transport.Close())
@@ -46,7 +46,7 @@ func TestLocalTransportDoNotDispatchUntilListen(t *testing.T) {
 func TestLocalTransportDispatch(t *testing.T) {
 	t.Parallel()
 
-	transport := NewLocalTransport()
+	transport := NewLocalTransport(NewSubscriberList(0))
 
 	t.Cleanup(func() {
 		assert.NoError(t, transport.Close())
@@ -66,7 +66,7 @@ func TestLocalTransportDispatch(t *testing.T) {
 func TestLocalTransportClosed(t *testing.T) {
 	t.Parallel()
 
-	transport := NewLocalTransport()
+	transport := NewLocalTransport(NewSubscriberList(0))
 
 	t.Cleanup(func() {
 		assert.NoError(t, transport.Close())
@@ -90,7 +90,7 @@ func TestLocalTransportClosed(t *testing.T) {
 func TestLiveCleanDisconnectedSubscribers(t *testing.T) {
 	t.Parallel()
 
-	transport := NewLocalTransport()
+	transport := NewLocalTransport(NewSubscriberList(0))
 
 	t.Cleanup(func() {
 		assert.NoError(t, transport.Close())
@@ -119,7 +119,7 @@ func TestLiveCleanDisconnectedSubscribers(t *testing.T) {
 func TestLiveReading(t *testing.T) {
 	t.Parallel()
 
-	transport := NewLocalTransport()
+	transport := NewLocalTransport(NewSubscriberList(0))
 
 	t.Cleanup(func() {
 		assert.NoError(t, transport.Close())
@@ -141,7 +141,7 @@ func TestLiveReading(t *testing.T) {
 func TestLocalTransportGetSubscribers(t *testing.T) {
 	t.Parallel()
 
-	transport := NewLocalTransport()
+	transport := NewLocalTransport(NewSubscriberList(0))
 
 	t.Cleanup(func() {
 		assert.NoError(t, transport.Close())

--- a/subscriber.go
+++ b/subscriber.go
@@ -48,7 +48,7 @@ func escapeTopics(topics []string) []string {
 	return escapedTopics
 }
 
-// MatchTopics checks if the current subscriber can access to the given topic.
+// MatchTopics checks if the current subscriber can access to at least one of the given topics.
 //
 //nolint:gocognit
 func (s *Subscriber) MatchTopics(topics []string, private bool) bool {

--- a/subscriberlist_test.go
+++ b/subscriberlist_test.go
@@ -28,7 +28,7 @@ func BenchmarkSubscriberList(b *testing.B) {
 	logger := zap.NewNop()
 	tss := &TopicSelectorStore{}
 
-	l := NewSubscriberList()
+	l := NewSubscriberList(DefaultSubscriberListCacheSize)
 
 	for i := range 100 {
 		s := NewLocalSubscriber("", logger, tss)

--- a/topicselectorcache.go
+++ b/topicselectorcache.go
@@ -28,7 +28,7 @@ func NewTopicSelectorStoreCache(maxEntriesPerShard int, shardCount uint64) (*Top
 	}
 
 	cacheMap := make(shardedCache, shardCount)
-	for i := uint64(0); i < shardCount; i++ {
+	for i := range shardCount {
 		cacheMap[i] = otter.Must(&otter.Options[string, any]{MaximumSize: maxEntriesPerShard})
 	}
 


### PR DESCRIPTION
Fix a bug introduced in #1090. The subscriber list cache size must have a limit to prevent a leak.

cc @naxo8628, this may dramatically reduce memory usage. 