### PR TITLE
fix: cap default topic selector cache to 100k entries

### DIFF
--- a/topicselector.go
+++ b/topicselector.go
@@ -8,8 +8,11 @@ import (
 	"github.com/yosida95/uritemplate/v3"
 )
 
-// DefaultTopicSelectorStoreCacheSize is the default maximum number of entries in the cache.
-const DefaultTopicSelectorStoreCacheSize = 2_560_000
+// DefaultTopicSelectorStoreCacheSize bounds the (topic_selector, topic) -> bool
+// match cache. At ~100 B/entry, 100_000 keeps the cache under ~10 MB. Raise it
+// via the `topic_selector_cache <N>` Caddyfile directive for hubs handling a
+// much larger topic / selector universe.
+const DefaultTopicSelectorStoreCacheSize = 100_000
 
 type matchCacheKey struct {
 	topicSelector string


### PR DESCRIPTION
## Why

`TopicSelectorStore` keeps a `(topic_selector, topic) -> bool` otter LRU. The previous default of `2_560_000` entries was sized for very large bare-metal deployments. At ~100 B/entry (otter overhead + the two strings) the cache can grow to roughly **256 MB** before evicting.

On common K8s pod sizes (128–256 MiB) that pins the heap to the cgroup ceiling, and the runtime burns >90% of CPU in `gcBgMarkWorker` trying to stay under `GOMEMLIMIT` (90% of cgroup, set by Caddy's `automemlimit`).

We hit this on a busy production hub: 7 of 30 pods stuck at 600m CPU vs the rest at ~30m. CPU pprof on a hot pod showed:

```
File: caddy
Type: cpu
Duration: 30.01s, Total samples = 13.43s (44.76%)
      flat  flat%   sum%        cum   cum%
         0     0%     0%     12.34s 91.88%  runtime.systemstack
         0     0%     0%     12.31s 91.66%  runtime.gcBgMarkWorker
     0.04s   0.3%   0.3%     12.29s 91.51%  runtime.gcDrain
     ...
```

Heap pprof on the same pod pinned 73 MB / 77% of live heap on `skipfilter.getFilter` (the Mercure subscriber list), with `otter.../node.NewBS[matchCacheKey, bool]` and `otter.../hashmap.newMapTable[matchCacheKey]` accounting for 51 MB on their own. None of it was a leak, just the cache filling its very generous bound.

## Fix

Drop the default to `100_000` (~10 MB max). Fits any reasonable pod, still absorbs the typical hub working set.

## Migration

* No behavior change for hubs that already pass an explicit cache size via the `topic_selector_cache <N>` Caddyfile directive.
* Hubs running on the previous default and relying on a very large topic/selector universe being fully cached should set `topic_selector_cache <N>` to whatever they were implicitly using before.