### PR TITLE
Revert "ci: set up QEMU and Buildx before goreleaser to fix the arm64…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,19 +62,6 @@ jobs:
           echo "GORELEASER_CURRENT_TAG=$(awk 'NR==1 {print;exit}' <<< "$tags")"  >> "$GITHUB_ENV"
           echo "GORELEASER_PREVIOUS_TAG=$(awk 'NR==2 {print;exit}' <<< "$tags")"  >> "$GITHUB_ENV"
 
-      # Required for goreleaser to build the linux/arm64 Docker image on the
-      # amd64 runner: any non-COPY instruction (e.g. `RUN setcap`) needs the
-      # arm64 binfmt handler registered, otherwise buildx fails with
-      # "exec format error" the moment it tries to execute /bin/sh in the
-      # cross-built image.
-      - name: Set up QEMU
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/setup-buildx-action@v4
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7.1.0
         with:


### PR DESCRIPTION
… image build (#1232)"

This reverts commit 8a31d23a162a6dfc408885a0ed52fd9767874bb1. This isn't needed since #1234.

<!--
The commit message must follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
The following types are allowed:

* `fix`: bug fix
* `feat`: new feature
* `docs`: change in the documentation
* `spec`: spec change
* `test`: test-related change
* `perf`: performance optimization
* `ci`: CI-related change
* `chore`: updating dependencies and related changes

Examples:

    fix: Fix something

    feat: Introduce X

    feat!: Introduce Y, BC break

    docs: Add docs for X

    spec: Z disambiguation
-->
