### PR TITLE
chore(examples/chat/chart): scope NetworkPolicy to Deployment pods

### DIFF
--- a/examples/chat/chart/mercure-example-chat/templates/deployment.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "mercure-example-chat.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -21,6 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "mercure-example-chat.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/examples/chat/chart/mercure-example-chat/templates/networkpolicy.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/networkpolicy.yaml
@@ -6,9 +6,13 @@ metadata:
   labels:
     {{- include "mercure-example-chat.labels" . | nindent 4 }}
 spec:
+  # Selects only the Deployment pods (component=server). The Helm test
+  # pod inherits selectorLabels via `<chart>.labels` but does not get
+  # the component label, so it isn't subject to this policy.
   podSelector:
     matchLabels:
       {{- include "mercure-example-chat.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
   policyTypes:
     - Ingress
     - Egress
@@ -34,10 +38,6 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
-    # Same-namespace egress so `helm test` and any sidecars can reach the
-    # service backends through their pod IPs.
-    - to:
-        - podSelector: {}
     # The Mercure hub used by the demo lives at a public URL, so allow
     # egress to anywhere outside the cluster CIDR. Tighten as needed.
     - to:


### PR DESCRIPTION
Follow-up to #1227.

Tag the Deployment pods with `app.kubernetes.io/component: server` and select on it in the NetworkPolicy `podSelector`. The Helm test pod inherits `selectorLabels` through `<chart>.labels` but doesn't get the component label, so it's exempt from the policy and can reach the Service via the namespace-internal CNI without a same-namespace egress allowance.

Drop the `to: podSelector: {}` egress rule (and its later port-restricted variant) added to keep `helm test` working. Egress is once again strictly DNS plus the configured outside-cluster traffic, matching the values.yaml documentation and the chart's egress-minimal intent.

Same shape just landed on the [`uri-template-tester` chart](https://github.com/dunglas/uri-template-tester/pull/10).