### PR TITLE
fix: crash when using legacy transports with a build not supporting them

### DIFF
--- a/caddy/mercure_notdeprecated_transport.go
+++ b/caddy/mercure_notdeprecated_transport.go
@@ -5,6 +5,7 @@ package caddy
 import (
 	"os"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/dunglas/mercure"
 )
 
@@ -13,12 +14,12 @@ func (_ *Mercure) createTransportDeprecated() (mercure.Transport, error) {
 }
 
 func (m *Mercure) assignDeprecatedTransportURL(_ string) {
-	m.logger.Error(`Setting the MERCURE_TRANSPORT_URL environment variable is not available anymore, use the "transport" directive instead`)
+	caddy.Log().Error(`Setting the "transport_url" directive is not available anymore, use the "transport" directive instead`)
 }
 
 func (m *Mercure) assignDeprecatedTransportURLForEnv() {
 	if "" != os.Getenv("MERCURE_TRANSPORT_URL") {
-		m.logger.Error(`Setting the "transport_url" directive is not available anymore, use the "transport" directive instead`)
+		caddy.Log().Error(`The "MERCURE_TRANSPORT_URL"" environment variable is not supported anymore, set the "transport" directive in the "MERCURE_EXTRA_DIRECTIVES" environment variable instead`)
 	}
 }
 


### PR DESCRIPTION
Fix #1141.