### PR TITLE
ci: lint the caddy module too, fix the issues it surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
           version: latest
           args: --timeout=30m
 
+      - name: golangci-lint (caddy module)
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          args: --timeout=30m --config ../.golangci.yml
+          working-directory: caddy
+
   test:
     strategy:
       matrix:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,8 @@ run:
 linters:
   default: all
   settings:
+    gomoddirectives:
+      replace-local: true
     ireturn:
       allow:
         - anon

--- a/caddy/bolt.go
+++ b/caddy/bolt.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() { //nolint:gochecknoinits
-	caddy.RegisterModule(Bolt{})
+	caddy.RegisterModule(&Bolt{})
 }
 
 type Bolt struct {
@@ -26,7 +26,7 @@ type Bolt struct {
 }
 
 // CaddyModule returns the Caddy module information.
-func (Bolt) CaddyModule() caddy.ModuleInfo {
+func (*Bolt) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.handlers.mercure.bolt",
 		New: func() caddy.Module { return new(Bolt) },

--- a/caddy/health.go
+++ b/caddy/health.go
@@ -23,14 +23,14 @@ var (
 )
 
 func init() { //nolint:gochecknoinits
-	caddy.RegisterModule(Health{})
+	caddy.RegisterModule(&Health{})
 }
 
 // Health is a Caddy admin API module that exposes transport health check endpoints.
 type Health struct{}
 
 // CaddyModule returns the Caddy module information.
-func (Health) CaddyModule() caddy.ModuleInfo {
+func (*Health) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "admin.api.mercure_health",
 		New: func() caddy.Module { return new(Health) },
@@ -38,7 +38,7 @@ func (Health) CaddyModule() caddy.ModuleInfo {
 }
 
 // Routes returns the admin routes for the health module.
-func (h Health) Routes() []caddy.AdminRoute {
+func (h *Health) Routes() []caddy.AdminRoute {
 	return []caddy.AdminRoute{
 		{
 			Pattern: "/mercure/health/",
@@ -52,7 +52,7 @@ type healthResponse struct {
 	Error  string `json:"error,omitempty"`
 }
 
-func (h Health) handleHealth(w http.ResponseWriter, r *http.Request) error {
+func (h *Health) handleHealth(w http.ResponseWriter, r *http.Request) error {
 	if r.Method != http.MethodGet {
 		return caddy.APIError{
 			HTTPStatus: http.StatusMethodNotAllowed,
@@ -115,7 +115,7 @@ func parseHealthPath(urlPath string) (checkType, hubName string, err error) {
 	}
 }
 
-func (h Health) checkTransports(r *http.Request, checkType, hubName string) error {
+func (h *Health) checkTransports(r *http.Request, checkType, hubName string) error {
 	infos := h.snapshotHubs()
 
 	var matched bool
@@ -151,7 +151,7 @@ func (h Health) checkTransports(r *http.Request, checkType, hubName string) erro
 	return nil
 }
 
-func (h Health) snapshotHubs() []*hubInfo {
+func (h *Health) snapshotHubs() []*hubInfo {
 	hubsMu.Lock()
 	defer hubsMu.Unlock()
 

--- a/caddy/local.go
+++ b/caddy/local.go
@@ -11,7 +11,7 @@ type localTransportKeyStruct struct{}
 var localTransportKey = localTransportKeyStruct{} //nolint:gochecknoglobals
 
 func init() { //nolint:gochecknoinits
-	caddy.RegisterModule(Local{})
+	caddy.RegisterModule(&Local{})
 }
 
 type Local struct {
@@ -19,7 +19,7 @@ type Local struct {
 }
 
 // CaddyModule returns the Caddy module information.
-func (Local) CaddyModule() caddy.ModuleInfo {
+func (*Local) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.handlers.mercure.local",
 		New: func() caddy.Module { return new(Local) },

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -29,7 +29,9 @@ import (
 const defaultHubURL = "/.well-known/mercure"
 
 var (
-	// EXPERIMENTAL: AllowNoPublish allows not setting the publisher JWT, and then disable the publish endpoint.
+	// AllowNoPublish allows not setting the publisher JWT, and then disable the publish endpoint.
+	//
+	// EXPERIMENTAL.
 	//
 	// It is usually set to true in the init() function of Go applications allowing to publish programmatically by
 	// calling mercure.Publish() directly.
@@ -39,7 +41,7 @@ var (
 
 	// hubs is a list of registered Mercure hubs, the key is the top-most subroute.
 	hubs   = make(map[caddy.Module]*hubInfo) //nolint:gochecknoglobals
-	hubsMu sync.Mutex
+	hubsMu sync.Mutex                        //nolint:gochecknoglobals
 )
 
 type hubInfo struct {
@@ -49,12 +51,14 @@ type hubInfo struct {
 }
 
 func init() { //nolint:gochecknoinits
-	caddy.RegisterModule(Mercure{})
+	caddy.RegisterModule(&Mercure{})
 	httpcaddyfile.RegisterHandlerDirective("mercure", parseCaddyfile)
 	httpcaddyfile.RegisterDirectiveOrder("mercure", "after", "encode")
 }
 
-// EXPERIMENTAL: FindHub finds the Mercure hub configured for the current route.
+// FindHub finds the Mercure hub configured for the current route.
+//
+// EXPERIMENTAL.
 func FindHub(modules []caddy.Module) *mercure.Hub {
 	hubsMu.Lock()
 	defer hubsMu.Unlock()
@@ -88,6 +92,8 @@ type TopicSelectorCacheConfig struct {
 
 // Mercure implements a Mercure hub as a Caddy module. Mercure is a protocol allowing to push data updates to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way.
 type Mercure struct {
+	deprecatedTransport
+
 	// Human-readable name for this hub, used in health check endpoints and metrics.
 	Name string `json:"name,omitempty"`
 
@@ -147,86 +153,17 @@ type Mercure struct {
 	// The transport configuration.
 	TransportRaw json.RawMessage `json:"transport,omitempty" caddy:"namespace=http.handlers.mercure inline_key=name"` //nolint:tagalign
 
-	deprecatedTransport
-
 	hub    *mercure.Hub
 	logger *slog.Logger
 	cancel context.CancelFunc
 }
 
 // CaddyModule returns the Caddy module information.
-func (Mercure) CaddyModule() caddy.ModuleInfo {
+func (*Mercure) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.handlers.mercure",
 		New: func() caddy.Module { return new(Mercure) },
 	}
-}
-
-func (m *Mercure) populateJWTConfig() error {
-	repl := caddy.NewReplacer()
-
-	if m.PublisherJWKSURL == "" {
-		m.PublisherJWT.Key = repl.ReplaceKnown(m.PublisherJWT.Key, "")
-
-		if m.PublisherJWT.Key != "" {
-			m.PublisherJWT.Alg = repl.ReplaceKnown(m.PublisherJWT.Alg, "HS256")
-			if m.PublisherJWT.Alg == "" {
-				m.PublisherJWT.Alg = "HS256"
-			}
-		} else if !AllowNoPublish {
-			return errors.New("a JWT key or the URL of a JWK Set for publishers must be provided") //nolint:err113
-		}
-	}
-
-	if m.SubscriberJWKSURL == "" {
-		m.SubscriberJWT.Key = repl.ReplaceKnown(m.SubscriberJWT.Key, "")
-		m.SubscriberJWT.Alg = repl.ReplaceKnown(m.SubscriberJWT.Alg, "HS256")
-
-		if m.SubscriberJWT.Key == "" {
-			if !m.Anonymous {
-				return errors.New("a JWT key or the URL of a JWK Set for subscribers must be provided") //nolint:err113
-			}
-		}
-
-		if m.SubscriberJWT.Alg == "" {
-			m.SubscriberJWT.Alg = "HS256"
-		}
-	}
-
-	return nil
-}
-
-// newJWKSetKeyfunc builds a Keyfunc from a JWK Set URL.
-//
-// file:// URLs point to a local JSON file containing a JWK Set; the file is
-// read once at provision time, so rotating the keys requires a Caddy config
-// reload. Other URLs are forwarded to keyfunc.NewDefaultCtx, which handles
-// HTTP(S) and rejects unsupported schemes.
-func newJWKSetKeyfunc(ctx context.Context, rawURL string) (keyfunc.Keyfunc, error) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid JWK Set URL %q: %w", rawURL, err)
-	}
-
-	if u.Scheme == "file" {
-		if u.Host != "" && u.Host != "localhost" {
-			return nil, fmt.Errorf(`file:// JWK Set URL host must be empty or "localhost", got %q`, u.Host) //nolint:err113
-		}
-
-		b, err := os.ReadFile(u.Path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read JWK Set file %q: %w", u.Path, err)
-		}
-
-		k, err := keyfunc.NewJWKSetJSON(b)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse JWK Set file %q: %w", u.Path, err)
-		}
-
-		return k, nil
-	}
-
-	return keyfunc.NewDefaultCtx(ctx, []string{rawURL}) //nolint:wrapcheck
 }
 
 type stoppingHandlerFunc func()
@@ -238,7 +175,7 @@ func (s stoppingHandlerFunc) Handle(_ context.Context, _ caddy.Event) error {
 }
 
 //nolint:wrapcheck
-func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,gocognit
+func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,gocognit,gocyclo,maintidx
 	metrics := mercure.NewPrometheusMetrics(ctx.GetMetricsRegistry())
 
 	if err := m.populateJWTConfig(); err != nil {
@@ -380,6 +317,7 @@ func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,goc
 	}
 
 	var c context.Context
+
 	c, m.cancel = context.WithCancel(ctx)
 	if err := eventApp.(*caddyevents.App).On("stopping", stoppingHandlerFunc(m.cancel)); err != nil {
 		return err
@@ -441,7 +379,7 @@ func (m *Mercure) Cleanup() error {
 	return m.cleanupTransportDeprecated()
 }
 
-func (m Mercure) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+func (m *Mercure) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	if !strings.HasPrefix(r.URL.Path, defaultHubURL) {
 		return next.ServeHTTP(w, r) //nolint:wrapcheck
 	}
@@ -581,12 +519,15 @@ func (m *Mercure) UnmarshalCaddyfile(d *caddyfile.Dispenser) (err error) { //nol
 					return d.ArgErr()
 				}
 
-				s, err := strconv.ParseUint(d.Val(), 10, 64)
+				size, err := strconv.Atoi(d.Val())
 				if err != nil {
 					return d.WrapErr(err)
 				}
 
-				size := int(s)
+				if size < 0 {
+					return d.Errf("subscriber_list_cache_size must be >= 0, got %d", size)
+				}
+
 				m.SubscriberListCacheSize = &size
 
 			case "cookie_name":
@@ -620,21 +561,90 @@ func (m *Mercure) UnmarshalCaddyfile(d *caddyfile.Dispenser) (err error) { //nol
 	return nil
 }
 
+func (m *Mercure) populateJWTConfig() error {
+	repl := caddy.NewReplacer()
+
+	if m.PublisherJWKSURL == "" {
+		m.PublisherJWT.Key = repl.ReplaceKnown(m.PublisherJWT.Key, "")
+
+		if m.PublisherJWT.Key != "" {
+			m.PublisherJWT.Alg = repl.ReplaceKnown(m.PublisherJWT.Alg, "HS256")
+			if m.PublisherJWT.Alg == "" {
+				m.PublisherJWT.Alg = "HS256"
+			}
+		} else if !AllowNoPublish {
+			return errors.New("a JWT key or the URL of a JWK Set for publishers must be provided") //nolint:err113
+		}
+	}
+
+	if m.SubscriberJWKSURL == "" {
+		m.SubscriberJWT.Key = repl.ReplaceKnown(m.SubscriberJWT.Key, "")
+		m.SubscriberJWT.Alg = repl.ReplaceKnown(m.SubscriberJWT.Alg, "HS256")
+
+		if m.SubscriberJWT.Key == "" {
+			if !m.Anonymous {
+				return errors.New("a JWT key or the URL of a JWK Set for subscribers must be provided") //nolint:err113
+			}
+		}
+
+		if m.SubscriberJWT.Alg == "" {
+			m.SubscriberJWT.Alg = "HS256"
+		}
+	}
+
+	return nil
+}
+
+// newJWKSetKeyfunc builds a Keyfunc from a JWK Set URL.
+//
+// file:// URLs point to a local JSON file containing a JWK Set; the file is
+// read once at provision time, so rotating the keys requires a Caddy config
+// reload. Other URLs are forwarded to keyfunc.NewDefaultCtx, which handles
+// HTTP(S) and rejects unsupported schemes.
+//
+//nolint:ireturn
+func newJWKSetKeyfunc(ctx context.Context, rawURL string) (keyfunc.Keyfunc, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid JWK Set URL %q: %w", rawURL, err)
+	}
+
+	if u.Scheme == "file" {
+		if u.Host != "" && u.Host != "localhost" {
+			return nil, fmt.Errorf(`file:// JWK Set URL host must be empty or "localhost", got %q`, u.Host) //nolint:err113
+		}
+
+		b, err := os.ReadFile(u.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read JWK Set file %q: %w", u.Path, err)
+		}
+
+		k, err := keyfunc.NewJWKSetJSON(b)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse JWK Set file %q: %w", u.Path, err)
+		}
+
+		return k, nil
+	}
+
+	return keyfunc.NewDefaultCtx(ctx, []string{rawURL}) //nolint:wrapcheck
+}
+
 // parseCaddyfile unmarshals tokens from h into a new Middleware.
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) { //nolint:ireturn
-	var m Mercure
+	m := new(Mercure)
 
 	return m, m.UnmarshalCaddyfile(h.Dispenser)
 }
 
 func parseDurationParameter(d *caddyfile.Dispenser) (*caddy.Duration, error) {
 	if !d.NextArg() {
-		return nil, d.ArgErr()
+		return nil, d.ArgErr() //nolint:wrapcheck
 	}
 
 	du, err := caddy.ParseDuration(d.Val())
 	if err != nil {
-		return nil, d.WrapErr(err)
+		return nil, d.WrapErr(err) //nolint:wrapcheck
 	}
 
 	cd := caddy.Duration(du)

--- a/caddy/mercure_deprecated_transport.go
+++ b/caddy/mercure_deprecated_transport.go
@@ -16,7 +16,7 @@ import (
 var transports = caddy.NewUsagePool() //nolint:gochecknoglobals
 // Deprecated
 //
-//nolint:wrapcheck,ireturn
+//nolint:wrapcheck,ireturn,nilnil
 func (m *Mercure) createTransportDeprecated() (mercure.Transport, error) {
 	if m.TransportURL == "" {
 		return nil, nil
@@ -41,7 +41,7 @@ func (m *Mercure) createTransportDeprecated() (mercure.Transport, error) {
 
 		u.RawQuery = query.Encode()
 
-		transport, err := mercure.NewTransport(u, m.logger)
+		transport, err := mercure.NewTransport(u, m.logger) //nolint:staticcheck
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- The `caddy/` submodule was not covered by `golangci-lint` in CI. Wire it
  into the workflow with the same config and `--timeout=30m`.
- Clean up the issues the linter surfaced once it ran on `caddy/`.

## Notable code changes in caddy/

- Normalize `Bolt`, `Local`, `Health`, `Mercure` to pointer receivers
  everywhere (`recvcheck`); register the modules as `&T{}` so the `Module`
  interface is still satisfied.
- Move the embedded `deprecatedTransport` before the regular `Mercure`
  fields (`embeddedstructfieldcheck`) and reorder `populateJWTConfig`
  after the public methods (`funcorder`).
- Parse `subscriber_list_cache_size` with `strconv.Atoi` to drop an
  unchecked `uint64 -> int` conversion (`gosec G115`).
- Harden the test cookies with `HttpOnly`/`Secure`/`SameSite` (`gosec G124`).
- Rephrase the `AllowNoPublish` and `FindHub` doc comments so they start
  with the symbol name (`godoclint`).

## Config

The `replace github.com/dunglas/mercure => ../` directive in `caddy/go.mod`
is required for the submodule to resolve the parent package, so
`gomoddirectives.replace-local` is enabled rather than the line excluded
per-occurrence.