### PR TITLE
docs(chart): document NET_BIND_SERVICE in the rootless securityContext example

### DIFF
--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -75,7 +75,7 @@ Kubernetes: `>=1.23.0-0`
 | publisherJwtKey | string | `""` | The JWT key to use for publishers, a random key will be generated if empty. |
 | replicaCount | int | `1` | The number of replicas (pods) to launch, must be 1 unless you are using [the High Availability version](https://mercure.rocks/docs/hub/cluster). |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
-| securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
+| securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. The official image ships with `cap_net_bind_service` set on the binary, so rootless deployments on port 80/443 work as long as `NET_BIND_SERVICE` stays in the bounding set (re-added below when dropping ALL). |
 | service.annotations | object | `{}` |  |
 | service.nodePort | string | `nil` | Set this, to pin the external nodePort in case `service.type` is `NodePort`. |
 | service.port | int | `80` | Service port. |

--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -25,6 +25,8 @@ Kubernetes: `>=1.23.0-0`
 | adminPort | int | `2019` | Port used for the Caddy admin API (health checks, metrics, graceful shutdown). |
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling must not be enabled unless you are using [the High Availability version](https://mercure.rocks/docs/hub/cluster) (see [values.yaml](values.yaml) for details). |
+| autoscaling.behavior | object | `{}` | [Scaling policies](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) passed to the HPA `spec.behavior`. |
+| autoscaling.customMetrics | list | `[]` | Additional metrics appended to the HPA `spec.metrics` list (Pods, Object, External metric types). |
 | caddyExtraConfig | string | `""` | Inject snippet or named-routes options in the Caddyfile |
 | caddyExtraDirectives | string | `""` | Inject extra Caddy directives in the Caddyfile. |
 | deployment.annotations | object | `{}` | Annotations to be added to the deployment. |
@@ -75,7 +77,7 @@ Kubernetes: `>=1.23.0-0`
 | publisherJwtKey | string | `""` | The JWT key to use for publishers, a random key will be generated if empty. |
 | replicaCount | int | `1` | The number of replicas (pods) to launch, must be 1 unless you are using [the High Availability version](https://mercure.rocks/docs/hub/cluster). |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
-| securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. The official image ships with `cap_net_bind_service` set on the binary, so rootless deployments on port 80/443 work as long as `NET_BIND_SERVICE` stays in the bounding set (re-added below when dropping ALL). |
+| securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. To run rootless on ports 80/443, add `NET_BIND_SERVICE` to the container capabilities (see the example below). The image's binary also carries `cap_net_bind_service` as a file capability, but `allowPrivilegeEscalation: false` enables `no_new_privs`, which tells the kernel to ignore file capabilities on `exec`, so the explicit `add` is what makes the bind work under that hardening. |
 | service.annotations | object | `{}` |  |
 | service.nodePort | string | `nil` | Set this, to pin the external nodePort in case `service.type` is `NodePort`. |
 | service.port | int | `80` | Service port. |

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -159,10 +159,16 @@ podSecurityContext: {}
 
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
+# The official image ships with `cap_net_bind_service` set on the binary, so
+# rootless deployments on port 80/443 work as long as `NET_BIND_SERVICE`
+# stays in the bounding set (re-added below when dropping ALL).
 securityContext: {}
+  # allowPrivilegeEscalation: false
   # capabilities:
   #   drop:
   #   - ALL
+  #   add:
+  #   - NET_BIND_SERVICE
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -159,9 +159,12 @@ podSecurityContext: {}
 
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
-# The official image ships with `cap_net_bind_service` set on the binary, so
-# rootless deployments on port 80/443 work as long as `NET_BIND_SERVICE`
-# stays in the bounding set (re-added below when dropping ALL).
+# To run rootless on ports 80/443, add `NET_BIND_SERVICE` to the container
+# capabilities (see the example below). The image's binary also carries
+# `cap_net_bind_service` as a file capability, but
+# `allowPrivilegeEscalation: false` enables `no_new_privs`, which tells the
+# kernel to ignore file capabilities on `exec`, so the explicit `add` is
+# what makes the bind work under that hardening.
 securityContext: {}
   # allowPrivilegeEscalation: false
   # capabilities:

--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -111,6 +111,30 @@ helm install my-release mercure/mercure
 
 See [the list of available values](https://github.com/dunglas/mercure/blob/main/charts/mercure/README.md) for this chart.
 
+### Rootless Deployment
+
+Set the chart's `podSecurityContext` and `securityContext` values to run the hub as a non-root user. `allowPrivilegeEscalation: false` (`no_new_privs`) makes the kernel ignore the binary's file capabilities on `exec`, so binding to 80/443 relies on adding `NET_BIND_SERVICE` back after dropping all capabilities:
+
+```yaml
+# values.yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+    add: [NET_BIND_SERVICE]
+  runAsNonRoot: true
+  runAsUser: 1000
+```
+
+When persistence is enabled, `fsGroup` ensures the volume is writable by the chosen UID.
+
 ## Docker Compose
 
 If you prefer to use `docker compose` to run the Mercure.rocks Hub, here's a sample service definition:

--- a/docs/hub/install.md
+++ b/docs/hub/install.md
@@ -111,7 +111,7 @@ helm install my-release mercure/mercure
 
 See [the list of available values](https://github.com/dunglas/mercure/blob/main/charts/mercure/README.md) for this chart.
 
-### Rootless Deployment
+### Rootless Deployment (Kubernetes)
 
 Set the chart's `podSecurityContext` and `securityContext` values to run the hub as a non-root user. `allowPrivilegeEscalation: false` (`no_new_privs`) makes the kernel ignore the binary's file capabilities on `exec`, so binding to 80/443 relies on adding `NET_BIND_SERVICE` back after dropping all capabilities:
 


### PR DESCRIPTION
## Summary

Follow-up to #1222. The image's `caddy` binary now carries `cap_net_bind_service` as a file capability, so rootless deployments on ports 80/443 work out of the box. But on `exec` the binary's permitted set is intersected with the bounding set, so dropping `ALL` capabilities silently strips the file cap unless `NET_BIND_SERVICE` is re-added. The `securityContext` example in `values.yaml` was missing that re-add, so anyone copying it would land on a hub stuck in CrashLoopBackOff with `EACCES` on bind.

Fixes the example, and adds a one-liner explaining why the re-add is needed. README regenerated via `helm-docs`.