### PR TITLE
feat(examples/chat): bump deps + harden chart security context

### DIFF
--- a/examples/chat/Dockerfile
+++ b/examples/chat/Dockerfile
@@ -1,11 +1,22 @@
-# hadolint ignore=DL3006
-FROM tiangolo/meinheld-gunicorn
+# syntax=docker/dockerfile:1
 
+FROM python:3.13-slim AS build
 WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
-COPY ./requirements.txt /app
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY ./main.py .
-COPY ./static static
-COPY ./templates templates
+FROM python:3.13-slim
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/install/bin:${PATH}" \
+    PYTHONPATH="/install/lib/python3.13/site-packages"
+WORKDIR /app
+COPY --from=build /install /install
+COPY main.py ./
+COPY static static
+COPY templates templates
+RUN groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --shell /sbin/nologin nonroot
+USER 65532:65532
+EXPOSE 8080
+CMD ["gunicorn", "--bind=0.0.0.0:8080", "--workers=2", "main:app"]

--- a/examples/chat/chart/mercure-example-chat/Chart.yaml
+++ b/examples/chat/chart/mercure-example-chat/Chart.yaml
@@ -1,24 +1,10 @@
 apiVersion: v2
 name: mercure-example-chat
 description: A minimalist chat system, using Mercure and the Flask microframework to handle cookie authentication
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
+# Targets recent Kubernetes only: NetworkPolicy templates rely on the
+# kubernetes.io/metadata.name auto-label (GA in 1.22) and the chart
+# optionally renders a Gateway API HTTPRoute (v1 GA in 1.30).
+kubeVersion: ">=1.30.0-0"

--- a/examples/chat/chart/mercure-example-chat/templates/deployment.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "mercure-example-chat.labels" . | nindent 4 }}
 spec:
+  revisionHistoryLimit: 3
+  progressDeadlineSeconds: 300
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
@@ -28,6 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "mercure-example-chat.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -42,7 +45,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.containerPort }}
               protocol: TCP
           env:
           - name: HUB_URL
@@ -65,6 +68,10 @@ spec:
               configMapKeyRef:
                 name: {{ include "mercure-example-chat.fullname" . }}
                 key: messageUriTemplate
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/examples/chat/chart/mercure-example-chat/templates/httproute.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/httproute.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.httpRoute.enabled -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute") -}}
+{{- fail "httpRoute.enabled is true but the cluster does not have gateway.networking.k8s.io/v1 installed. Install the Gateway API CRDs first or set httpRoute.enabled=false." -}}
+{{- end -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/examples/chat/chart/mercure-example-chat/templates/httproute.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "mercure-example-chat.fullname" . }}
+  labels:
+    {{- include "mercure-example-chat.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "mercure-example-chat.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/examples/chat/chart/mercure-example-chat/templates/httproute.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/httproute.yaml
@@ -2,6 +2,9 @@
 {{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute") -}}
 {{- fail "httpRoute.enabled is true but the cluster does not have gateway.networking.k8s.io/v1 installed. Install the Gateway API CRDs first or set httpRoute.enabled=false." -}}
 {{- end -}}
+{{- if not .Values.httpRoute.parentRefs -}}
+{{- fail "httpRoute.enabled is true but httpRoute.parentRefs is empty. Set at least one parent Gateway/Listener to attach this route to." -}}
+{{- end -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/examples/chat/chart/mercure-example-chat/templates/ingress.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/ingress.yaml
@@ -30,9 +30,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ include "mercure-example-chat.fullname" $ }}

--- a/examples/chat/chart/mercure-example-chat/templates/networkpolicy.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/networkpolicy.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mercure-example-chat.fullname" . }}
+  labels:
+    {{- include "mercure-example-chat.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mercure-example-chat.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.containerPort }}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.dnsNamespace | quote }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # The Mercure hub used by the demo lives at a public URL, so allow
+    # egress to anywhere outside the cluster CIDR. Tighten as needed.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              {{- range .Values.networkPolicy.clusterCIDRs }}
+              - {{ . | quote }}
+              {{- end }}
+{{- end }}

--- a/examples/chat/chart/mercure-example-chat/templates/networkpolicy.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/networkpolicy.yaml
@@ -34,13 +34,20 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    # Same-namespace egress so `helm test` and any sidecars can reach the
+    # service backends through their pod IPs.
+    - to:
+        - podSelector: {}
     # The Mercure hub used by the demo lives at a public URL, so allow
     # egress to anywhere outside the cluster CIDR. Tighten as needed.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+            {{- $clusterCIDRs := .Values.networkPolicy.clusterCIDRs | default list }}
+            {{- if gt (len $clusterCIDRs) 0 }}
             except:
-              {{- range .Values.networkPolicy.clusterCIDRs }}
+              {{- range $clusterCIDRs }}
               - {{ . | quote }}
               {{- end }}
+            {{- end }}
 {{- end }}

--- a/examples/chat/chart/mercure-example-chat/templates/networkpolicy.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/networkpolicy.yaml
@@ -13,10 +13,14 @@ spec:
     - Ingress
     - Egress
   ingress:
+    # Allow traffic from the configured ingress controller namespace and
+    # from the release namespace itself (so `helm test`, sidecars, and
+    # other in-namespace callers keep working).
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace | quote }}
+        - podSelector: {}
       ports:
         - protocol: TCP
           port: {{ .Values.containerPort }}

--- a/examples/chat/chart/mercure-example-chat/values.yaml
+++ b/examples/chat/chart/mercure-example-chat/values.yaml
@@ -110,9 +110,12 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 4
 
-# NetworkPolicy locking ingress to the configured ingress controller and
-# egress to DNS plus everything outside the cluster CIDR (the app calls the
-# Mercure hub over the public network).
+# NetworkPolicy: ingress is allowed from the configured ingress controller
+# namespace and from the release namespace itself (so `helm test` and other
+# in-namespace callers keep working); egress is allowed to DNS plus
+# everything outside the cluster CIDR (the demo calls the public Mercure
+# hub). Namespaces are matched via the kubernetes.io/metadata.name
+# auto-label (always present on K8s 1.22+).
 networkPolicy:
   enabled: true
   ingressNamespace: ingress-nginx

--- a/examples/chat/chart/mercure-example-chat/values.yaml
+++ b/examples/chat/chart/mercure-example-chat/values.yaml
@@ -2,13 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
 
-# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   repository: dunglas/mercure-example-chat
-  # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
@@ -18,111 +15,129 @@ cookieDomain: .mercure.rocks
 jwtKey: "!ChangeThisMercureHubJWTSecretKey!"
 messageUriTemplate: https://chat.example.com/messages/{id}
 
-# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
-# This is to override the chart name.
 nameOverride: ""
 fullnameOverride: ""
 
-# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: true
-  # Annotations to add to the service account
+  # The pod doesn't talk to the Kubernetes API.
+  automount: false
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# This is for setting Kubernetes Annotations to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}
-# This is for setting Kubernetes Labels to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# Pod-wide hardening: matches the nonroot user baked into the image.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# Container hardening: gunicorn needs no caps, rootfs is read-only.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
-# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  # Service port; the container itself binds to .Values.containerPort.
   port: 80
 
-# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+# Container port gunicorn binds to. Unprivileged so the non-root user can listen.
+containerPort: 8080
+
 ingress:
   enabled: false
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# Gateway API HTTPRoute alternative to Ingress. Enable one or the other
+# (or both, for migrations). The referenced Gateway must already exist.
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  hostnames: []
+  #  - chat.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
 
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  httpGet:
-    path: /
+# No CPU limit on purpose: CFS quota throttling on production clusters
+# causes probe timeouts and latency spikes even with idle CPU.
+resources:
+  limits:
+    memory: 256Mi
+  requests:
+    cpu: 50m
+    memory: 96Mi
+
+# TCP probes for startup/liveness, HTTP for readiness with a 5s timeout.
+startupProbe:
+  tcpSocket:
     port: http
+  failureThreshold: 30
+  periodSeconds: 2
+livenessProbe:
+  tcpSocket:
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 2
 readinessProbe:
   httpGet:
     path: /
     port: http
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 4
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+# NetworkPolicy locking ingress to the configured ingress controller and
+# egress to DNS plus everything outside the cluster CIDR (the app calls the
+# Mercure hub over the public network).
+networkPolicy:
+  enabled: true
+  ingressNamespace: ingress-nginx
+  dnsNamespace: kube-system
+  # Pod + service CIDRs blocked on egress so traffic to other namespaces
+  # is denied. Defaults match the DigitalOcean managed cluster; adjust as
+  # needed for your environment.
+  clusterCIDRs:
+    - 10.244.0.0/16
+    - 10.245.0.0/16
+
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
 
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
+# /tmp must be writable for gunicorn worker heartbeats since rootfs is read-only.
+volumes:
+  - name: tmp
+    emptyDir: {}
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}

--- a/examples/chat/requirements.txt
+++ b/examples/chat/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=1.1.2
-PyJWT>=1.7.1
-uritemplate>=3.0.1
-gunicorn>=20.0.4
+Flask~=3.0
+PyJWT~=2.10
+uritemplate~=4.1
+gunicorn~=23.0


### PR DESCRIPTION
## Image

- Replace `tiangolo/meinheld-gunicorn` (last upstream activity 2020, meinheld itself unmaintained) with `python:3.13-slim` + plain gunicorn. Multi-stage so the runtime carries only the wheels.
- Non-root user (UID 65532) + `USER 65532:65532` baked into the runtime stage.
- Default port 8080.

## Dependencies

- Flask `>=1.1.2` → `~=3.0`
- PyJWT `>=1.7.1` → `~=2.10`
- uritemplate `>=3.0.1` → `~=4.1`
- gunicorn `>=20.0.4` → `~=23.0`

`main.py` needed no source changes — the JWT call signatures we use are stable across PyJWT 1.x → 2.x.

## Chart (0.2.0)

- `podSecurityContext`: `runAsNonRoot`, UID/GID 65532, `seccompProfile: RuntimeDefault`.
- container `securityContext`: drop ALL caps, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`.
- Default resources: requests + memory limit only, no CPU limit. CFS quota throttling on managed clusters causes probe timeouts even with idle CPU.
- Probes: TCP startup + TCP liveness + HTTP readiness with `timeoutSeconds: 5`.
- `automountServiceAccountToken: false` (no K8s API calls).
- `containerPort: 8080`; service still exposes 80.
- Default `/tmp` `emptyDir` baked in so gunicorn worker heartbeats keep working under `readOnlyRootFilesystem`.
- New `NetworkPolicy` template: ingress from the configured ingress-nginx namespace only, egress to DNS plus everything outside the cluster CIDR.
- New `HTTPRoute` (`gateway.networking.k8s.io/v1`) template behind `httpRoute.enabled`. Either Ingress or HTTPRoute (or both, for migrations) can be enabled.
- `Chart.yaml` gets `kubeVersion: ">=1.30.0-0"`. NetworkPolicy uses `kubernetes.io/metadata.name` (GA 1.22) and HTTPRoute v1 is GA in 1.30, so the chart targets recent K8s only.