### PR TITLE
feat: add deployment strategy configuration to Helm chart

### DIFF
--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+      type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       {{- include "mercure.selectorLabels" . | nindent 6 }}

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -72,6 +72,11 @@ metrics:
 # -- The number of replicas (pods) to launch, must be 1 unless you are using [the High Availability version](https://mercure.rocks/docs/hub/cluster).
 replicaCount: 1
 
+# -- [Deployment strategy type](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
+# Useful to set it to 'Recreate' when using BoltDB transport with persistence.
+updateStrategy:
+  type: RollingUpdate
+
 image:
   # -- Name of the image repository to pull the container image from.
   repository: dunglas/mercure


### PR DESCRIPTION
Updating the k8s deployment with the default strategy fails with BoltDB transport and persistence because 2 pods cannot run simultaneously.
Setting the strategy to "Recreate" allows the old pod to stop before the new one starts.

<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->
