### PR TITLE
ci: publish Helm chart as an asset of the hub GitHub release

### DIFF
--- a/.github/workflows/cd-chart.yml
+++ b/.github/workflows/cd-chart.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Upload Helm chart to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" .cr-release-packages/*.tgz --clobber
+          gh release upload "$RELEASE_TAG" .cr-release-packages/*.tgz --clobber
 
       - name: Update Helm chart repo index
         uses: helm/chart-releaser-action@v1.7.0

--- a/.github/workflows/cd-chart.yml
+++ b/.github/workflows/cd-chart.yml
@@ -1,15 +1,15 @@
 name: Release Chart
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: write
 
 jobs:
   release:
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,6 +17,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Configure Git
         run: |
@@ -26,10 +27,22 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
 
-      - name: Run chart-releaser
-        uses: dunglas/chart-releaser-action@feat/match-tags
+      - name: Package Helm chart
+        run: |
+          mkdir -p .cr-release-packages
+          helm package charts/mercure -d .cr-release-packages
+
+      - name: Upload Helm chart to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" .cr-release-packages/*.tgz --clobber
+
+      - name: Update Helm chart repo index
+        uses: helm/chart-releaser-action@v1.7.0
         with:
-          match_tags: helm-chart-*
+          skip_packaging: true
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"
+          CR_RELEASE_NAME_TEMPLATE: "v{{ .Version }}"


### PR DESCRIPTION
## Summary

Today every release produces two GitHub releases: one for the hub (draft, created by GoReleaser) and one for the Helm chart (`helm-chart-X.Y.Z`, published immediately by chart-releaser). This PR unifies them onto the hub release.

- Trigger `Release Chart` on `release: published` (filtered to `v*` tags) instead of tag push, so it runs after the hub draft is manually published.
- Package the chart with `helm package` and upload the `.tgz` onto the existing hub release via `gh release upload --clobber`.
- Use `helm/chart-releaser-action@v1.7.0` only to refresh the `gh-pages` `index.yaml` (`skip_packaging: true`, `skip_existing: true`, `CR_RELEASE_NAME_TEMPLATE: "v{{ .Version }}"`). Entries now point at `.../releases/download/v<version>/mercure-<version>.tgz`.
- Drop the `dunglas/chart-releaser-action@feat/match-tags` fork — `match_tags` was only needed during change-detection in the packaging step, which we now skip.

Existing `helm-chart-*` tags and releases remain untouched, so older chart versions referenced by `index.yaml` keep working.