### PR TITLE
docs: Add Bolt Adapter configuration example

### DIFF
--- a/docs/hub/config.md
+++ b/docs/hub/config.md
@@ -128,6 +128,17 @@ MERCURE_SUBSCRIBER_JWT_ALG=RS256 \
 
 ## Bolt Adapter
 
+```Caddyfile
+localhost {
+	mercure {
+		transport bolt {
+			path /data/mercure.db
+		}
+		...
+	}
+}
+```
+
 | Option              | Description                                                                                                                                                        |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `path`              | path of the database file (default: `mercure.db`)                                                                                                                  |


### PR DESCRIPTION
Added configuration example for Bolt Adapter in Caddyfile to clarify use.