### PR TITLE
chore: Clarify that `transport_url` and the `MERCURE_TRANSPORT_URL` env no longer affect the configuration for builds without the `deprecated_transport` flag

### DIFF
--- a/caddy/mercure_notdeprecated_transport.go
+++ b/caddy/mercure_notdeprecated_transport.go
@@ -2,16 +2,24 @@
 
 package caddy
 
-import "github.com/dunglas/mercure"
+import (
+	"os"
+
+	"github.com/dunglas/mercure"
+)
 
 func (_ *Mercure) createTransportDeprecated() (mercure.Transport, error) {
 	return nil, nil
 }
 
 func (m *Mercure) assignDeprecatedTransportURL(_ string) {
+	m.logger.Error(`Setting the MERCURE_TRANSPORT_URL environment variable is not available anymore, use the "transport" directive instead`)
 }
 
 func (m *Mercure) assignDeprecatedTransportURLForEnv() {
+	if "" != os.Getenv("MERCURE_TRANSPORT_URL") {
+		m.logger.Error(`Setting the "transport_url" directive is not available anymore, use the "transport" directive instead`)
+	}
 }
 
 func (m *Mercure) cleanupTransportDeprecated() error {


### PR DESCRIPTION
Since Mercure v0.21 introduced the `deprecated_transport` build flag. This flag is used by default for Mercure builds, but builds for other projects (such as FrankenPHP) may not include this flag.

The `transport_url` directive and the `MERCURE_TRANSPORT_URL` env have been deprecated, but when building Mercure 0.21 without the `deprecated_transport` flag, they are silently unused. I suspect this could cause problems for some configurations.

With this PR, I propose adding error messages when using the `transport_url` or the `MERCURE_TRANSPORT_URL`. I hope this will make it easier to determine why they might not work.

Relates https://github.com/dunglas/symfony-docker/issues/870