### PR TITLE
feat(chart): expose customMetrics and behavior on HPA

### DIFF
--- a/charts/mercure/templates/hpa.yaml
+++ b/charts/mercure/templates/hpa.yaml
@@ -29,4 +29,11 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- with .Values.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -268,6 +268,24 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  # -- Additional metrics appended to the HPA `spec.metrics` list (Pods, Object, External metric types).
+  customMetrics: []
+  # customMetrics:
+  #   - type: Pods
+  #     pods:
+  #       metric:
+  #         name: mercure_subscribers_connected
+  #       target:
+  #         type: AverageValue
+  #         averageValue: "1000"
+  # -- [Scaling policies](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) passed to the HPA `spec.behavior`.
+  behavior: {}
+  # behavior:
+  #   scaleDown:
+  #     policies:
+  #       - type: Pods
+  #         value: 1
+  #         periodSeconds: 300
 
 # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration.
 nodeSelector: {}


### PR DESCRIPTION
The HPA template currently only renders CPU/memory Resource metrics and doesn't expose scaling behavior. Add two additive passthroughs:

- `autoscaling.customMetrics` — list appended to `spec.metrics` for Pods/Object/External metric types. Append semantics match the common pattern (ingress-nginx `autoscalingTemplate`), renamed to match K8s docs terminology ("custom metrics").
- `autoscaling.behavior` — passed verbatim into `spec.behavior` for rate-limited scale-up/down policies.

Both default to no-op (empty list / empty map). No breaking change for existing values.yaml consumers.

Example:

```yaml
autoscaling:
  enabled: true
  minReplicas: 2
  maxReplicas: 10
  customMetrics:
    - type: Pods
      pods:
        metric:
          name: mercure_subscribers_connected
        target:
          type: AverageValue
          averageValue: "1000"
  behavior:
    scaleDown:
      policies:
        - type: Pods
          value: 1
          periodSeconds: 300
```