### PR TITLE
fix(chart): multiple fixes + SSE-friendly rolling update defaults

### DIFF
--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -13,7 +13,29 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   strategy:
-      type: {{ .Values.updateStrategy.type }}
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    # Rotate one pod at a time without dropping capacity. Each pod
+    # termination closes its in-flight SSE subscribers; keeping the pace
+    # slow lets the ingress and the transport absorb each batch of
+    # reconnects separately instead of as a single storm.
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    {{- end }}
+  {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+  # Delay marking a newly-Ready pod as Available by 30s, which paces the
+  # rolling update (combined with maxSurge=1, maxUnavailable=0 the next
+  # pod only rotates out after the current one has been Available for
+  # this long). Gives the transport backend loops (BoltDB warm-up, or
+  # the Enterprise transport loops) time to reach steady state before
+  # the Deployment hands more of the rollout to them.
+  minReadySeconds: 30
+  # Raise the default k8s progress deadline (600s) so `helm upgrade --wait`
+  # doesn't flag ProgressDeadlineExceeded while a pod is draining SSE
+  # connections within its terminationGracePeriodSeconds window.
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mercure.selectorLabels" . | nindent 6 }}
@@ -31,6 +53,16 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+      # Driven by .Values.terminationGracePeriodSeconds so the hub can
+      # gracefully drain SSE subscribers at their own writeTimeout pace
+      # before k8s SIGKILLs the pod. Only set when RollingUpdate is in
+      # effect; with Recreate (used e.g. for BoltDB+persistence single-pod
+      # deployments) a long grace period would extend the downtime window
+      # because the replacement Pod isn't created until the old one fully
+      # terminates.
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -99,6 +99,27 @@ replicaCount: 1
 updateStrategy:
   type: RollingUpdate
 
+# -- Pod terminationGracePeriodSeconds. Must be >= `write_timeout` plus a
+# margin so the hub's graceful SSE drain (subscribers close at their own
+# write deadline) finishes before k8s SIGKILLs the pod. Default matches
+# Mercure's DefaultWriteTimeout (600s) plus a 60s margin. Only applied
+# when `updateStrategy.type` is `RollingUpdate` — with `Recreate` we
+# intentionally leave k8s to use its default (30s) to minimize the
+# downtime window between old-pod-gone and new-pod-ready.
+terminationGracePeriodSeconds: 660
+
+# -- Deployment `spec.progressDeadlineSeconds`. A rolling update of a hub
+# with live SSE subscribers can legitimately spend up to
+# `terminationGracePeriodSeconds` on each pod while the old replica
+# drains — well above the k8s default of 600s. Too-low values make
+# `helm upgrade --wait` (and similar CI gates) fail with
+# `ProgressDeadlineExceeded` even though the rollout is healthy. Default
+# covers a 2-pod rolling update with the defaults above; for larger
+# `replicaCount`, scale up accordingly (roughly `replicaCount ×
+# (terminationGracePeriodSeconds + minReadySeconds)` plus a safety
+# margin). Only applied when `updateStrategy.type` is `RollingUpdate`.
+progressDeadlineSeconds: 1800
+
 image:
   # -- Name of the image repository to pull the container image from.
   repository: dunglas/mercure


### PR DESCRIPTION
## Summary

New Deployment defaults that make rolling updates non-disruptive for hubs with live SSE subscribers. Rebased against `main` — the earlier ServiceMonitor / Ingress / NOTES / probe fixes in this branch have been absorbed into main already, so only the rolling-update defaults remain.

## Changes (on the Deployment template)

- `strategy.rollingUpdate.maxSurge=1, maxUnavailable=0` — one pod at a time, no capacity drop, so each batch of reconnects lands separately on the ingress and the transport.
- `minReadySeconds: 30` — a newly-Ready pod gets 30s of quiet time to reach steady state (BoltDB warm-up, or the backend loops of Enterprise transports) before the next rotation fires.
- `template.spec.terminationGracePeriodSeconds: 660` — Mercure's `DefaultWriteTimeout` (600s) plus a 60s margin, so the graceful-shutdown drain (#1212) has time to let SSE handlers close at `writeTimeout`'s own pace instead of being SIGKILLed mid-drain. Users overriding `writeTimeout` via the `write_timeout` Caddyfile directive should bump this accordingly; documented inline in the template comment.

All three are chart-internal — no new `values.yaml` surface.