### PR TITLE
fix(subscribe): drain SSE subscribers naturally on hub shutdown

### DIFF
--- a/hub_test.go
+++ b/hub_test.go
@@ -361,6 +361,35 @@ func TestWithSubscribeDisabled(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }
 
+// waitSubscribers waits until the LocalTransport reports exactly n live
+// subscribers. Used to synchronize tests that need subscribers registered
+// before a Dispatch or context cancel runs. Sleeps between checks to avoid
+// busy-spinning, and fails the test via tb.Fatalf after 5s so a genuinely
+// stuck expectation surfaces as a clear error instead of a hung suite.
+func waitSubscribers(tb testing.TB, transport *LocalTransport, n int) {
+	tb.Helper()
+
+	const timeout = 5 * time.Second
+
+	deadline := time.Now().Add(timeout)
+
+	for {
+		transport.RLock()
+		got := transport.subscribers.Len()
+		transport.RUnlock()
+
+		if got == n {
+			return
+		}
+
+		if !time.Now().Before(deadline) {
+			tb.Fatalf("waited %s for %d subscribers, have %d", timeout, n, got)
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func createDummy(tb testing.TB, options ...Option) *Hub {
 	tb.Helper()
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -131,9 +131,26 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 
 	debugLevel := rc.hub.logger.Enabled(ctx, slog.LevelDebug)
 
+	// On hub shutdown (Caddy "stopping" event, pod SIGTERM, …) we prefer to
+	// let each subscriber drain on its own per-connection write deadline
+	// (derived from writeTimeout, and optionally shortened by JWT expiry)
+	// rather than closing everything at once — that spreads the reconnect
+	// load at the same pace clients already experience in steady state,
+	// instead of producing a synchronized storm on the ingress and the
+	// transport. The orchestrator's grace period (k8s
+	// terminationGracePeriodSeconds, etc.) remains the hard deadline.
+	//
+	// When writeTimeout is disabled (0) there is no disconnectionTimerC, so
+	// the only way out on shutdown is still h.ctx.Done() — otherwise
+	// http.Server.Shutdown would hang indefinitely on active handlers.
+	var hubCtxDoneC <-chan struct{}
+	if h.writeTimeout == 0 {
+		hubCtxDoneC = h.ctx.Done()
+	}
+
 	for {
 		select {
-		case <-h.ctx.Done():
+		case <-hubCtxDoneC:
 			if debugLevel {
 				rc.hub.logger.LogAttrs(ctx, slog.LevelDebug, "Hub is shutting down, closing connection")
 			}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1020,3 +1020,83 @@ func BenchmarkSubscribe(b *testing.B) {
 		subscribe(b, 1000)
 	}
 }
+
+// hubShutdownTestHub builds a hub with a caller-controlled context so tests
+// can cancel the hub independently of the subscriber's request context.
+func hubShutdownTestHub(ctx context.Context, tb testing.TB, writeTimeout time.Duration) *Hub {
+	tb.Helper()
+
+	tss, err := NewTopicSelectorStore(0)
+	require.NoError(tb, err)
+
+	h, err := NewHub(ctx,
+		WithAnonymous(),
+		WithPublisherJWT([]byte("publisher"), jwt.SigningMethodHS256.Name),
+		WithSubscriberJWT([]byte("subscriber"), jwt.SigningMethodHS256.Name),
+		WithTopicSelectorStore(tss),
+		WithWriteTimeout(writeTimeout),
+	)
+	require.NoError(tb, err)
+	setDeprecatedOptions(tb, h)
+
+	return h
+}
+
+// TestShutdownKeepsSubscribersWhenWriteTimeoutEnabled verifies the graceful
+// drain contract: when the hub context is cancelled (Caddy stopping, pod
+// SIGTERM, ...) and writeTimeout is set, subscribers stay connected until
+// their per-connection disconnection timer fires or the client disconnects.
+func TestShutdownKeepsSubscribersWhenWriteTimeoutEnabled(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		hubCtx, cancelHub := context.WithCancel(t.Context())
+		hub := hubShutdownTestHub(hubCtx, t, 5*time.Minute)
+		transport, _ := hub.transport.(*LocalTransport)
+
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=https://example.com/books/1", nil).WithContext(t.Context())
+			hub.SubscribeHandler(newSubscribeRecorder(), req)
+		}()
+
+		waitSubscribers(t, transport, 1)
+
+		// Simulate hub shutdown.
+		cancelHub()
+		synctest.Wait()
+
+		transport.RLock()
+		n := transport.subscribers.Len()
+		transport.RUnlock()
+		assert.Equal(t, 1, n, "subscriber must stay connected when writeTimeout is set; disconnect timer is the drain mechanism")
+	})
+}
+
+// TestShutdownClosesSubscribersWhenWriteTimeoutDisabled covers the escape
+// hatch: with writeTimeout == 0 there is no per-connection disconnect timer,
+// so the hub context cancel must still terminate subscribers — otherwise
+// http.Server.Shutdown would hang forever on active handlers.
+func TestShutdownClosesSubscribersWhenWriteTimeoutDisabled(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		hubCtx, cancelHub := context.WithCancel(t.Context())
+		hub := hubShutdownTestHub(hubCtx, t, 0)
+		transport, _ := hub.transport.(*LocalTransport)
+
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=https://example.com/books/1", nil).WithContext(t.Context())
+			hub.SubscribeHandler(newSubscribeRecorder(), req)
+		}()
+
+		waitSubscribers(t, transport, 1)
+
+		cancelHub()
+		synctest.Wait()
+
+		transport.RLock()
+		n := transport.subscribers.Len()
+		transport.RUnlock()
+		assert.Equal(t, 0, n, "subscriber must exit on hub shutdown when writeTimeout is 0")
+	})
+}


### PR DESCRIPTION
## Summary

When the hub context is cancelled (Caddy `stopping` event, pod receiving SIGTERM, graceful config reload), the subscriber `select` loop no longer observes `h.ctx.Done()`. Existing SSE connections keep running until either the client disconnects or the per-connection `writeTimeout` fires.

## Motivation

Rolling a hub replica with active SSE subscribers used to close every connection at once, producing a synchronized reconnect storm on the ingress and on the transport backend. Since `writeTimeout` already forces clients to reconnect every ~10 minutes in steady state (default `600s`), letting shutdown drain at the same pace is indistinguishable from normal operation — no storm, no browser-side `EventSource` error log.

The hard deadline stays with the orchestrator: k8s `terminationGracePeriodSeconds` (or equivalent) SIGKILLs the process if draining takes too long. Operators who want the drain benefit bump that value to `>= writeTimeout + margin`. Operators keeping the default 30s see the same effective behavior as before (SIGKILL instead of an internal force-close — indistinguishable to SSE clients).

## Change

- `subscribe.go`: remove the `case <-h.ctx.Done(): return` branch from the subscriber select loop. The other exit conditions (client disconnect via `ctx.Done()`, per-connection `writeTimeout` via `disconnectionTimerC`, transport close via `s.Receive()` returning `!ok`) cover the remaining cases.

Existing tests + `-race` pass.