### PR TITLE
feat(docker): re-apply net_bind_service capability and ship a HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM caddy:2-alpine
 LABEL org.opencontainers.image.title=Mercure.rocks
 LABEL org.opencontainers.image.description="Real-time made easy"
 LABEL org.opencontainers.image.url=https://mercure.rocks
+LABEL org.opencontainers.image.documentation=https://mercure.rocks/docs/hub/install
 LABEL org.opencontainers.image.source=https://github.com/dunglas/mercure
 LABEL org.opencontainers.image.licenses=AGPL-3.0-or-later
 LABEL org.opencontainers.image.vendor="Kévin Dunglas"
@@ -11,3 +12,10 @@ LABEL org.opencontainers.image.vendor="Kévin Dunglas"
 COPY mercure /usr/bin/caddy
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY dev.Caddyfile /etc/caddy/dev.Caddyfile
+
+# Re-applies the same capability the upstream caddy:2-alpine binary ships with, so the binary can bind to 80/443 when running as a non-root user.
+RUN setcap cap_net_bind_service=+ep /usr/bin/caddy
+
+# Transport-aware readiness check on the Caddy admin API (localhost:2019 by default).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=5 \
+	CMD ["wget", "-q", "--spider", "http://127.0.0.1:2019/mercure/health/ready"]

--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -144,7 +144,8 @@ The image ships a `HEALTHCHECK` that queries the [transport-aware](config.md#hea
 
 ### Rootless deployment
 
-The image runs as `root` by default to keep prior deployments backward-compatible with volumes created by older versions. The `mercure` binary has the `cap_net_bind_service` capability set, so it can bind to ports `80` and `443` when run as an unprivileged user. To run rootless, pass `--user`:
+The image runs as `root` by default, but the `mercure` binary has the `cap_net_bind_service` capability set, so it can bind to ports `80` and `443` when run as an unprivileged user.
+To run rootless, pass `--user`:
 
 ```console
 docker run \
@@ -160,7 +161,7 @@ docker run \
     dunglas/mercure
 ```
 
-The `/data` and `/config` volumes must be writable by the chosen UID. For a fresh named volume, pre-set ownership once:
+The `/data` and `/config` volumes must be writable by the chosen UID. For a fresh-named volume, pre-set ownership once:
 
 ```console
 docker run --rm -v mercure_data:/data -v mercure_config:/config alpine chown 1000:1000 /data /config

--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -128,11 +128,6 @@ services:
       MERCURE_SUBSCRIBER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
     # Uncomment the following line to enable the development mode
     #command: /usr/bin/caddy run --config /etc/caddy/dev.Caddyfile
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "https://localhost/healthz"]
-      timeout: 5s
-      retries: 5
-      start_period: 60s
     ports:
       - "80:80"
       - "443:443"
@@ -144,6 +139,34 @@ volumes:
   mercure_data:
   mercure_config:
 ```
+
+The image ships a `HEALTHCHECK` that queries the [transport-aware](config.md#health-check) `/mercure/health/ready` endpoint on the Caddy admin API.
+
+### Rootless deployment
+
+The image runs as `root` by default to keep prior deployments backward-compatible with volumes created by older versions. The `mercure` binary has the `cap_net_bind_service` capability set, so it can bind to ports `80` and `443` when run as an unprivileged user. To run rootless, pass `--user`:
+
+```console
+docker run \
+    --user 1000:1000 \
+    --read-only \
+    --tmpfs /tmp \
+    -e MERCURE_PUBLISHER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
+    -e MERCURE_SUBSCRIBER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
+    -p 80:80 \
+    -p 443:443 \
+    -v mercure_data:/data \
+    -v mercure_config:/config \
+    dunglas/mercure
+```
+
+The `/data` and `/config` volumes must be writable by the chosen UID. For a fresh named volume, pre-set ownership once:
+
+```console
+docker run --rm -v mercure_data:/data -v mercure_config:/config alpine chown 1000:1000 /data /config
+```
+
+For bind mounts, run `chown 1000:1000` on the host directory.
 
 Alternatively, you may want to [run the Mercure.rocks hub behind Traefik Proxy](traefik.md).
 

--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -142,26 +142,37 @@ volumes:
 
 The image ships a `HEALTHCHECK` that queries the [transport-aware](config.md#health-check) `/mercure/health/ready` endpoint on the Caddy admin API.
 
-### Rootless deployment
+### Rootless Deployment
 
 The image runs as `root` by default, but the `mercure` binary has the `cap_net_bind_service` capability set, so it can bind to ports `80` and `443` when run as an unprivileged user.
-To run rootless, pass `--user`:
+To run rootless, set the `user` key:
 
-```console
-docker run \
-    --user 1000:1000 \
-    --read-only \
-    --tmpfs /tmp \
-    -e MERCURE_PUBLISHER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
-    -e MERCURE_SUBSCRIBER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
-    -p 80:80 \
-    -p 443:443 \
-    -v mercure_data:/data \
-    -v mercure_config:/config \
-    dunglas/mercure
+```yaml
+# compose.yaml
+services:
+  mercure:
+    image: dunglas/mercure
+    user: "1000:1000"
+    read_only: true
+    tmpfs:
+      - /tmp
+    restart: unless-stopped
+    environment:
+      MERCURE_PUBLISHER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+      MERCURE_SUBSCRIBER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - mercure_data:/data
+      - mercure_config:/config
+
+volumes:
+  mercure_data:
+  mercure_config:
 ```
 
-The `/data` and `/config` volumes must be writable by the chosen UID. For a fresh-named volume, pre-set ownership once:
+The `/data` and `/config` volumes must be writable by the chosen UID. For fresh named volumes, pre-set ownership once:
 
 ```console
 docker run --rm -v mercure_data:/data -v mercure_config:/config alpine chown 1000:1000 /data /config


### PR DESCRIPTION
## Summary

- Re-applies `cap_net_bind_service` on the embedded `mercure` binary. The `COPY` overwrites the upstream `caddy:2-alpine` binary, which already shipped this capability, so the image can be run with `docker run --user 1000:1000` and still bind ports 80/443.
- Ships a `HEALTHCHECK` that queries the transport-aware `/mercure/health/ready` endpoint on the Caddy admin API, replacing the deprecated `/healthz` advice in the Compose snippet.
- Adds an `org.opencontainers.image.documentation` label.
- Documents rootless deployment, including how to pre-chown the named `/data` and `/config` volumes for a chosen UID.