### PR TITLE
perf: allocate header values only one time

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -263,7 +263,7 @@ func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSu
 	header["X-Accel-Buffering"] = headerXAccelBuffering
 
 	if s.RequestLastEventID != "" {
-		header["Last-Event-ID"] = []string{<-s.responseLastEventID}
+		header["Last-Event-Id"] = []string{<-s.responseLastEventID}
 	}
 
 	// Write a comment in the body


### PR DESCRIPTION
<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->
