### PR TITLE
ci: set up QEMU and Buildx before goreleaser to fix the arm64 image build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,6 +62,19 @@ jobs:
           echo "GORELEASER_CURRENT_TAG=$(awk 'NR==1 {print;exit}' <<< "$tags")"  >> "$GITHUB_ENV"
           echo "GORELEASER_PREVIOUS_TAG=$(awk 'NR==2 {print;exit}' <<< "$tags")"  >> "$GITHUB_ENV"
 
+      # Required for goreleaser to build the linux/arm64 Docker image on the
+      # amd64 runner: any non-COPY instruction (e.g. `RUN setcap`) needs the
+      # arm64 binfmt handler registered, otherwise buildx fails with
+      # "exec format error" the moment it tries to execute /bin/sh in the
+      # cross-built image.
+      - name: Set up QEMU
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/setup-buildx-action@v4
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7.1.0
         with:


### PR DESCRIPTION
The arm64 Docker image is built from an amd64 runner via buildx. As long as the Dockerfile only had \`COPY\` instructions, no actual code had to run inside the cross-built image and the missing binfmt handler went unnoticed. The recent \`RUN setcap cap_net_bind_service=+ep /usr/bin/caddy\` step (#1222) is the first instruction that has to execute \`/bin/sh\` in the arm64 image, so \`v0.23.3\`'s release failed with \`exec format error\`.

Register the binfmt handlers and create a Buildx builder before goreleaser runs, gated on tag pushes since snapshot builds are single-target on the runner's native arch.