### PR TITLE
feat(transport): add transport-aware health check endpoints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,6 @@ jobs:
           VALIDATE_GO: false
           VALIDATE_GO_MODULES: false
           VALIDATE_GO_RELEASER: false
-          VALIDATE_SPELL_CODESPELL: false
           VALIDATE_PHP_PHPCS: false
           VALIDATE_KUBERNETES_KUBECONFORM: false
           VALIDATE_JAVASCRIPT_STANDARD: false

--- a/Caddyfile
+++ b/Caddyfile
@@ -44,6 +44,7 @@
 	Read the documentation on <a href="https://mercure.rocks">Mercure.rocks, real-time apps made easy</a>.`
 	respond /robots.txt `User-agent: *
 	Disallow: /`
+	# Deprecated: use the /mercure/health/ready and /mercure/health/live admin API endpoints for transport-aware health checks
 	respond /healthz 200
 	respond "Not Found" 404
 }

--- a/caddy/health.go
+++ b/caddy/health.go
@@ -19,6 +19,7 @@ const (
 var (
 	errMethodNotAllowed  = errors.New("method not allowed")
 	errUnknownHealthPath = errors.New("unknown health endpoint")
+	errHubNotFound       = errors.New("hub not found")
 )
 
 func init() { //nolint:gochecknoinits
@@ -69,12 +70,27 @@ func (h Health) handleHealth(w http.ResponseWriter, r *http.Request) error {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	if err := h.checkTransports(r, checkType, hubName); err != nil {
+	err = h.checkTransports(r, checkType, hubName)
+	if errors.Is(err, errHubNotFound) {
+		return caddy.APIError{
+			HTTPStatus: http.StatusNotFound,
+			Err:        err,
+		}
+	}
+
+	if err != nil {
+		// Log the detailed error server-side; return a generic message to
+		// avoid exposing internal connection details if the admin API is
+		// reachable beyond localhost.
+		caddy.Log().Named("admin.api.mercure_health").Error(
+			fmt.Sprintf("transport health check failed for check_type=%q hub=%q: %v", checkType, hubName, err),
+		)
+
 		w.WriteHeader(http.StatusServiceUnavailable)
 
 		return json.NewEncoder(w).Encode(healthResponse{ //nolint:wrapcheck
 			Status: "error",
-			Error:  err.Error(),
+			Error:  "transport health check failed",
 		})
 	}
 
@@ -102,10 +118,14 @@ func parseHealthPath(urlPath string) (checkType, hubName string, err error) {
 func (h Health) checkTransports(r *http.Request, checkType, hubName string) error {
 	infos := h.snapshotHubs()
 
+	var matched bool
+
 	for _, info := range infos {
 		if hubName != "" && info.name != hubName {
 			continue
 		}
+
+		matched = true
 
 		checker, ok := info.transport.(mercure.TransportHealthChecker)
 		if !ok {
@@ -122,6 +142,10 @@ func (h Health) checkTransports(r *http.Request, checkType, hubName string) erro
 		if err != nil {
 			return fmt.Errorf("transport %q: %w", info.name, err)
 		}
+	}
+
+	if hubName != "" && !matched {
+		return fmt.Errorf("%w: %q", errHubNotFound, hubName)
 	}
 
 	return nil

--- a/caddy/health.go
+++ b/caddy/health.go
@@ -1,0 +1,143 @@
+package caddy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/dunglas/mercure"
+)
+
+const (
+	checkReady = "ready"
+	checkLive  = "live"
+)
+
+var (
+	errMethodNotAllowed  = errors.New("method not allowed")
+	errUnknownHealthPath = errors.New("unknown health endpoint")
+)
+
+func init() { //nolint:gochecknoinits
+	caddy.RegisterModule(Health{})
+}
+
+// Health is a Caddy admin API module that exposes transport health check endpoints.
+type Health struct{}
+
+// CaddyModule returns the Caddy module information.
+func (Health) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "admin.api.mercure_health",
+		New: func() caddy.Module { return new(Health) },
+	}
+}
+
+// Routes returns the admin routes for the health module.
+func (h Health) Routes() []caddy.AdminRoute {
+	return []caddy.AdminRoute{
+		{
+			Pattern: "/mercure/health/",
+			Handler: caddy.AdminHandlerFunc(h.handleHealth),
+		},
+	}
+}
+
+type healthResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (h Health) handleHealth(w http.ResponseWriter, r *http.Request) error {
+	if r.Method != http.MethodGet {
+		return caddy.APIError{
+			HTTPStatus: http.StatusMethodNotAllowed,
+			Err:        errMethodNotAllowed,
+		}
+	}
+
+	checkType, hubName, err := parseHealthPath(r.URL.Path)
+	if err != nil {
+		return caddy.APIError{
+			HTTPStatus: http.StatusNotFound,
+			Err:        err,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := h.checkTransports(r, checkType, hubName); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+
+		return json.NewEncoder(w).Encode(healthResponse{ //nolint:wrapcheck
+			Status: "error",
+			Error:  err.Error(),
+		})
+	}
+
+	return json.NewEncoder(w).Encode(healthResponse{Status: "ok"}) //nolint:wrapcheck
+}
+
+func parseHealthPath(urlPath string) (checkType, hubName string, err error) {
+	path := strings.TrimPrefix(urlPath, "/mercure/health/")
+	path = strings.TrimSuffix(path, "/")
+
+	switch {
+	case path == checkReady:
+		return checkReady, "", nil
+	case path == checkLive:
+		return checkLive, "", nil
+	case strings.HasSuffix(path, "/"+checkReady):
+		return checkReady, strings.TrimSuffix(path, "/"+checkReady), nil
+	case strings.HasSuffix(path, "/"+checkLive):
+		return checkLive, strings.TrimSuffix(path, "/"+checkLive), nil
+	default:
+		return "", "", errUnknownHealthPath
+	}
+}
+
+func (h Health) checkTransports(r *http.Request, checkType, hubName string) error {
+	infos := h.snapshotHubs()
+
+	for _, info := range infos {
+		if hubName != "" && info.name != hubName {
+			continue
+		}
+
+		checker, ok := info.transport.(mercure.TransportHealthChecker)
+		if !ok {
+			continue
+		}
+
+		var err error
+		if checkType == checkReady {
+			err = checker.Ready(r.Context())
+		} else {
+			err = checker.Live(r.Context())
+		}
+
+		if err != nil {
+			return fmt.Errorf("transport %q: %w", info.name, err)
+		}
+	}
+
+	return nil
+}
+
+func (h Health) snapshotHubs() []*hubInfo {
+	hubsMu.Lock()
+	defer hubsMu.Unlock()
+
+	infos := make([]*hubInfo, 0, len(hubs))
+	for _, info := range hubs {
+		infos = append(infos, info)
+	}
+
+	return infos
+}
+
+// Interface guards.
+var _ caddy.AdminRouter = (*Health)(nil)

--- a/caddy/health_test.go
+++ b/caddy/health_test.go
@@ -1,0 +1,210 @@
+package caddy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+	"github.com/dunglas/mercure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthEndpoints(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+	skip_install_trust
+	admin localhost:2999
+	http_port     9080
+	https_port    9443
+}
+
+localhost:9080 {
+	route {
+		mercure {
+			anonymous
+			publisher_jwt !ChangeMe!
+			transport local
+		}
+
+		respond 404
+	}
+}`, "caddyfile")
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"aggregate ready", "/mercure/health/ready"},
+		{"aggregate live", "/mercure/health/live"},
+		{"per-hub ready", "/mercure/health/default/ready"},
+		{"per-hub live", "/mercure/health/default/live"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:2999"+tt.path, nil)
+			require.NoError(t, err)
+
+			resp := tester.AssertResponseCode(req, http.StatusOK)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, resp.Body.Close())
+			require.NoError(t, err)
+
+			assert.Contains(t, string(body), `"status":"ok"`)
+		})
+	}
+}
+
+func TestHealthEndpointNotFound(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+	skip_install_trust
+	admin localhost:2999
+	http_port     9080
+	https_port    9443
+}
+
+localhost:9080 {
+	route {
+		mercure {
+			anonymous
+			publisher_jwt !ChangeMe!
+			transport local
+		}
+
+		respond 404
+	}
+}`, "caddyfile")
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:2999/mercure/health/invalid", nil)
+	require.NoError(t, err)
+
+	resp := tester.AssertResponseCode(req, http.StatusNotFound)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestHealthEndpointMethodNotAllowed(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+	skip_install_trust
+	admin localhost:2999
+	http_port     9080
+	https_port    9443
+}
+
+localhost:9080 {
+	route {
+		mercure {
+			anonymous
+			publisher_jwt !ChangeMe!
+			transport local
+		}
+
+		respond 404
+	}
+}`, "caddyfile")
+
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:2999/mercure/health/ready", nil)
+	require.NoError(t, err)
+
+	resp := tester.AssertResponseCode(req, http.StatusMethodNotAllowed)
+	require.NoError(t, resp.Body.Close())
+}
+
+// failingTransport is mock transport that implements TransportHealthChecker
+// and always reports unhealthy.
+type failingTransport struct {
+	mercure.Transport
+}
+
+var (
+	errMockNotReady = errors.New("connection refused")
+	errMockNotLive  = errors.New("unhealthy for 30s")
+)
+
+func (failingTransport) Ready(_ context.Context) error {
+	return errMockNotReady
+}
+
+func (failingTransport) Live(_ context.Context) error {
+	return errMockNotLive
+}
+
+func TestHealthEndpointUnhealthy(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+	skip_install_trust
+	admin localhost:2999
+	http_port     9080
+	https_port    9443
+}
+
+localhost:9080 {
+	route {
+		mercure {
+			anonymous
+			publisher_jwt !ChangeMe!
+			transport local
+		}
+
+		respond 404
+	}
+}`, "caddyfile")
+
+	// Inject a failing transport into the hubs map to simulate transport failure
+	hubsMu.Lock()
+
+	originalInfos := make([]*hubInfo, 0, len(hubs))
+	for _, info := range hubs {
+		originalInfos = append(originalInfos, info)
+	}
+
+	for k, info := range hubs {
+		hubs[k] = &hubInfo{
+			hub:       info.hub,
+			transport: failingTransport{},
+			name:      info.name,
+		}
+	}
+	hubsMu.Unlock()
+
+	t.Cleanup(func() {
+		hubsMu.Lock()
+		for k, info := range hubs {
+			for _, orig := range originalInfos {
+				if info.name == orig.name {
+					hubs[k] = orig
+
+					break
+				}
+			}
+		}
+		hubsMu.Unlock()
+	})
+
+	// Ready should return 503
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:2999/mercure/health/ready", nil)
+	require.NoError(t, err)
+
+	resp := tester.AssertResponseCode(req, http.StatusServiceUnavailable)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, resp.Body.Close())
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"status":"error"`)
+	assert.Contains(t, string(body), "connection refused")
+
+	// Live should return 503
+	req, err = http.NewRequest(http.MethodGet, "http://localhost:2999/mercure/health/live", nil)
+	require.NoError(t, err)
+
+	resp = tester.AssertResponseCode(req, http.StatusServiceUnavailable)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, resp.Body.Close())
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"status":"error"`)
+	assert.Contains(t, string(body), "unhealthy for 30s")
+}

--- a/caddy/health_test.go
+++ b/caddy/health_test.go
@@ -186,7 +186,8 @@ localhost:9080 {
 		hubsMu.Unlock()
 	})
 
-	// Ready should return 503
+	// Ready should return 503 with a generic error message
+	// (detailed errors are logged server-side, not exposed in the response).
 	req, err := http.NewRequest(http.MethodGet, "http://localhost:2999/mercure/health/ready", nil)
 	require.NoError(t, err)
 
@@ -195,9 +196,10 @@ localhost:9080 {
 	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"status":"error"`)
-	assert.Contains(t, string(body), "connection refused")
+	assert.Contains(t, string(body), "transport health check failed")
+	assert.NotContains(t, string(body), "connection refused") // internal detail must not leak
 
-	// Live should return 503
+	// Live should return 503 with a generic error message
 	req, err = http.NewRequest(http.MethodGet, "http://localhost:2999/mercure/health/live", nil)
 	require.NoError(t, err)
 
@@ -206,5 +208,35 @@ localhost:9080 {
 	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"status":"error"`)
-	assert.Contains(t, string(body), "unhealthy for 30s")
+	assert.Contains(t, string(body), "transport health check failed")
+	assert.NotContains(t, string(body), "unhealthy for 30s") // internal detail must not leak
+}
+
+func TestHealthEndpointUnknownHub(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+	skip_install_trust
+	admin localhost:2999
+	http_port     9080
+	https_port    9443
+}
+
+localhost:9080 {
+	route {
+		mercure {
+			anonymous
+			publisher_jwt !ChangeMe!
+			transport local
+		}
+
+		respond 404
+	}
+}`, "caddyfile")
+
+	// Querying a hub name that doesn't exist should return 404, not 200.
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:2999/mercure/health/nonexistent/ready", nil)
+	require.NoError(t, err)
+
+	resp := tester.AssertResponseCode(req, http.StatusNotFound)
+	require.NoError(t, resp.Body.Close())
 }

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -36,9 +36,15 @@ var (
 	ErrCompatibility = errors.New("compatibility mode only supports protocol version 7")
 
 	// hubs is a list of registered Mercure hubs, the key is the top-most subroute.
-	hubs   = make(map[caddy.Module]*mercure.Hub) //nolint:gochecknoglobals
+	hubs   = make(map[caddy.Module]*hubInfo) //nolint:gochecknoglobals
 	hubsMu sync.Mutex
 )
+
+type hubInfo struct {
+	hub       *mercure.Hub
+	transport mercure.Transport
+	name      string
+}
 
 func init() { //nolint:gochecknoinits
 	caddy.RegisterModule(Mercure{})
@@ -52,12 +58,16 @@ func FindHub(modules []caddy.Module) *mercure.Hub {
 	defer hubsMu.Unlock()
 
 	for _, m := range modules {
-		if h, ok := hubs[m]; ok {
-			return h
+		if info, ok := hubs[m]; ok {
+			return info.hub
 		}
 	}
 
-	return hubs[nil]
+	if info := hubs[nil]; info != nil {
+		return info.hub
+	}
+
+	return nil
 }
 
 type JWTConfig struct {
@@ -76,6 +86,9 @@ type TopicSelectorCacheConfig struct {
 
 // Mercure implements a Mercure hub as a Caddy module. Mercure is a protocol allowing to push data updates to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way.
 type Mercure struct {
+	// Human-readable name for this hub, used in health check endpoints and metrics.
+	Name string `json:"name,omitempty"`
+
 	// Allow subscribers with no valid JWT.
 	Anonymous bool `json:"anonymous,omitempty"`
 
@@ -344,6 +357,17 @@ func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,goc
 
 	m.hub = h
 
+	name := m.Name
+	if name == "" {
+		name = "default"
+	}
+
+	info := &hubInfo{
+		hub:       h,
+		transport: transport,
+		name:      name,
+	}
+
 	var found bool
 
 	hubsMu.Lock()
@@ -351,7 +375,7 @@ func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,goc
 
 	for _, m := range ctx.Modules() {
 		if _, ok := m.(*caddyhttp.Subroute); ok {
-			hubs[m] = h
+			hubs[m] = info
 			found = true
 
 			break
@@ -359,7 +383,7 @@ func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,goc
 	}
 
 	if !found {
-		hubs[nil] = h
+		hubs[nil] = info
 	}
 
 	return nil
@@ -373,8 +397,8 @@ func (m *Mercure) Cleanup() error {
 	hubsMu.Lock()
 	defer hubsMu.Unlock()
 
-	for k, h := range hubs {
-		if h == m.hub {
+	for k, info := range hubs {
+		if info.hub == m.hub {
 			delete(hubs, k)
 		}
 	}
@@ -399,6 +423,13 @@ func (m *Mercure) UnmarshalCaddyfile(d *caddyfile.Dispenser) (err error) { //nol
 	for d.Next() {
 		for d.NextBlock(0) {
 			switch d.Val() {
+			case "name":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+
+				m.Name = d.Val()
+
 			case "anonymous":
 				m.Anonymous = true
 

--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -18,6 +18,7 @@ To install the chart with the release name `my-release`, run the following comma
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| adminPort | int | `2019` | Port used for the Caddy admin API (health checks, metrics, graceful shutdown). |
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling must not be enabled unless you are using [the High Availability version](https://mercure.rocks/docs/hub/cluster) (see [values.yaml](values.yaml) for details). |
 | caddyExtraConfig | string | `""` | Inject snippet or named-routes options in the Caddyfile |
@@ -28,6 +29,16 @@ To install the chart with the release name `my-release`, run the following comma
 | extraEnvs | list | `[]` | Additional environment variables to set |
 | fullnameOverride | string | `""` | A name to substitute for the full names of resources. |
 | globalOptions | string | `""` | Inject global options in the Caddyfile. |
+| healthCheck | object | Enabled by default. | Transport-aware health checks exposed via the Caddy admin API. When enabled, readiness and liveness probes use /mercure/health/ready and /mercure/health/live on the admin port instead of /healthz on the HTTP port. |
+| healthCheck.enabled | bool | `true` | Enable transport-aware health checks. |
+| healthCheck.liveness.failureThreshold | int | `3` |  |
+| healthCheck.liveness.initialDelaySeconds | int | `15` |  |
+| healthCheck.liveness.periodSeconds | int | `10` |  |
+| healthCheck.liveness.timeoutSeconds | int | `5` |  |
+| healthCheck.readiness.failureThreshold | int | `2` |  |
+| healthCheck.readiness.initialDelaySeconds | int | `5` |  |
+| healthCheck.readiness.periodSeconds | int | `5` |  |
+| healthCheck.readiness.timeoutSeconds | int | `3` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | image.repository | string | `"dunglas/mercure"` | Name of the image repository to pull the container image from. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
@@ -39,7 +50,7 @@ To install the chart with the release name `my-release`, run the following comma
 | ingress.tls | list | See [values.yaml](values.yaml). | Ingress TLS configuration. |
 | license | string | `""` | The license key for [the High Availability version](https://mercure.rocks/docs/hub/cluster) (not necessary is you use the FOSS version). |
 | metrics.enabled | bool | `false` | Enable metrics. You must also add a `servers` block with a [`metrics` directive](https://caddyserver.com/docs/caddyfile/options#metrics) in the `globalOptions` value. servers {     metrics } |
-| metrics.port | int | `2019` | The port to use for exposing the metrics. |
+| metrics.port | int | `2019` | Deprecated: The port to use for exposing the metrics (use adminPort instead). |
 | metrics.serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor for Prometheus Operator. |
 | metrics.serviceMonitor.honorLabels | bool | `false` | Specify honorLabels parameter to add the scrape endpoint |
 | metrics.serviceMonitor.interval | string | `"15s"` | The interval to use for the ServiceMonitor to scrape the metrics. |

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["curl", "-XPOST", "http://localhost:2019/stop"]
+                command: ["curl", "-XPOST", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/stop"]
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -108,11 +108,28 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-            {{- if .Values.metrics.enabled }}
-            - name: metrics
-              containerPort: {{ .Values.metrics.port }}
+            - name: admin
+              containerPort: {{ .Values.adminPort | default .Values.metrics.port }}
               protocol: TCP
-            {{- end }}
+          {{- if .Values.healthCheck.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /mercure/health/ready
+              port: admin
+            initialDelaySeconds: {{ .Values.healthCheck.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthCheck.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.healthCheck.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /mercure/health/live
+              port: admin
+            initialDelaySeconds: {{ .Values.healthCheck.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthCheck.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.healthCheck.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.liveness.failureThreshold }}
+          {{- else }}
+          # Deprecated: use healthCheck.enabled=true for transport-aware health checks
           livenessProbe:
             httpGet:
               path: /healthz
@@ -121,6 +138,7 @@ spec:
             httpGet:
               path: /healthz
               port: http
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           lifecycle:

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -113,17 +113,18 @@ spec:
               protocol: TCP
           {{- if .Values.healthCheck.enabled }}
           # The Caddy admin API binds to localhost by default, so probes run from
-          # inside the container via curl rather than using httpGet (which would hit the pod IP).
+          # inside the container via wget rather than using httpGet (which would hit the pod IP).
+          # wget is used because curl is not shipped in the caddy:2-alpine base image.
           readinessProbe:
             exec:
-              command: ["curl", "-fsS", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/ready"]
+              command: ["wget", "-q", "--spider", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/ready"]
             initialDelaySeconds: {{ .Values.healthCheck.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.readiness.timeoutSeconds }}
             failureThreshold: {{ .Values.healthCheck.readiness.failureThreshold }}
           livenessProbe:
             exec:
-              command: ["curl", "-fsS", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/live"]
+              command: ["wget", "-q", "--spider", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/live"]
             initialDelaySeconds: {{ .Values.healthCheck.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.liveness.timeoutSeconds }}
@@ -144,7 +145,8 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["curl", "-XPOST", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/stop"]
+                # wget is used because curl is not shipped in the caddy:2-alpine base image.
+                command: ["wget", "-q", "-O", "-", "--post-data=", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/stop"]
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -112,18 +112,18 @@ spec:
               containerPort: {{ .Values.adminPort | default .Values.metrics.port }}
               protocol: TCP
           {{- if .Values.healthCheck.enabled }}
+          # The Caddy admin API binds to localhost by default, so probes run from
+          # inside the container via curl rather than using httpGet (which would hit the pod IP).
           readinessProbe:
-            httpGet:
-              path: /mercure/health/ready
-              port: admin
+            exec:
+              command: ["curl", "-fsS", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/ready"]
             initialDelaySeconds: {{ .Values.healthCheck.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.readiness.timeoutSeconds }}
             failureThreshold: {{ .Values.healthCheck.readiness.failureThreshold }}
           livenessProbe:
-            httpGet:
-              path: /mercure/health/live
-              port: admin
+            exec:
+              command: ["curl", "-fsS", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/live"]
             initialDelaySeconds: {{ .Values.healthCheck.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.liveness.timeoutSeconds }}

--- a/charts/mercure/templates/service.yaml
+++ b/charts/mercure/templates/service.yaml
@@ -38,7 +38,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.metrics.port }}
+    - port: {{ .Values.adminPort | default .Values.metrics.port }}
       targetPort: admin
       protocol: TCP
       name: metrics

--- a/charts/mercure/templates/service.yaml
+++ b/charts/mercure/templates/service.yaml
@@ -39,7 +39,7 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.metrics.port }}
-      targetPort: metrics
+      targetPort: admin
       protocol: TCP
       name: metrics
   selector:

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -46,13 +46,33 @@ existingSecret: ""
 # -- The license key for [the High Availability version](https://mercure.rocks/docs/hub/cluster) (not necessary is you use the FOSS version).
 license: ""
 
+## -- Port used for the Caddy admin API (health checks, metrics, graceful shutdown).
+adminPort: 2019
+
+# -- Transport-aware health checks exposed via the Caddy admin API.
+# When enabled, readiness and liveness probes use /mercure/health/ready and /mercure/health/live
+# on the admin port instead of /healthz on the HTTP port.
+healthCheck:
+  # -- Enable transport-aware health checks.
+  enabled: true
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 2
+  liveness:
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
 metrics:
   # -- Enable metrics. You must also add a `servers` block with a [`metrics` directive](https://caddyserver.com/docs/caddyfile/options#metrics) in the `globalOptions` value.
   # servers {
   #     metrics
   # }
   enabled: false
-  # -- The port to use for exposing the metrics.
+  # -- Deprecated: The port to use for exposing the metrics (use adminPort instead).
   port: 2019
 
   serviceMonitor:

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -46,7 +46,7 @@ existingSecret: ""
 # -- The license key for [the High Availability version](https://mercure.rocks/docs/hub/cluster) (not necessary is you use the FOSS version).
 license: ""
 
-## -- Port used for the Caddy admin API (health checks, metrics, graceful shutdown).
+# -- Port used for the Caddy admin API (health checks, metrics, graceful shutdown).
 adminPort: 2019
 
 # -- Transport-aware health checks exposed via the Caddy admin API.

--- a/dev.Caddyfile
+++ b/dev.Caddyfile
@@ -37,8 +37,9 @@
 
 	redir / /.well-known/mercure/ui/
 
-	respond /healthz 200
 	respond /robots.txt `User-agent: *
 	Disallow: /`
+	# Deprecated: use the /mercure/health/ready and /mercure/health/live admin API endpoints for transport-aware health checks
+	respond /healthz 200
 	respond "Not Found" 404
 }

--- a/docs/hub/config.md
+++ b/docs/hub/config.md
@@ -92,18 +92,20 @@ The Mercure.rocks Hub provides transport-aware health check endpoints through th
 
 For transports that do not support health checking (e.g. Bolt, Local), the endpoints always return `200`.
 
-These endpoints are exposed on the admin API port, not the main HTTP port. In Kubernetes, configure probes to hit the admin port:
+These endpoints are exposed on the admin API port, not the main HTTP port. The Caddy admin API binds to `localhost:2019` by default for security, so Kubernetes probes should run from inside the container using `exec`:
 
 ```yaml
 readinessProbe:
-  httpGet:
-    path: /mercure/health/ready
-    port: 2019
+  exec:
+    command:
+      ["curl", "-fsS", "http://localhost:2019/mercure/health/ready"]
 livenessProbe:
-  httpGet:
-    path: /mercure/health/live
-    port: 2019
+  exec:
+    command:
+      ["curl", "-fsS", "http://localhost:2019/mercure/health/live"]
 ```
+
+Alternatively, you can bind the admin API to all interfaces by adding `admin 0.0.0.0:2019` to the Caddyfile's global options, and then use `httpGet` probes — but that exposes the admin API (including `/stop` and `/load`) on the pod network.
 
 Here is an example of how to use the health check in a Docker Compose file:
 

--- a/docs/hub/config.md
+++ b/docs/hub/config.md
@@ -98,11 +98,11 @@ These endpoints are exposed on the admin API port, not the main HTTP port. The C
 readinessProbe:
   exec:
     command:
-      ["curl", "-fsS", "http://localhost:2019/mercure/health/ready"]
+      ["wget", "-q", "--spider", "http://localhost:2019/mercure/health/ready"]
 livenessProbe:
   exec:
     command:
-      ["curl", "-fsS", "http://localhost:2019/mercure/health/live"]
+      ["wget", "-q", "--spider", "http://localhost:2019/mercure/health/live"]
 ```
 
 Alternatively, you can bind the admin API to all interfaces by adding `admin 0.0.0.0:2019` to the Caddyfile's global options, and then use `httpGet` probes — but that exposes the admin API (including `/stop` and `/load`) on the pod network.

--- a/docs/hub/config.md
+++ b/docs/hub/config.md
@@ -79,9 +79,31 @@ The provided `Caddyfile` and Docker image offer convenient environment variables
 | `MERCURE_EXTRA_DIRECTIVES`      | a list of extra [Mercure directives](#directives) inject in the Caddy file, one per line                                                                                                                             |               |
 | `MERCURE_LICENSE`               | the license to use ([only applicable for the Enterprise version](cluster.md))                                                                                                                                        |               |
 
-## HealthCheck
+## Health Check
 
-The Mercure.rocks Hub provides a `/healthz` endpoint that returns a `200 OK` status code if the server is healthy.
+The Mercure.rocks Hub provides transport-aware health check endpoints through the [Caddy admin API](https://caddyserver.com/docs/api) (port 2019 by default):
+
+| Endpoint                           | Description                                                                                                                                          |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /mercure/health/ready`        | Returns `200` if all transports can serve traffic, `503` otherwise. Suitable for readiness probes.                                                   |
+| `GET /mercure/health/live`         | Returns `200` if all transports are fundamentally operational, `503` if any has been unhealthy for an extended period. Suitable for liveness probes. |
+| `GET /mercure/health/{name}/ready` | Per-hub readiness check (when using multiple hubs).                                                                                                  |
+| `GET /mercure/health/{name}/live`  | Per-hub liveness check (when using multiple hubs).                                                                                                   |
+
+For transports that do not support health checking (e.g. Bolt, Local), the endpoints always return `200`.
+
+These endpoints are exposed on the admin API port, not the main HTTP port. In Kubernetes, configure probes to hit the admin port:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /mercure/health/ready
+    port: 2019
+livenessProbe:
+  httpGet:
+    path: /mercure/health/live
+    port: 2019
+```
 
 Here is an example of how to use the health check in a Docker Compose file:
 
@@ -91,11 +113,20 @@ services:
   mercure:
     # ...
     healthcheck:
-      test: ["CMD", "wget", "-O-", "https://localhost/healthz"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "-q",
+          "--spider",
+          "http://localhost:2019/mercure/health/ready",
+        ]
       timeout: 5s
       retries: 5
       start_period: 60s
 ```
+
+> **Note:** The legacy `/healthz` endpoint on the main HTTP port is deprecated. It only checks that the Caddy process is running, not the transport connection status.
 
 ## JWT Verification
 

--- a/examples/chat/chart/mercure-example-chat/README.md
+++ b/examples/chat/chart/mercure-example-chat/README.md
@@ -6,50 +6,51 @@ A minimalist chat system, using Mercure and the Flask microframework to handle c
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `100` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| cookieDomain | string | `".mercure.rocks"` |  |
-| fullnameOverride | string | `""` |  |
-| hubUrl | string | `"https://demo.mercure.rocks/.well-known/mercure"` |  |
-| image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"dunglas/mercure-example-chat"` |  |
-| image.tag | string | `"latest"` |  |
-| imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.className | string | `""` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths[0].path | string | `"/"` |  |
-| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
-| ingress.tls | list | `[]` |  |
-| jwtKey | string | `"!ChangeThisMercureHubJWTSecretKey!"` |  |
-| livenessProbe.httpGet.path | string | `"/"` |  |
-| livenessProbe.httpGet.port | string | `"http"` |  |
-| messageUriTemplate | string | `"https://chat.example.com/messages/{id}"` |  |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
-| readinessProbe.httpGet.path | string | `"/"` |  |
-| readinessProbe.httpGet.port | string | `"http"` |  |
-| replicaCount | int | `1` |  |
-| resources | object | `{}` |  |
-| securityContext | object | `{}` |  |
-| service.port | int | `80` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.automount | bool | `true` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| tolerations | list | `[]` |  |
-| volumeMounts | list | `[]` |  |
-| volumes | list | `[]` |  |
+| Key                                        | Type   | Default                                            | Description |
+| ------------------------------------------ | ------ | -------------------------------------------------- | ----------- |
+| affinity                                   | object | `{}`                                               |             |
+| autoscaling.enabled                        | bool   | `false`                                            |             |
+| autoscaling.maxReplicas                    | int    | `100`                                              |             |
+| autoscaling.minReplicas                    | int    | `1`                                                |             |
+| autoscaling.targetCPUUtilizationPercentage | int    | `80`                                               |             |
+| cookieDomain                               | string | `".mercure.rocks"`                                 |             |
+| fullnameOverride                           | string | `""`                                               |             |
+| hubUrl                                     | string | `"https://demo.mercure.rocks/.well-known/mercure"` |             |
+| image.pullPolicy                           | string | `"Always"`                                         |             |
+| image.repository                           | string | `"dunglas/mercure-example-chat"`                   |             |
+| image.tag                                  | string | `"latest"`                                         |             |
+| imagePullSecrets                           | list   | `[]`                                               |             |
+| ingress.annotations                        | object | `{}`                                               |             |
+| ingress.className                          | string | `""`                                               |             |
+| ingress.enabled                            | bool   | `false`                                            |             |
+| ingress.hosts[0].host                      | string | `"chart-example.local"`                            |             |
+| ingress.hosts[0].paths[0].path             | string | `"/"`                                              |             |
+| ingress.hosts[0].paths[0].pathType         | string | `"ImplementationSpecific"`                         |             |
+| ingress.tls                                | list   | `[]`                                               |             |
+| jwtKey                                     | string | `"!ChangeThisMercureHubJWTSecretKey!"`             |             |
+| livenessProbe.httpGet.path                 | string | `"/"`                                              |             |
+| livenessProbe.httpGet.port                 | string | `"http"`                                           |             |
+| messageUriTemplate                         | string | `"https://chat.example.com/messages/{id}"`         |             |
+| nameOverride                               | string | `""`                                               |             |
+| nodeSelector                               | object | `{}`                                               |             |
+| podAnnotations                             | object | `{}`                                               |             |
+| podLabels                                  | object | `{}`                                               |             |
+| podSecurityContext                         | object | `{}`                                               |             |
+| readinessProbe.httpGet.path                | string | `"/"`                                              |             |
+| readinessProbe.httpGet.port                | string | `"http"`                                           |             |
+| replicaCount                               | int    | `1`                                                |             |
+| resources                                  | object | `{}`                                               |             |
+| securityContext                            | object | `{}`                                               |             |
+| service.port                               | int    | `80`                                               |             |
+| service.type                               | string | `"ClusterIP"`                                      |             |
+| serviceAccount.annotations                 | object | `{}`                                               |             |
+| serviceAccount.automount                   | bool   | `true`                                             |             |
+| serviceAccount.create                      | bool   | `true`                                             |             |
+| serviceAccount.name                        | string | `""`                                               |             |
+| tolerations                                | list   | `[]`                                               |             |
+| volumeMounts                               | list   | `[]`                                               |             |
+| volumes                                    | list   | `[]`                                               |             |
 
-----------------------------------------------
+---
+
 Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/transport.go
+++ b/transport.go
@@ -35,6 +35,21 @@ type TransportTopicSelectorStore interface {
 	SetTopicSelectorStore(store *TopicSelectorStore)
 }
 
+// TransportHealthChecker may be implemented by transports that support health checking.
+// Transports that do not implement this interface are assumed to always be healthy.
+type TransportHealthChecker interface {
+	// Ready reports whether the transport can currently serve traffic.
+	// Returns nil if healthy, or an error describing the problem.
+	// This is typically used for readiness probes (e.g. Kubernetes).
+	Ready(ctx context.Context) error
+
+	// Live reports whether the transport is fundamentally operational.
+	// Returns nil if alive, or an error if the transport has been unhealthy
+	// for an extended period and should be restarted.
+	// This is typically used for liveness probes (e.g. Kubernetes).
+	Live(ctx context.Context) error
+}
+
 // ErrClosedTransport is returned by the Transport's Dispatch and AddSubscriber methods after a call to Close.
 var ErrClosedTransport = errors.New("hub: read/write on closed Transport")
 


### PR DESCRIPTION
Expose readiness and liveness probes via the Caddy admin API so Kubernetes (and other orchestrators) can detect when a hub's transport connection is actually healthy, not just that the process is running.

- New TransportHealthChecker optional interface (Ready / Live) that transports can implement to report their state.
- New admin.api.mercure_health Caddy module exposing /mercure/health/{ready,live} aggregate endpoints and /mercure/health/{name}/{ready,live} per-hub endpoints on the admin API (port 2019).
- Caddyfile name directive for identifying hubs in per-hub endpoints and future metrics labels (defaults to "default").
- Helm chart: transport-aware probes enabled by default, with fallback to the legacy /healthz on HTTP port when healthCheck.enabled=false. Admin port always exposed; metrics.port kept for backward compat.
- /healthz on the HTTP port is deprecated (only checks that Caddy is running, not transport connectivity).

Transports that do not implement the interface (Bolt, Local) are considered always-healthy; the Enterprise transports (Redis, Postgres, Kafka, Pulsar) implement it in the Mercure Enterprise repository.

<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->
