### PR TITLE
ci(chart): use correct ghaction-import-gpg output name

### DIFF
--- a/.github/workflows/cd-chart.yml
+++ b/.github/workflows/cd-chart.yml
@@ -40,7 +40,7 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
           # `helm package --sign --key` substring-matches User IDs only
           # (fingerprint/keyid lookups fail), so pass the full UID.
-          KEY_UID: ${{ steps.import_gpg.outputs.userid }}
+          KEY_UID: ${{ steps.import_gpg.outputs.user }}
         run: |
           umask 077
           mkdir -p .cr-release-packages


### PR DESCRIPTION
## Summary

`cd-chart.yml` references `steps.import_gpg.outputs.userid`, but `crazy-max/ghaction-import-gpg@v7` doesn't expose `userid`. Its outputs are `fingerprint`, `keyid`, `name`, `email`, and `user` (the full UID `Name <email>`). The substitution silently resolved to an empty string, so the `helm package --sign --key "$KEY_UID"` step failed with `Error: --key is required for signing a package` on the [v0.24.1 release run](https://github.com/dunglas/mercure/actions/runs/25919661777), and the chart tarball never got attached.

Switching to `outputs.user` matches the inline comment ("pass the full UID").

Verified locally: `helm package --sign --key "Kévin Dunglas <dunglas@gmail.com>" ...` produces a `.tgz` + `.prov` pair that `helm verify` accepts.

v0.24.1's `mercure-0.24.1.tgz` was attached manually as a stopgap; this fix unbreaks future releases.