### PR TITLE
fix(helm): use helper in secret reference to caddy-extra-config

### DIFF
--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: CADDY_EXTRA_CONFIG
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mercure.fullname" . }}
+                  name: {{ include "mercure.secretName" . }}
                   key: caddy-extra-config
             - name: CADDY_SERVER_EXTRA_DIRECTIVES
               valueFrom:


### PR DESCRIPTION
This PR fixes an issue we encountered using `existingSecret` value:

  * The caddy-extra-config is defined in the secret generated by the [template](https://github.com/dunglas/mercure/blob/main/charts/mercure/templates/secrets.yaml#L17)
  * Our secret contained the correct keys
  * We were having an error `Error: secret "<release_name>" not found`
 
