### PR TITLE
ci: fix zizmor workflow audit findings

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -4,3 +4,8 @@ rules:
     config:
       policies:
         "*": ref-pin
+  # Dependabot auto-merge requires pull_request_target to access repo-write
+  # permissions; the workflow is guarded by an `if:` check on the PR author.
+  dangerous-triggers:
+    ignore:
+      - dependabot.yml

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: docs
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
- Scope secret access in cd.yml (release) and cd-docs.yml (publish) to dedicated GitHub Actions environments, so repo owners can add protection rules (required reviewers, branch restrictions) without further workflow changes.
- Suppress dangerous-triggers on dependabot.yml: pull_request_target is required for Dependabot auto-merge to access write permissions, and the workflow already guards with an author check.

<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->
