### PR TITLE
fix(bolt): stop leaking post-subscribe events into Last-Event-ID header

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -196,9 +196,14 @@ func (t *BoltTransport) Close(_ context.Context) (err error) {
 	return fmt.Errorf("unable to close Bolt DB: %w", err)
 }
 
-// pastSeqBound reports whether the BoltDB key k is at or past the sequence bound toSeq.
+// pastSeqBound reports whether the BoltDB key k was written strictly after
+// the sequence snapshot toSeq, and therefore falls outside the subscriber's
+// history window. Events whose seq equals toSeq are the most recent ones
+// observed at subscription time and are still considered part of history.
+// toSeq == 0 means the bucket was empty at subscription time, so any key
+// (all with seq >= 1) is "past the bound".
 func pastSeqBound(k []byte, toSeq uint64) bool {
-	return toSeq > 0 && binary.BigEndian.Uint64(k[:8]) >= toSeq
+	return binary.BigEndian.Uint64(k[:8]) > toSeq
 }
 
 //nolint:gocognit
@@ -213,17 +218,21 @@ func (t *BoltTransport) dispatchHistory(ctx context.Context, s *LocalSubscriber,
 
 		c := b.Cursor()
 		responseLastEventID := EarliestLastEventID
-
 		afterFromID := s.RequestLastEventID == EarliestLastEventID
+
 		for k, v := c.First(); k != nil; k, v = c.Next() {
+			// Keys written after the subscribe snapshot (concurrent Dispatch
+			// between subscriber registration and this read transaction)
+			// must not leak into the response header or be re-delivered
+			// alongside the live dispatch queue — check the bound first.
+			if pastSeqBound(k, toSeq) {
+				break
+			}
+
 			if !afterFromID {
 				responseLastEventID = string(k[8:])
 				if responseLastEventID == s.RequestLastEventID {
 					afterFromID = true
-				}
-
-				if pastSeqBound(k, toSeq) {
-					break
 				}
 
 				continue
@@ -242,7 +251,7 @@ func (t *BoltTransport) dispatchHistory(ctx context.Context, s *LocalSubscriber,
 				return err
 			}
 
-			if (s.Match(update) && !s.Dispatch(ctx, update, true)) || pastSeqBound(k, toSeq) {
+			if s.Match(update) && !s.Dispatch(ctx, update, true) {
 				s.HistoryDispatched(responseLastEventID)
 
 				return nil


### PR DESCRIPTION
## Summary

`BoltTransport.dispatchHistory` had two interacting bugs that surface as the `TestUnknownLastEventIDEmptyHistory` flake on main. This PR makes the test deterministic and tightens the history-window semantics.

## Root cause

1. `dispatchHistory` updated `responseLastEventID` with each key the cursor visited **before** checking whether that key was past the subscriber's sequence snapshot. So when contention put keys past the bound, they leaked into the response header.
2. `pastSeqBound` used `toSeq > 0 && seq >= toSeq`. Two issues with that:
   - The `toSeq > 0` short-circuit made the function always return `false` when the bucket was empty at subscribe time — every subsequent write was treated as history.
   - `>= toSeq` was also off-by-one: a subscriber whose snapshot was `toSeq = 5` would break the loop on the exact key with seq = 5, i.e. the most recent event observed at subscribe time.

Reproduction path for the flake: the subscriber is added to the transport's subscriber list *before* `dispatchHistory` opens its read transaction. A `Dispatch` between those two points persists a new key that's visible in the later read. With `toSeq == 0`, `pastSeqBound` returned `false`, the loop iterated the new key, set `responseLastEventID = "b"`, and reported it out.

## Change

- Reorder the loop so `pastSeqBound` is checked **before** `responseLastEventID` is assigned. Keys past the bound no longer touch the response.
- Switch `pastSeqBound` to a strict `>` comparison. Drop the `toSeq > 0` short-circuit — a bigendian `uint64 > uint64` compare handles the empty-bucket case correctly (any key has `seq >= 1`, so `seq > 0` is always `true`).

## Verified

- Full Go test suite green with `-race`.
- `TestUnknownLastEventID*` ran 200 times under `-race -count=200` — deterministic.
- `TestUnknownLastEventID` (non-empty history) still returns the last scanned key's ID as expected — the reorder doesn't change semantics when the bound isn't exceeded.