### PR TITLE
feat(chart): seed replicas at minReplicas on fresh install with HPA

### DIFF
--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- else if .Release.IsInstall }}
+  # Seed the Deployment at minReplicas on fresh install so the HPA
+  # doesn't have to scale up from Kubernetes' default of 1. On
+  # subsequent upgrades, the field is omitted so the HPA keeps full
+  # ownership of the replica count.
+  replicas: {{ .Values.autoscaling.minReplicas }}
   {{- end }}
   strategy:
     type: {{ .Values.updateStrategy.type }}


### PR DESCRIPTION
Without this, a fresh install with `autoscaling.enabled: true` creates a Deployment with no `spec.replicas`. Kubernetes defaults the field to 1 and the HPA then has to scale up to `minReplicas`, leaving a 30-90s window (HPA sync interval + pod scheduling + startup) during which the workload runs under-provisioned.

Gate the initial replicas value behind `.Release.IsInstall` so the field is set only on first install. On subsequent upgrades the field stays omitted, leaving the HPA in full control of the replica count (no fights between Helm and the HPA controller on every `helm upgrade`).

Follow-up to #1217, splits the install-time fix out of the passthrough PR as requested.