### PR TITLE
feat(examples/chat/chart): set enableServiceLinks: false and harden the helm test pod

### DIFF
--- a/examples/chat/chart/mercure-example-chat/templates/deployment.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "mercure-example-chat.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      # Don't expose every neighbour Service's host/port via env vars; the
+      # chat app does its own service discovery (the Mercure hub URL is a
+      # config value, not derived from K8s env).
+      enableServiceLinks: false
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/examples/chat/chart/mercure-example-chat/templates/tests/test-connection.yaml
+++ b/examples/chat/chart/mercure-example-chat/templates/tests/test-connection.yaml
@@ -7,9 +7,26 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  # The test pod calls a single HTTP endpoint, so no Kubernetes API
+  # access, no service-link env, and no privileged execution is needed.
+  # Stays compatible with the restricted PodSecurity Standard.
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: wget
-      image: busybox
+      image: busybox:1.37
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
       command: ['wget']
-      args: ['{{ include "mercure-example-chat.fullname" . }}:{{ .Values.service.port }}']
+      args: ['-q', '--spider', 'http://{{ include "mercure-example-chat.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never


### PR DESCRIPTION
Bring the chat demo chart in line with the main mercure chart's
secure-by-default settings.

- `enableServiceLinks: false` on the hub Pod so a multi-tenant
  namespace does not get a free in-pod inventory of every neighbour
  Service via the auto-injected env vars. The chat app does its own
  service discovery (the Mercure hub URL is a config value, not
  derived from K8s env), so nothing on the app side needs the env.
- Harden the helm test pod: pinned `busybox:1.37`, no SA token, no
  service links, RuntimeDefault seccomp, drop ALL caps, RO rootfs,
  non-root, `wget -q --spider` so the response body is not written
  to disk under RO rootfs. Stays compatible with the restricted
  PodSecurity Standard.