### PR TITLE
feat(chart): add opt-in NetworkPolicy and CiliumNetworkPolicy templates

### DIFF
--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -29,6 +29,12 @@ Kubernetes: `>=1.23.0-0`
 | autoscaling.customMetrics | list | `[]` | Additional metrics appended to the HPA `spec.metrics` list (Pods, Object, External metric types). |
 | caddyExtraConfig | string | `""` | Inject snippet or named-routes options in the Caddyfile |
 | caddyExtraDirectives | string | `""` | Inject extra Caddy directives in the Caddyfile. |
+| ciliumNetworkPolicy | object | Disabled by default. | [CiliumNetworkPolicy](https://docs.cilium.io/en/stable/security/policy/) for the hub pods. Use this on Cilium-enabled clusters when you need features that the standard NetworkPolicy spec does not support (FQDN-based egress, L7 rules, explicit deny rules, etc.). Independent of `networkPolicy.enabled` — enable whichever your CNI supports. |
+| ciliumNetworkPolicy.egress | list | `[]` | Allowed outbound traffic. Pass-through to `spec.egress`. The DNS rule below is required when using `toFQDNs`: Cilium learns IPs by inspecting responses, so DNS visibility on `kube-dns` must be allowed first. |
+| ciliumNetworkPolicy.egressDeny | list | `[]` | Explicit outbound deny rules. Pass-through to `spec.egressDeny`. |
+| ciliumNetworkPolicy.enabled | bool | `false` | Enable the CiliumNetworkPolicy. Requires the `cilium.io/v2` CRDs to be installed in the cluster. |
+| ciliumNetworkPolicy.ingress | list | `[]` | Allowed inbound traffic. Pass-through to `spec.ingress`. |
+| ciliumNetworkPolicy.ingressDeny | list | `[]` | Explicit inbound deny rules. Pass-through to `spec.ingressDeny`. |
 | deployment.annotations | object | `{}` | Annotations to be added to the deployment. |
 | dev | bool | `false` | Enable the development mode, including the debug UI and the demo. |
 | existingSecret | string | `""` | Allows to pass an existing secret name, the above values will be used if empty. |

--- a/charts/mercure/README.md
+++ b/charts/mercure/README.md
@@ -64,6 +64,11 @@ Kubernetes: `>=1.23.0-0`
 | metrics.serviceMonitor.scrapeTimeout | string | `""` | Timeout after which the scrape is ended |
 | metrics.serviceMonitor.selector | object | `{}` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus |
 | nameOverride | string | `""` | A name in place of the chart name for `app:` labels. |
+| networkPolicy | object | Disabled by default. | [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for the hub pods. When enabled with no ingress/egress rules, all traffic to/from the hub pods is denied. Supply rules to allow what you need. |
+| networkPolicy.egress | list | `[]` | Egress rules (allowed outbound traffic). Pass-through to NetworkPolicy `spec.egress`. Allow at least DNS (UDP/TCP 53 to kube-system) plus the transport backend port. |
+| networkPolicy.enabled | bool | `false` | Enable the NetworkPolicy. |
+| networkPolicy.ingress | list | `[]` | Ingress rules (allowed inbound traffic). Pass-through to NetworkPolicy `spec.ingress`. With `policyTypes: [Ingress]` and `ingress: []`, all inbound traffic is denied. |
+| networkPolicy.policyTypes | list | `[]` | `policyTypes` for the NetworkPolicy. The chart always renders both `ingress` and `egress` (defaulting to empty lists), so Kubernetes infers `policyTypes: [Ingress, Egress]`. Override (e.g. to `[Ingress]`) to opt out of egress restrictions. |
 | nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration. |
 | persistence | object | `{"accessMode":"ReadWriteOnce","enabled":false,"existingClaim":"","size":"1Gi","storageClass":""}` | Enable persistence using [Persistent Volume Claims](http://kubernetes.io/docs/user-guide/persistent-volumes/), only useful if you the BoltDB transport. |
 | persistence.accessMode | string | `"ReadWriteOnce"` | A manually managed Persistent Volume and Claim. Requires `persistence.enabled: true` If defined, PVC must be created manually before volume will be bound. |

--- a/charts/mercure/templates/ciliumnetworkpolicy.yaml
+++ b/charts/mercure/templates/ciliumnetworkpolicy.yaml
@@ -14,41 +14,32 @@ spec:
       {{- include "mercure.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: server
   {{- /*
-    `hasKey` (not `with`) so an explicit empty list passes through. Cilium
-    treats `ingress: []` and a missing `ingress` key differently from each
-    other for some rule combinations, so the chart should not silently
-    collapse one into the other.
+    All four list fields render unconditionally so an explicit empty list
+    surfaces in the manifest. With `values.yaml` defaulting each to `[]`,
+    enabling the policy without rules yields default-deny on every side.
   */}}
-  {{- if hasKey .Values.ciliumNetworkPolicy "ingress" }}
   {{- if .Values.ciliumNetworkPolicy.ingress }}
   ingress:
     {{- toYaml .Values.ciliumNetworkPolicy.ingress | nindent 4 }}
   {{- else }}
   ingress: []
   {{- end }}
-  {{- end }}
-  {{- if hasKey .Values.ciliumNetworkPolicy "ingressDeny" }}
   {{- if .Values.ciliumNetworkPolicy.ingressDeny }}
   ingressDeny:
     {{- toYaml .Values.ciliumNetworkPolicy.ingressDeny | nindent 4 }}
   {{- else }}
   ingressDeny: []
   {{- end }}
-  {{- end }}
-  {{- if hasKey .Values.ciliumNetworkPolicy "egress" }}
   {{- if .Values.ciliumNetworkPolicy.egress }}
   egress:
     {{- toYaml .Values.ciliumNetworkPolicy.egress | nindent 4 }}
   {{- else }}
   egress: []
   {{- end }}
-  {{- end }}
-  {{- if hasKey .Values.ciliumNetworkPolicy "egressDeny" }}
   {{- if .Values.ciliumNetworkPolicy.egressDeny }}
   egressDeny:
     {{- toYaml .Values.ciliumNetworkPolicy.egressDeny | nindent 4 }}
   {{- else }}
   egressDeny: []
-  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/mercure/templates/ciliumnetworkpolicy.yaml
+++ b/charts/mercure/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ciliumNetworkPolicy.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "mercure.fullname" . }}
+  labels:
+    {{- include "mercure.labels" . | nindent 4 }}
+spec:
+  # Selects only the Deployment pods. The helm test pod inherits
+  # `mercure.selectorLabels` via `mercure.labels` but does not carry
+  # `app.kubernetes.io/component: server`, so it stays unscoped.
+  endpointSelector:
+    matchLabels:
+      {{- include "mercure.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  {{- with .Values.ciliumNetworkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ciliumNetworkPolicy.ingressDeny }}
+  ingressDeny:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ciliumNetworkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ciliumNetworkPolicy.egressDeny }}
+  egressDeny:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mercure/templates/ciliumnetworkpolicy.yaml
+++ b/charts/mercure/templates/ciliumnetworkpolicy.yaml
@@ -13,20 +13,42 @@ spec:
     matchLabels:
       {{- include "mercure.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: server
-  {{- with .Values.ciliumNetworkPolicy.ingress }}
+  {{- /*
+    `hasKey` (not `with`) so an explicit empty list passes through. Cilium
+    treats `ingress: []` and a missing `ingress` key differently from each
+    other for some rule combinations, so the chart should not silently
+    collapse one into the other.
+  */}}
+  {{- if hasKey .Values.ciliumNetworkPolicy "ingress" }}
+  {{- if .Values.ciliumNetworkPolicy.ingress }}
   ingress:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .Values.ciliumNetworkPolicy.ingress | nindent 4 }}
+  {{- else }}
+  ingress: []
   {{- end }}
-  {{- with .Values.ciliumNetworkPolicy.ingressDeny }}
+  {{- end }}
+  {{- if hasKey .Values.ciliumNetworkPolicy "ingressDeny" }}
+  {{- if .Values.ciliumNetworkPolicy.ingressDeny }}
   ingressDeny:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .Values.ciliumNetworkPolicy.ingressDeny | nindent 4 }}
+  {{- else }}
+  ingressDeny: []
   {{- end }}
-  {{- with .Values.ciliumNetworkPolicy.egress }}
+  {{- end }}
+  {{- if hasKey .Values.ciliumNetworkPolicy "egress" }}
+  {{- if .Values.ciliumNetworkPolicy.egress }}
   egress:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .Values.ciliumNetworkPolicy.egress | nindent 4 }}
+  {{- else }}
+  egress: []
   {{- end }}
-  {{- with .Values.ciliumNetworkPolicy.egressDeny }}
+  {{- end }}
+  {{- if hasKey .Values.ciliumNetworkPolicy "egressDeny" }}
+  {{- if .Values.ciliumNetworkPolicy.egressDeny }}
   egressDeny:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .Values.ciliumNetworkPolicy.egressDeny | nindent 4 }}
+  {{- else }}
+  egressDeny: []
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
       {{- end }}
       labels:
         {{- include "mercure.labels" . | nindent 8 }}
+        # Lets the NetworkPolicy podSelector target the Deployment pods only,
+        # without making the Deployment's immutable spec.selector fail to
+        # roll forward on existing installs.
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -58,7 +58,8 @@ spec:
         # Merge so the chart's component label always wins over user podLabels:
         # the NetworkPolicy podSelector relies on it. Safe to add post-install
         # because the Deployment's immutable spec.selector doesn't reference it.
-        {{- $podLabels := merge (dict "app.kubernetes.io/component" "server") .Values.podLabels }}
+        # `default dict` keeps the merge null-safe when podLabels is null/unset.
+        {{- $podLabels := merge (dict "app.kubernetes.io/component" "server") (.Values.podLabels | default dict) }}
         {{- toYaml $podLabels | nindent 8 }}
     spec:
       {{- if eq .Values.updateStrategy.type "RollingUpdate" }}

--- a/charts/mercure/templates/deployment.yaml
+++ b/charts/mercure/templates/deployment.yaml
@@ -55,13 +55,11 @@ spec:
       {{- end }}
       labels:
         {{- include "mercure.labels" . | nindent 8 }}
-        # Lets the NetworkPolicy podSelector target the Deployment pods only,
-        # without making the Deployment's immutable spec.selector fail to
-        # roll forward on existing installs.
-        app.kubernetes.io/component: server
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        # Merge so the chart's component label always wins over user podLabels:
+        # the NetworkPolicy podSelector relies on it. Safe to add post-install
+        # because the Deployment's immutable spec.selector doesn't reference it.
+        {{- $podLabels := merge (dict "app.kubernetes.io/component" "server") .Values.podLabels }}
+        {{- toYaml $podLabels | nindent 8 }}
     spec:
       {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
       # Driven by .Values.terminationGracePeriodSeconds so the hub can

--- a/charts/mercure/templates/networkpolicy.yaml
+++ b/charts/mercure/templates/networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mercure.fullname" . }}
+  labels:
+    {{- include "mercure.labels" . | nindent 4 }}
+spec:
+  # Selects only the Deployment pods. The helm test pod inherits
+  # `mercure.selectorLabels` via `mercure.labels` but does not carry
+  # `app.kubernetes.io/component: server`, so it stays unscoped.
+  podSelector:
+    matchLabels:
+      {{- include "mercure.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  {{- with .Values.networkPolicy.policyTypes }}
+  policyTypes:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  # Both fields are always rendered (defaulting to empty lists) so that
+  # Kubernetes infers `policyTypes: [Ingress, Egress]` and the policy is
+  # truly default-deny when enabled with no rules.
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- else }}
+  ingress: []
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- else }}
+  egress: []
+  {{- end }}
+{{- end }}

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -316,6 +316,54 @@ networkPolicy:
   #     - protocol: TCP
   #       port: 53
 
+# -- [CiliumNetworkPolicy](https://docs.cilium.io/en/stable/security/policy/) for
+# the hub pods. Use this on Cilium-enabled clusters when you need features that
+# the standard NetworkPolicy spec does not support (FQDN-based egress, L7 rules,
+# explicit deny rules, etc.). Independent of `networkPolicy.enabled` — enable
+# whichever your CNI supports.
+# @default -- Disabled by default.
+ciliumNetworkPolicy:
+  # -- Enable the CiliumNetworkPolicy. Requires the `cilium.io/v2` CRDs to be
+  # installed in the cluster.
+  enabled: false
+  # -- Allowed inbound traffic. Pass-through to `spec.ingress`.
+  ingress: []
+  # ingress:
+  #   - fromEndpoints:
+  #       - matchLabels:
+  #           k8s:io.kubernetes.pod.namespace: ingress-nginx
+  #           app.kubernetes.io/name: ingress-nginx
+  #     toPorts:
+  #       - ports:
+  #           - port: "80"
+  #             protocol: TCP
+  # -- Explicit inbound deny rules. Pass-through to `spec.ingressDeny`.
+  ingressDeny: []
+  # -- Allowed outbound traffic. Pass-through to `spec.egress`. The DNS rule
+  # below is required when using `toFQDNs`: Cilium learns IPs by inspecting
+  # responses, so DNS visibility on `kube-dns` must be allowed first.
+  egress: []
+  # egress:
+  #   - toEndpoints:
+  #       - matchLabels:
+  #           k8s:io.kubernetes.pod.namespace: kube-system
+  #           k8s:k8s-app: kube-dns
+  #     toPorts:
+  #       - ports:
+  #           - port: "53"
+  #             protocol: ANY
+  #         rules:
+  #           dns:
+  #             - matchPattern: "*"
+  #   - toFQDNs:
+  #       - matchName: redis.example.com
+  #     toPorts:
+  #       - ports:
+  #           - port: "6379"
+  #             protocol: TCP
+  # -- Explicit outbound deny rules. Pass-through to `spec.egressDeny`.
+  egressDeny: []
+
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
 # @default -- No requests or limits.

--- a/charts/mercure/values.yaml
+++ b/charts/mercure/values.yaml
@@ -274,6 +274,48 @@ httpRoute:
   #     timeouts:
   #       request: 30s
 
+# -- [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for the hub pods.
+# When enabled with no ingress/egress rules, all traffic to/from the
+# hub pods is denied. Supply rules to allow what you need.
+# @default -- Disabled by default.
+networkPolicy:
+  # -- Enable the NetworkPolicy.
+  enabled: false
+  # -- `policyTypes` for the NetworkPolicy. The chart always renders both
+  # `ingress` and `egress` (defaulting to empty lists), so Kubernetes infers
+  # `policyTypes: [Ingress, Egress]`. Override (e.g. to `[Ingress]`) to opt
+  # out of egress restrictions.
+  policyTypes: []
+  # policyTypes:
+  #   - Ingress
+  #   - Egress
+  # -- Ingress rules (allowed inbound traffic). Pass-through to NetworkPolicy
+  # `spec.ingress`. With `policyTypes: [Ingress]` and `ingress: []`, all
+  # inbound traffic is denied.
+  ingress: []
+  # ingress:
+  #   - from:
+  #     - namespaceSelector:
+  #         matchLabels:
+  #           kubernetes.io/metadata.name: ingress-nginx
+  #     ports:
+  #     - protocol: TCP
+  #       port: 80
+  # -- Egress rules (allowed outbound traffic). Pass-through to NetworkPolicy
+  # `spec.egress`. Allow at least DNS (UDP/TCP 53 to kube-system) plus the
+  # transport backend port.
+  egress: []
+  # egress:
+  #   - to:
+  #     - namespaceSelector:
+  #         matchLabels:
+  #           kubernetes.io/metadata.name: kube-system
+  #     ports:
+  #     - protocol: UDP
+  #       port: 53
+  #     - protocol: TCP
+  #       port: 53
+
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
 # @default -- No requests or limits.


### PR DESCRIPTION
## Summary

Two opt-in templates that let operators restrict the hub pods' inbound and outbound traffic via chart values rather than maintaining external manifests. Both default to disabled (no behaviour change), and they're independent — enable whichever your CNI supports.

### `templates/networkpolicy.yaml` — standard `networking.k8s.io/v1`

- Gated on `networkPolicy.enabled`.
- `networkPolicy.ingress` / `networkPolicy.egress` are pass-through to `spec.ingress` / `spec.egress`. Both render unconditionally (defaulting to empty lists), so Kubernetes infers `policyTypes: [Ingress, Egress]` and the policy is true default-deny when enabled with no rules.
- `networkPolicy.policyTypes` overridable for the rare case where you want default-deny on only one side.

### `templates/ciliumnetworkpolicy.yaml` — `cilium.io/v2`

- Gated on `ciliumNetworkPolicy.enabled`.
- Pass-through `ingress` / `ingressDeny` / `egress` / `egressDeny` to the matching `spec` fields, so users can use Cilium-only features the standard spec lacks: FQDN-based egress (`toFQDNs`), L7 rules, explicit deny semantics, etc.
- Requires the `cilium.io/v2` CRDs in the cluster (Cilium must be the CNI).

### Selector design (both templates)

The `app.kubernetes.io/component: server` label is added to the Deployment's pod template (not to its immutable `spec.selector`, so existing installs roll forward cleanly), and matched on in both policy templates. The Deployment merges that label over `.Values.podLabels` so a user-supplied entry with the same key cannot silently take the pods out of the policy's podSelector.

The helm test pod inherits `mercure.selectorLabels` via `mercure.labels` but does not carry `component: server`, so the policy doesn't apply to it. Note: `helm test` will still fail when default-deny ingress is enabled, because the *hub* pods are subject to the policy and won't accept the test pod's connection. Users who run `helm test` should add an ingress rule allowing the test pod, or disable the policy temporarily during testing.

## Examples

Standard `NetworkPolicy` (any CNI that implements the API):

```yaml
networkPolicy:
  enabled: true
  ingress:
    - from:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: ingress-nginx
      ports:
        - protocol: TCP
          port: 80
  egress:
    - to:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: kube-system
      ports:
        - protocol: UDP
          port: 53
```

`CiliumNetworkPolicy` with FQDN-pinned egress to a managed DB:

```yaml
ciliumNetworkPolicy:
  enabled: true
  ingress:
    - fromEndpoints:
        - matchLabels:
            k8s:io.kubernetes.pod.namespace: ingress-nginx
      toPorts:
        - ports:
            - port: "80"
              protocol: TCP
  egress:
    - toEndpoints:
        - matchLabels:
            k8s:io.kubernetes.pod.namespace: kube-system
            k8s:k8s-app: kube-dns
      toPorts:
        - ports:
            - port: "53"
              protocol: ANY
          rules:
            dns:
              - matchPattern: "*"
    - toFQDNs:
        - matchName: redis.example.com
      toPorts:
        - ports:
            - port: "6379"
              protocol: TCP
```

`helm lint` and `helm template` checked with each template disabled, enabled-with-no-rules, and the example values above. Both CI value sets (`default-values.yaml` and `httproute-values.yaml`) lint clean.