### PR TITLE
fix(chart): use wget in probes and preStop so they work on caddy:2-alpine

### DIFF
--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -18,6 +18,7 @@ To install the chart with the release name `my-release`, run the following comma
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| adminPort | int | `2019` | Port used for the Caddy admin API (health checks, metrics, graceful shutdown). |
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling must not be enabled unless you are using [the High Availability version](https://mercure.rocks/docs/hub/cluster) (see [values.yaml](values.yaml) for details). |
 | caddyExtraConfig | string | `""` | Inject snippet or named-routes options in the Caddyfile |
@@ -28,6 +29,16 @@ To install the chart with the release name `my-release`, run the following comma
 | extraEnvs | list | `[]` | Additional environment variables to set |
 | fullnameOverride | string | `""` | A name to substitute for the full names of resources. |
 | globalOptions | string | `""` | Inject global options in the Caddyfile. |
+| healthCheck | object | Enabled by default. | Transport-aware health checks exposed via the Caddy admin API. When enabled, readiness and liveness probes use /mercure/health/ready and /mercure/health/live on the admin port instead of /healthz on the HTTP port. |
+| healthCheck.enabled | bool | `true` | Enable transport-aware health checks. |
+| healthCheck.liveness.failureThreshold | int | `3` |  |
+| healthCheck.liveness.initialDelaySeconds | int | `15` |  |
+| healthCheck.liveness.periodSeconds | int | `10` |  |
+| healthCheck.liveness.timeoutSeconds | int | `5` |  |
+| healthCheck.readiness.failureThreshold | int | `2` |  |
+| healthCheck.readiness.initialDelaySeconds | int | `5` |  |
+| healthCheck.readiness.periodSeconds | int | `5` |  |
+| healthCheck.readiness.timeoutSeconds | int | `3` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | image.repository | string | `"dunglas/mercure"` | Name of the image repository to pull the container image from. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
@@ -39,7 +50,7 @@ To install the chart with the release name `my-release`, run the following comma
 | ingress.tls | list | See [values.yaml](values.yaml). | Ingress TLS configuration. |
 | license | string | `""` | The license key for [the High Availability version](https://mercure.rocks/docs/hub/cluster) (not necessary is you use the FOSS version). |
 | metrics.enabled | bool | `false` | Enable metrics. You must also add a `servers` block with a [`metrics` directive](https://caddyserver.com/docs/caddyfile/options#metrics) in the `globalOptions` value. servers {     metrics } |
-| metrics.port | int | `2019` | The port to use for exposing the metrics. |
+| metrics.port | int | `2019` | Deprecated: The port to use for exposing the metrics (use adminPort instead). |
 | metrics.serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor for Prometheus Operator. |
 | metrics.serviceMonitor.honorLabels | bool | `false` | Specify honorLabels parameter to add the scrape endpoint |
 | metrics.serviceMonitor.interval | string | `"15s"` | The interval to use for the ServiceMonitor to scrape the metrics. |

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -113,17 +113,18 @@ spec:
               protocol: TCP
           {{- if .Values.healthCheck.enabled }}
           # The Caddy admin API binds to localhost by default, so probes run from
-          # inside the container via curl rather than using httpGet (which would hit the pod IP).
+          # inside the container via wget rather than using httpGet (which would hit the pod IP).
+          # wget is used because curl is not shipped in the caddy:2-alpine base image.
           readinessProbe:
             exec:
-              command: ["curl", "-fsS", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/ready"]
+              command: ["wget", "-q", "--spider", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/ready"]
             initialDelaySeconds: {{ .Values.healthCheck.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.readiness.timeoutSeconds }}
             failureThreshold: {{ .Values.healthCheck.readiness.failureThreshold }}
           livenessProbe:
             exec:
-              command: ["curl", "-fsS", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/live"]
+              command: ["wget", "-q", "--spider", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/mercure/health/live"]
             initialDelaySeconds: {{ .Values.healthCheck.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.liveness.timeoutSeconds }}
@@ -144,7 +145,8 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["curl", "-XPOST", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/stop"]
+                # wget is used because curl is not shipped in the caddy:2-alpine base image.
+                command: ["wget", "-q", "-O", "-", "--post-data=", "http://localhost:{{ .Values.adminPort | default .Values.metrics.port }}/stop"]
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The caddy:2-alpine base image ships ca-certificates, libcap and mailcap but does not include curl. With healthCheck.enabled=true (the new default) the curl-based exec probes would always fail readiness and liveness, blocking ct install and any real deployment. The preStop hook had the same latent issue but failed silently.

Switch both probes and the preStop hook to BusyBox wget (which is included in alpine), matching the wget-based Docker healthcheck already recommended in docs/hub/config.md.

Also regenerate charts/mercure/README.md so the values table documents the new adminPort and healthCheck.* fields.

<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->
