### PR TITLE
feat(chart): pass through HTTPRoute rule timeouts

### DIFF
--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -25,6 +25,8 @@ Kubernetes: `>=1.23.0-0`
 | adminPort | int | `2019` | Port used for the Caddy admin API (health checks, metrics, graceful shutdown). |
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling must not be enabled unless you are using [the High Availability version](https://mercure.rocks/docs/hub/cluster) (see [values.yaml](values.yaml) for details). |
+| autoscaling.behavior | object | `{}` | [Scaling policies](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) passed to the HPA `spec.behavior`. |
+| autoscaling.customMetrics | list | `[]` | Additional metrics appended to the HPA `spec.metrics` list (Pods, Object, External metric types). |
 | caddyExtraConfig | string | `""` | Inject snippet or named-routes options in the Caddyfile |
 | caddyExtraDirectives | string | `""` | Inject extra Caddy directives in the Caddyfile. |
 | deployment.annotations | object | `{}` | Annotations to be added to the deployment. |
@@ -41,7 +43,7 @@ Kubernetes: `>=1.23.0-0`
 | httpRoute.enabled | bool | `false` | HTTPRoute enabled. |
 | httpRoute.hostnames | list | `["mercure-example.local"]` | Hostnames matching HTTP header. |
 | httpRoute.parentRefs | list | `[{"name":"gateway","sectionName":"http"}]` | Which Gateways this Route is attached to. |
-| httpRoute.rules | list | See [values.yaml](values.yaml). | List of rules and filters applied. When empty, a default rule routing all traffic to the service is created. |
+| httpRoute.rules | list | See [values.yaml](values.yaml). | List of rules and filters applied. When empty, a default rule routing all traffic to the service is created with `timeouts.request: 0s` so long-lived SSE subscriptions aren't cut by the gateway (most controllers default to a finite timeout, e.g. Envoy: 15s). Mercure's own `write_timeout` (default 600s) drives subscriber rotation. |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | image.repository | string | `"dunglas/mercure"` | Name of the image repository to pull the container image from. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/mercure/ci/httproute-values.yaml
+++ b/charts/mercure/ci/httproute-values.yaml
@@ -11,3 +11,7 @@ httpRoute:
         - path:
             type: PathPrefix
             value: /.well-known/mercure
+      # Exercise the rules[].timeouts rendering path so `ct install`
+      # catches Gateway API schema or template indentation regressions.
+      timeouts:
+        request: 0s

--- a/charts/mercure/templates/httproute.yaml
+++ b/charts/mercure/templates/httproute.yaml
@@ -35,6 +35,10 @@ spec:
       filters:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- else }}
     - backendRefs:

--- a/charts/mercure/templates/httproute.yaml
+++ b/charts/mercure/templates/httproute.yaml
@@ -45,5 +45,7 @@ spec:
         - name: {{ $fullName }}
           port: {{ $svcPort }}
           weight: 1
+      timeouts:
+        request: 0s
     {{- end }}
 {{- end }}

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -244,6 +244,9 @@ httpRoute:
   #         headers:
   #           - name: version
   #             value: v2
+  #   - timeouts:
+  #       request: 30s
+  #       backendRequest: 10s
 
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -221,7 +221,12 @@ httpRoute:
   # -- Hostnames matching HTTP header.
   hostnames:
     - mercure-example.local
-  # -- List of rules and filters applied. When empty, a default rule routing all traffic to the service is created.
+  # -- List of rules and filters applied. When empty, a default rule
+  # routing all traffic to the service is created with
+  # `timeouts.request: 0s` so long-lived SSE subscriptions aren't cut
+  # by the gateway (most controllers default to a finite timeout, e.g.
+  # Envoy: 15s). Mercure's own `write_timeout` (default 600s) drives
+  # subscriber rotation.
   # @default -- See [values.yaml](values.yaml).
   rules: []
   # rules:
@@ -248,12 +253,14 @@ httpRoute:
   #       - path:
   #           type: PathPrefix
   #           value: /.well-known/mercure
-  #     # Mercure subscriptions are long-lived SSE streams. The hub's
-  #     # own `write_timeout` (default 600s) drives subscriber rotation.
-  #     # Set `request: 0s` to disable the gateway-level timeout — most
-  #     # controllers cut at their own default otherwise (Envoy: 15s).
+  #         method: POST
+  #     # Supplying `rules` opts out of the auto-default. Use
+  #     # `timeouts` to bound a specific path: for instance, cap
+  #     # publish POSTs so a slow publisher can't hold a gateway
+  #     # connection open. SSE-serving rules should keep
+  #     # `request: 0s` to avoid premature stream cutoffs.
   #     timeouts:
-  #       request: 0s
+  #       request: 30s
 
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -244,9 +244,16 @@ httpRoute:
   #         headers:
   #           - name: version
   #             value: v2
-  #   - timeouts:
-  #       request: 30s
-  #       backendRequest: 10s
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /.well-known/mercure
+  #     # Mercure subscriptions are long-lived SSE streams. The hub's
+  #     # own `write_timeout` (default 600s) drives subscriber rotation.
+  #     # Set `request: 0s` to disable the gateway-level timeout — most
+  #     # controllers cut at their own default otherwise (Envoy: 15s).
+  #     timeouts:
+  #       request: 0s
 
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.


### PR DESCRIPTION
The chart's httproute.yaml template only renders backendRefs, matches, and filters per rule, so rules[].timeouts.request set in values is silently dropped. Useful for long-lived SSE streams where the default Envoy route timeout (15s) cuts the connection.

<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->
