### PR TITLE
chore: automate releases via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,234 @@
+name: Release
+# Cuts a Mercure release end-to-end: bumps the Caddy module's mercure
+# dependency, bumps the Helm chart version, regenerates chart docs,
+# commits the result as github-actions[bot], tags v<version> and
+# caddy/v<version>, and dispatches the downstream build workflow which
+# drafts the GitHub release through GoReleaser. Dispatched by release.sh.
+#
+# The workflow is idempotent: re-dispatching after a partial failure
+# (network blip, registry hiccup) detects which steps already completed
+# and skips them, so the release can be resumed without manual cleanup.
+on:
+  workflow_dispatch:
+    inputs:
+      #checkov:skip=CKV_GHA_7
+      version:
+        description: "Version to release (e.g. 0.25.0, no v prefix)"
+        required: true
+        type: string
+permissions:
+  contents: write
+  # Needed to dispatch the downstream build workflow from this run.
+  actions: write
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+jobs:
+  release:
+    name: Release ${{ inputs.version }}
+    runs-on: ubuntu-latest
+    environment: release
+    env:
+      GOTOOLCHAIN: local
+      GOFLAGS: "-tags=deprecated_server,deprecated_transport,nobadger,nomysql,nopgx"
+    steps:
+      - name: Refuse non-main dispatch
+        # workflow_dispatch can target any ref; reject anything but main so a
+        # mis-dispatched run fails loudly instead of being silently skipped.
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::release.yml must be dispatched against refs/heads/main, got ${GITHUB_REF}"
+            exit 1
+          fi
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Determine release state
+        id: state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        # Tag existence is the source of truth for "release in progress":
+        # main HEAD may have moved past the release commit (a follow-up fix
+        # merged on top), so the commit-message check on HEAD is too narrow.
+        # If v<version> exists, resume from the commit it points at;
+        # otherwise it's a fresh attempt and tags must not exist.
+        run: |
+          set -euo pipefail
+          err=$(mktemp)
+          trap 'rm -f "${err}"' EXIT
+          # Capture stderr so we can distinguish a real 404 (tag absent → fresh
+          # attempt) from any other failure (rate limit, 5xx, auth) which must
+          # not be silently treated as "tag missing".
+          if ref=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/v${VERSION}" 2>"${err}"); then
+            sha=$(jq -r .object.sha <<<"${ref}")
+            type=$(jq -r .object.type <<<"${ref}")
+            if [[ "${type}" == "tag" ]]; then
+              sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${sha}" -q .object.sha)
+            fi
+            # Refuse to resume against a tag that isn't reachable from main:
+            # protects against an orphan tag created on a side branch.
+            if ! git merge-base --is-ancestor "${sha}" HEAD; then
+              echo "::error::Tag v${VERSION} (${sha}) is not reachable from main; refusing to resume."
+              exit 1
+            fi
+            echo "Resuming: v${VERSION} exists at ${sha}"
+            {
+              echo "resume=true"
+              echo "release_commit=${sha}"
+            } >> "${GITHUB_OUTPUT}"
+          elif grep -qF "(HTTP 404)" "${err}"; then
+            echo "resume=false" >> "${GITHUB_OUTPUT}"
+            if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/caddy/v${VERSION}" --silent 2>/dev/null; then
+              echo "::error::caddy/v${VERSION} exists but v${VERSION} does not; refusing to release into a split state."
+              exit 1
+            fi
+          else
+            echo "::error::GitHub API call for tag v${VERSION} failed:"
+            cat "${err}" >&2
+            exit 1
+          fi
+      - if: steps.state.outputs.resume != 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache-dependency-path: |
+            go.sum
+            caddy/go.sum
+      - if: steps.state.outputs.resume != 'true'
+        name: Install helm-docs
+        # Mercure's chart README is generated; helm-docs ensures the
+        # version/appVersion badges match Chart.yaml after the bump.
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+      - if: steps.state.outputs.resume != 'true'
+        name: Bump Caddy module
+        working-directory: caddy
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          go get "github.com/dunglas/mercure@v${VERSION}"
+          go mod tidy
+      - if: steps.state.outputs.resume != 'true'
+        name: Bump Helm chart
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i \
+            -e "s/^version: .*$/version: ${VERSION}/" \
+            -e "s/^appVersion: .*$/appVersion: \"v${VERSION}\"/" \
+            charts/mercure/Chart.yaml
+          helm-docs
+      - name: Commit and tag via GitHub API
+        # API-created commits/tags are signed server-side with GitHub's key
+        # and show as "Verified" under the github-actions[bot] identity.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ inputs.version }}
+          RESUME: ${{ steps.state.outputs.resume }}
+          RELEASE_COMMIT: ${{ steps.state.outputs.release_commit }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${RESUME}" == "true" ]]; then
+            commit_sha="${RELEASE_COMMIT}"
+            echo "Reusing existing release commit ${commit_sha}"
+          else
+            # Stage the base64 in a temp file and feed it to jq via
+            # --rawfile: passing big blobs through --arg can exceed ARG_MAX
+            # on the runner. Subshell body + EXIT trap clean up the tmpfile
+            # even if base64/jq/gh aborts.
+            make_blob() (
+              local tmp
+              tmp=$(mktemp)
+              trap 'rm -f "$tmp"' EXIT
+              base64 -w0 <"$1" >"$tmp"
+              jq -nc --rawfile content "$tmp" \
+                '{content: $content, encoding: "base64"}' \
+                | gh api "repos/${REPO}/git/blobs" --input - -q .sha
+            )
+
+            parent_sha=$(gh api "repos/${REPO}/git/refs/heads/main" -q .object.sha)
+            base_tree=$(gh api "repos/${REPO}/git/commits/${parent_sha}" -q .tree.sha)
+
+            gomod_sha=$(make_blob caddy/go.mod)
+            gosum_sha=$(make_blob caddy/go.sum)
+            chart_sha=$(make_blob charts/mercure/Chart.yaml)
+            readme_sha=$(make_blob charts/mercure/README.md)
+
+            tree_sha=$(jq -nc \
+              --arg base_tree "$base_tree" \
+              --arg gomod "$gomod_sha" \
+              --arg gosum "$gosum_sha" \
+              --arg chart "$chart_sha" \
+              --arg readme "$readme_sha" \
+              '{
+                base_tree: $base_tree,
+                tree: [
+                  {path: "caddy/go.mod", mode: "100644", type: "blob", sha: $gomod},
+                  {path: "caddy/go.sum", mode: "100644", type: "blob", sha: $gosum},
+                  {path: "charts/mercure/Chart.yaml", mode: "100644", type: "blob", sha: $chart},
+                  {path: "charts/mercure/README.md", mode: "100644", type: "blob", sha: $readme}
+                ]
+              }' | gh api "repos/${REPO}/git/trees" --input - -q .sha)
+
+            # [skip ci] keeps push-triggered workflows from firing on top of
+            # the explicit downstream dispatch below.
+            commit_sha=$(jq -nc \
+              --arg message "chore: prepare release ${VERSION} [skip ci]" \
+              --arg tree "$tree_sha" \
+              --arg parent "$parent_sha" \
+              '{message: $message, tree: $tree, parents: [$parent]}' \
+              | gh api "repos/${REPO}/git/commits" --input - -q .sha)
+
+            gh api "repos/${REPO}/git/refs/heads/main" -X PATCH -f sha="$commit_sha" --silent
+          fi
+
+          # Idempotent tag creation: if the tag already exists and points at
+          # the release commit, leave it alone; if it points elsewhere, fail.
+          create_tag() {
+            local tag="$1"
+            local existing
+            if existing=$(gh api "repos/${REPO}/git/refs/tags/${tag}" 2>/dev/null); then
+              local obj_sha obj_type
+              obj_sha=$(jq -r .object.sha <<<"${existing}")
+              obj_type=$(jq -r .object.type <<<"${existing}")
+              if [[ "${obj_type}" == "tag" ]]; then
+                obj_sha=$(gh api "repos/${REPO}/git/tags/${obj_sha}" -q .object.sha)
+              fi
+              if [[ "${obj_sha}" == "${commit_sha}" ]]; then
+                echo "Tag ${tag} already points at ${commit_sha}; skipping."
+                return 0
+              fi
+              echo "::error::Tag ${tag} exists at ${obj_sha}, expected ${commit_sha}"
+              return 1
+            fi
+            local tag_sha
+            tag_sha=$(jq -nc \
+              --arg tag "${tag}" \
+              --arg message "Version ${VERSION}" \
+              --arg object "${commit_sha}" \
+              '{tag: $tag, message: $message, object: $object, type: "commit"}' \
+              | gh api "repos/${REPO}/git/tags" --input - -q .sha)
+            gh api "repos/${REPO}/git/refs" -f ref="refs/tags/${tag}" -f sha="${tag_sha}" --silent
+          }
+
+          create_tag "v${VERSION}"
+          create_tag "caddy/v${VERSION}"
+      - name: Trigger downstream release build
+        # GITHUB_TOKEN-driven API writes don't trigger workflows that listen
+        # on tag/push events, so dispatch cd.yml explicitly against the new
+        # tag. GoReleaser handles artifact builds and drafts the GitHub
+        # release; cd-chart.yml fires automatically once the release is
+        # published. Re-dispatch on resume is harmless: it just queues
+        # another build run.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! gh workflow run cd.yml --repo "${REPO}" --ref "v${VERSION}"; then
+            echo "::warning::Failed to dispatch cd.yml. Re-run it manually against v${VERSION}."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,7 @@
 name: Release
-# Cuts a Mercure release end-to-end: bumps the Caddy module's mercure
-# dependency, bumps the Helm chart version, regenerates chart docs,
-# commits the result as github-actions[bot], tags v<version> and
-# caddy/v<version>, and dispatches the downstream build workflow which
-# drafts the GitHub release through GoReleaser. Dispatched by release.sh.
-#
-# The workflow is idempotent: re-dispatching after a partial failure
-# (network blip, registry hiccup) detects which steps already completed
-# and skips them, so the release can be resumed without manual cleanup.
+# Bumps caddy/go.mod and the Helm chart, commits as github-actions[bot],
+# tags v<version> and caddy/v<version>, and dispatches cd.yml.
+# Idempotent: a re-dispatch after a partial failure resumes by tag.
 on:
   workflow_dispatch:
     inputs:
@@ -18,8 +12,7 @@ on:
         type: string
 permissions:
   contents: write
-  # Needed to dispatch the downstream build workflow from this run.
-  actions: write
+  actions: write # to dispatch cd.yml
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -32,13 +25,10 @@ jobs:
       GOTOOLCHAIN: local
     steps:
       - name: Validate inputs
-        # UI-triggered dispatches bypass release.sh's preflight regex, so
-        # re-validate the version string here. Any payload that would not
-        # produce a clean semver tag is rejected before it propagates into
-        # go get / sed / tag refs and breaks the release in mid-flight.
+        # Reject non-main refs and non-semver versions before they reach
+        # go get / sed / tag refs. https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         env:
           VERSION: ${{ inputs.version }}
-        # Adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         run: |
           if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
             echo "::error::release.yml must be dispatched against refs/heads/main, got ${GITHUB_REF}"
@@ -57,17 +47,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
-        # Tag existence is the source of truth for "release in progress":
-        # main HEAD may have moved past the release commit (a follow-up fix
-        # merged on top), so the commit-message check on HEAD is too narrow.
-        # If v<version> exists, resume from the commit it points at;
-        # otherwise it's a fresh attempt and tags must not exist.
+        # Tag existence is the resume signal — main HEAD may have moved
+        # past the release commit, so a HEAD message check is too narrow.
         run: |
           set -euo pipefail
-          # matching-refs returns an empty array (still HTTP 200) when the ref
-          # is absent — no need to parse error wording to distinguish 404
-          # from rate-limit/5xx/auth failures, which `gh` still surfaces as a
-          # non-zero exit through `set -e`.
+          # matching-refs returns [] (HTTP 200) for absent tags; real
+          # failures still trip set -e.
           lookup_tag() {
             gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/$1" \
               --jq ".[] | select(.ref == \"refs/tags/$1\") | {sha: .object.sha, type: .object.type}"
@@ -87,16 +72,12 @@ jobs:
           caddy_entry=$(lookup_tag "caddy/v${VERSION}")
           if [[ -n "${main_entry}" ]]; then
             sha=$(resolve_commit "${main_entry}")
-            # Refuse to resume against a tag that isn't reachable from main:
-            # protects against an orphan tag created on a side branch.
+            # Reject orphan tags created on a side branch.
             if ! git merge-base --is-ancestor "${sha}" HEAD; then
               echo "::error::Tag v${VERSION} (${sha}) is not reachable from main; refusing to resume."
               exit 1
             fi
-            # Symmetric split-state guard: the create_tag step further down
-            # also fails if caddy/v${VERSION} points to a different commit,
-            # but flagging the inconsistency here surfaces it before any
-            # writes happen.
+            # Catch a mismatched caddy/v${VERSION} before any writes.
             if [[ -n "${caddy_entry}" ]]; then
               caddy_sha=$(resolve_commit "${caddy_entry}")
               if [[ "${caddy_sha}" != "${sha}" ]]; then
@@ -126,10 +107,7 @@ jobs:
             caddy/go.sum
       - if: steps.state.outputs.resume != 'true'
         name: Install helm-docs
-        # Mercure's chart README is generated; helm-docs ensures the
-        # version/appVersion badges match Chart.yaml after the bump.
-        # Pin the version so two re-runs of the same release produce the
-        # same README byte-for-byte.
+        # Pinned so two re-runs of the same release produce the same README.
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
       - if: steps.state.outputs.resume != 'true'
         name: Bump Caddy module
@@ -150,8 +128,8 @@ jobs:
             charts/mercure/Chart.yaml
           helm-docs
       - name: Commit and tag via GitHub API
-        # API-created commits/tags are signed server-side with GitHub's key
-        # and show as "Verified" under the github-actions[bot] identity.
+        # API-created commits/tags are signed server-side and show as
+        # Verified under github-actions[bot].
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -165,10 +143,7 @@ jobs:
             commit_sha="${RELEASE_COMMIT}"
             echo "Reusing existing release commit ${commit_sha}"
           else
-            # Stage the base64 in a temp file and feed it to jq via
-            # --rawfile: passing big blobs through --arg can exceed ARG_MAX
-            # on the runner. Subshell body + EXIT trap clean up the tmpfile
-            # even if base64/jq/gh aborts.
+            # Use --rawfile: large blobs via --arg can exceed ARG_MAX.
             make_blob() (
               local tmp
               tmp=$(mktemp)
@@ -182,11 +157,8 @@ jobs:
             parent_sha=$(gh api "repos/${REPO}/git/refs/heads/main" -q .object.sha)
             base_tree=$(gh api "repos/${REPO}/git/commits/${parent_sha}" -q .tree.sha)
 
-            # Collect every tracked file modified by the bump/helm-docs
-            # steps so that, e.g., a transitive update to the top-level
-            # go.sum or a second helm-docs README doesn't get silently
-            # dropped from the release commit. Matches the old
-            # `git commit -a` behavior.
+            # Capture every touched file so transitive go.sum or helm-docs
+            # side effects aren't dropped from the release commit.
             mapfile -t changed < <(git diff --name-only HEAD)
             if [[ ${#changed[@]} -eq 0 ]]; then
               echo "::error::No file changes detected after bump steps."
@@ -208,8 +180,8 @@ jobs:
               '{base_tree: $base_tree, tree: $entries}' \
               | gh api "repos/${REPO}/git/trees" --input - -q .sha)
 
-            # [skip ci] keeps push-triggered workflows from firing on top of
-            # the explicit downstream dispatch below.
+            # [skip ci] avoids push-triggered workflows firing alongside
+            # the explicit cd.yml dispatch below.
             commit_sha=$(jq -nc \
               --arg message "chore: prepare release ${VERSION} [skip ci]" \
               --arg tree "$tree_sha" \
@@ -220,8 +192,8 @@ jobs:
             gh api "repos/${REPO}/git/refs/heads/main" -X PATCH -f sha="$commit_sha" --silent
           fi
 
-          # Idempotent tag creation: if the tag already exists and points at
-          # the release commit, leave it alone; if it points elsewhere, fail.
+          # Idempotent: skip if tag already points at the release commit,
+          # fail if it points elsewhere.
           create_tag() {
             local tag="$1"
             local existing
@@ -252,16 +224,9 @@ jobs:
           create_tag "v${VERSION}"
           create_tag "caddy/v${VERSION}"
       - name: Trigger downstream release build
-        # GITHUB_TOKEN-driven API writes don't trigger workflows that listen
-        # on tag/push events, so dispatch cd.yml explicitly against the new
-        # tag. GoReleaser handles artifact builds and drafts the GitHub
-        # release; cd-chart.yml fires automatically once the release is
-        # published.
-        #
-        # On resume, skip dispatch if a prior cd.yml run already succeeded
-        # or is still in-flight: GoReleaser's "release" step refuses to
-        # overwrite an existing release and would fail noisily. Failed
-        # runs are eligible for retry.
+        # GITHUB_TOKEN tag writes don't fire push triggers, so dispatch
+        # cd.yml explicitly. Skip if a prior run is in-flight or succeeded
+        # — GoReleaser refuses to overwrite an existing release.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
           VERSION: ${{ inputs.version }}
         # Tag existence is the resume signal — main HEAD may have moved
         # past the release commit, so a HEAD message check is too narrow.
+        # As a fallback, also detect a release-shaped commit already on
+        # main without tags (a previous run that pushed main but failed
+        # before create_tag).
         run: |
           set -euo pipefail
           # matching-refs returns [] (HTTP 200) for absent tags; real
@@ -71,6 +74,23 @@ jobs:
               printf '%s\n' "${sha}"
             fi
           }
+          # Match the require entry in both `require ( ... )` block form
+          # and single-line `require x v...` form.
+          verify_release_content() {
+            local ref="$1"
+            local chart_version
+            chart_version=$(git show "${ref}:charts/mercure/Chart.yaml" 2>/dev/null \
+              | awk '/^version:/ {print $2; exit}')
+            if [[ "${chart_version}" != "${VERSION}" ]]; then
+              echo "${ref}: Chart.yaml version '${chart_version}' != '${VERSION}'" >&2
+              return 1
+            fi
+            if ! git show "${ref}:caddy/go.mod" 2>/dev/null \
+              | grep -qE "(^|[[:space:]])github\\.com/dunglas/mercure v${VERSION//./\\.}([[:space:]]|\$)"; then
+              echo "${ref}: caddy/go.mod does not require mercure v${VERSION}" >&2
+              return 1
+            fi
+          }
           main_entry=$(lookup_tag "v${VERSION}")
           caddy_entry=$(lookup_tag "caddy/v${VERSION}")
           if [[ -n "${main_entry}" ]]; then
@@ -88,22 +108,23 @@ jobs:
                 exit 1
               fi
             fi
-            # Verify the tagged commit actually contains the expected
-            # bump — protects against a tag created manually or by an
-            # earlier run on stale code.
             git fetch --quiet origin "refs/tags/v${VERSION}:refs/tags/v${VERSION}"
-            chart_version=$(git show "v${VERSION}:charts/mercure/Chart.yaml" \
-              | awk '/^version:/ {print $2; exit}')
-            if [[ "${chart_version}" != "${VERSION}" ]]; then
-              echo "::error::v${VERSION} (${sha}) has Chart.yaml version '${chart_version}', expected '${VERSION}'."
-              exit 1
-            fi
-            if ! git show "v${VERSION}:caddy/go.mod" \
-              | grep -qE "^[[:space:]]+github\\.com/dunglas/mercure v${VERSION//./\\.}\$"; then
-              echo "::error::v${VERSION} (${sha}) caddy/go.mod does not require mercure v${VERSION}."
+            if ! verify_release_content "v${VERSION}"; then
+              echo "::error::v${VERSION} (${sha}) does not match expected release content."
               exit 1
             fi
             echo "Resuming: v${VERSION} exists at ${sha}"
+            {
+              echo "resume=true"
+              echo "release_commit=${sha}"
+            } >> "${GITHUB_OUTPUT}"
+          elif verify_release_content HEAD 2>/dev/null; then
+            if [[ -n "${caddy_entry}" ]]; then
+              echo "::error::caddy/v${VERSION} exists but v${VERSION} does not; refusing to release into a split state."
+              exit 1
+            fi
+            sha=$(git rev-parse HEAD)
+            echo "Resuming: main HEAD (${sha}) already matches v${VERSION}; tags will be created."
             {
               echo "resume=true"
               echo "release_commit=${sha}"
@@ -172,7 +193,15 @@ jobs:
                 | gh api "repos/${REPO}/git/blobs" --input - -q .sha
             )
 
+            # Concurrency is per-version, so a different version could
+            # land on main while this run is in flight. Abort rather than
+            # overlay our locally-bumped files on top of unseen commits.
+            checkout_sha=$(git rev-parse HEAD)
             parent_sha=$(gh api "repos/${REPO}/git/refs/heads/main" -q .object.sha)
+            if [[ "${checkout_sha}" != "${parent_sha}" ]]; then
+              echo "::error::main advanced from ${checkout_sha} to ${parent_sha} during the run; refusing to overlay locally-modified files on a newer base_tree."
+              exit 1
+            fi
             base_tree=$(gh api "repos/${REPO}/git/commits/${parent_sha}" -q .tree.sha)
 
             # Capture every touched file (modifications, additions,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,21 +157,33 @@ jobs:
             parent_sha=$(gh api "repos/${REPO}/git/refs/heads/main" -q .object.sha)
             base_tree=$(gh api "repos/${REPO}/git/commits/${parent_sha}" -q .tree.sha)
 
-            # Capture every touched file so transitive go.sum or helm-docs
-            # side effects aren't dropped from the release commit.
-            mapfile -t changed < <(git diff --name-only HEAD)
-            if [[ ${#changed[@]} -eq 0 ]]; then
-              echo "::error::No file changes detected after bump steps."
+            # Capture every touched file (modifications, additions,
+            # deletions) so transitive go.sum or helm-docs side effects
+            # aren't dropped from the release commit. Deletions are
+            # represented with a null sha in the tree.
+            mapfile -t modified < <(git diff --name-only --diff-filter=ACMR HEAD)
+            mapfile -t deleted < <(git diff --name-only --diff-filter=D HEAD)
+            mapfile -t untracked < <(git ls-files --others --exclude-standard)
+            if [[ ${#modified[@]} -eq 0 && ${#deleted[@]} -eq 0 && ${#untracked[@]} -eq 0 ]]; then
+              echo "::error::No file changes after bump/helm-docs. Is v${VERSION} already on main? Delete the local tags and pick a different version, or recreate the tags manually."
               exit 1
             fi
-            printf 'Including in release tree: %s\n' "${changed[@]}"
+            present=("${modified[@]}" "${untracked[@]}")
+            [[ ${#present[@]} -gt 0 ]] && printf 'Including (added/modified): %s\n' "${present[@]}"
+            [[ ${#deleted[@]} -gt 0 ]] && printf 'Including (deleted): %s\n' "${deleted[@]}"
 
             tree_entries=$(
-              for path in "${changed[@]}"; do
-                sha=$(make_blob "${path}")
-                jq -nc --arg path "${path}" --arg sha "${sha}" \
-                  '{path: $path, mode: "100644", type: "blob", sha: $sha}'
-              done | jq -sc .
+              {
+                for path in "${modified[@]}" "${untracked[@]}"; do
+                  sha=$(make_blob "${path}")
+                  jq -nc --arg path "${path}" --arg sha "${sha}" \
+                    '{path: $path, mode: "100644", type: "blob", sha: $sha}'
+                done
+                for path in "${deleted[@]}"; do
+                  jq -nc --arg path "${path}" \
+                    '{path: $path, mode: "100644", type: "blob", sha: null}'
+                done
+              } | jq -sc .
             )
 
             tree_sha=$(jq -nc \
@@ -193,14 +205,18 @@ jobs:
           fi
 
           # Idempotent: skip if tag already points at the release commit,
-          # fail if it points elsewhere.
+          # fail if it points elsewhere. matching-refs distinguishes
+          # "tag absent" (HTTP 200, empty array) from real failures, which
+          # still trip set -e.
           create_tag() {
             local tag="$1"
             local existing
-            if existing=$(gh api "repos/${REPO}/git/refs/tags/${tag}" 2>/dev/null); then
+            existing=$(gh api "repos/${REPO}/git/matching-refs/tags/${tag}" \
+              --jq ".[] | select(.ref == \"refs/tags/${tag}\") | {sha: .object.sha, type: .object.type}")
+            if [[ -n "${existing}" ]]; then
               local obj_sha obj_type
-              obj_sha=$(jq -r .object.sha <<<"${existing}")
-              obj_type=$(jq -r .object.type <<<"${existing}")
+              obj_sha=$(jq -r .sha <<<"${existing}")
+              obj_type=$(jq -r .type <<<"${existing}")
               if [[ "${obj_type}" == "tag" ]]; then
                 obj_sha=$(gh api "repos/${REPO}/git/tags/${obj_sha}" -q .object.sha)
               fi
@@ -225,30 +241,30 @@ jobs:
           create_tag "caddy/v${VERSION}"
       - name: Trigger downstream release build
         # GITHUB_TOKEN tag writes don't fire push triggers, so dispatch
-        # cd.yml explicitly. Skip if a prior run is in-flight or succeeded
-        # — GoReleaser refuses to overwrite an existing release.
+        # cd.yml explicitly. Skip if a GitHub Release for v${VERSION}
+        # already exists (GoReleaser drafts it and refuses to overwrite),
+        # or if a cd.yml run for the tag is still in flight.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          last_run=$(gh run list \
-            --repo "${REPO}" \
-            --workflow cd.yml \
-            --branch "v${VERSION}" \
-            --json databaseId,status,conclusion \
-            --jq '.[0] // empty')
-          if [[ -n "${last_run}" ]]; then
-            status=$(jq -r .status <<<"${last_run}")
-            conclusion=$(jq -r .conclusion <<<"${last_run}")
-            run_id=$(jq -r .databaseId <<<"${last_run}")
-            if [[ "${status}" != "completed" || "${conclusion}" == "success" ]]; then
-              echo "cd.yml run ${run_id} for v${VERSION} is ${status}/${conclusion:-none}; skipping dispatch."
-              exit 0
-            fi
-            echo "Previous cd.yml run ${run_id} ended as ${conclusion}; redispatching."
+          if gh release view "v${VERSION}" --repo "${REPO}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists; skipping cd.yml dispatch."
+            exit 0
+          fi
+          # head_branch on the runs API is the bare tag name (e.g.
+          # v0.25.0), regardless of gh CLI version quirks.
+          in_flight=$(gh api -X GET \
+            "repos/${REPO}/actions/workflows/cd.yml/runs" \
+            -F "branch=v${VERSION}" \
+            --jq '[.workflow_runs[] | select(.status != "completed")] | length')
+          if [[ "${in_flight}" -gt 0 ]]; then
+            echo "A cd.yml run for v${VERSION} is in flight; skipping dispatch."
+            exit 0
           fi
           if ! gh workflow run cd.yml --repo "${REPO}" --ref "v${VERSION}"; then
-            echo "::warning::Failed to dispatch cd.yml. Re-run it manually against v${VERSION}."
+            echo "::error::Failed to dispatch cd.yml against v${VERSION}."
+            exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,10 @@ permissions:
   contents: write
   actions: write # to dispatch cd.yml
 concurrency:
-  group: ${{ github.workflow }}
+  # Per-version: different versions race safely (the API parent_sha
+  # check rejects a stale main HEAD update); same-version dispatches
+  # serialize so resume logic isn't blocked by a pending approval.
+  group: ${{ github.workflow }}-${{ inputs.version }}
   cancel-in-progress: false
 jobs:
   release:
@@ -84,6 +87,21 @@ jobs:
                 echo "::error::caddy/v${VERSION} (${caddy_sha}) does not match v${VERSION} (${sha})."
                 exit 1
               fi
+            fi
+            # Verify the tagged commit actually contains the expected
+            # bump — protects against a tag created manually or by an
+            # earlier run on stale code.
+            git fetch --quiet origin "refs/tags/v${VERSION}:refs/tags/v${VERSION}"
+            chart_version=$(git show "v${VERSION}:charts/mercure/Chart.yaml" \
+              | awk '/^version:/ {print $2; exit}')
+            if [[ "${chart_version}" != "${VERSION}" ]]; then
+              echo "::error::v${VERSION} (${sha}) has Chart.yaml version '${chart_version}', expected '${VERSION}'."
+              exit 1
+            fi
+            if ! git show "v${VERSION}:caddy/go.mod" \
+              | grep -qE "^[[:space:]]+github\\.com/dunglas/mercure v${VERSION//./\\.}\$"; then
+              echo "::error::v${VERSION} (${sha}) caddy/go.mod does not require mercure v${VERSION}."
+              exit 1
             fi
             echo "Resuming: v${VERSION} exists at ${sha}"
             {
@@ -159,10 +177,11 @@ jobs:
 
             # Capture every touched file (modifications, additions,
             # deletions) so transitive go.sum or helm-docs side effects
-            # aren't dropped from the release commit. Deletions are
-            # represented with a null sha in the tree.
-            mapfile -t modified < <(git diff --name-only --diff-filter=ACMR HEAD)
-            mapfile -t deleted < <(git diff --name-only --diff-filter=D HEAD)
+            # aren't dropped from the release commit. --no-renames
+            # decomposes renames into add+delete so both halves land in
+            # the tree mutation.
+            mapfile -t modified < <(git diff --no-renames --name-only --diff-filter=ACM HEAD)
+            mapfile -t deleted < <(git diff --no-renames --name-only --diff-filter=D HEAD)
             mapfile -t untracked < <(git ls-files --others --exclude-standard)
             if [[ ${#modified[@]} -eq 0 && ${#deleted[@]} -eq 0 && ${#untracked[@]} -eq 0 ]]; then
               echo "::error::No file changes after bump/helm-docs. Is v${VERSION} already on main? Delete the local tags and pick a different version, or recreate the tags manually."
@@ -172,16 +191,31 @@ jobs:
             [[ ${#present[@]} -gt 0 ]] && printf 'Including (added/modified): %s\n' "${present[@]}"
             [[ ${#deleted[@]} -gt 0 ]] && printf 'Including (deleted): %s\n' "${deleted[@]}"
 
+            # Preserve the existing file mode (executable bit) when
+            # modifying tracked files; default to 100644 for new files
+            # unless the path is executable on disk.
+            mode_for() {
+              local path="$1" mode
+              mode=$(git ls-tree HEAD -- "$path" | awk '{print $1; exit}')
+              if [[ -n "$mode" ]]; then
+                printf '%s\n' "$mode"
+              elif [[ -x "$path" ]]; then
+                printf '100755\n'
+              else
+                printf '100644\n'
+              fi
+            }
+
             tree_entries=$(
               {
                 for path in "${modified[@]}" "${untracked[@]}"; do
                   sha=$(make_blob "${path}")
-                  jq -nc --arg path "${path}" --arg sha "${sha}" \
-                    '{path: $path, mode: "100644", type: "blob", sha: $sha}'
+                  jq -nc --arg path "${path}" --arg sha "${sha}" --arg mode "$(mode_for "${path}")" \
+                    '{path: $path, mode: $mode, type: "blob", sha: $sha}'
                 done
                 for path in "${deleted[@]}"; do
-                  jq -nc --arg path "${path}" \
-                    '{path: $path, mode: "100644", type: "blob", sha: null}'
+                  jq -nc --arg path "${path}" --arg mode "$(mode_for "${path}")" \
+                    '{path: $path, mode: $mode, type: "blob", sha: null}'
                 done
               } | jq -sc .
             )
@@ -242,8 +276,9 @@ jobs:
       - name: Trigger downstream release build
         # GITHUB_TOKEN tag writes don't fire push triggers, so dispatch
         # cd.yml explicitly. Skip if a GitHub Release for v${VERSION}
-        # already exists (GoReleaser drafts it and refuses to overwrite),
-        # or if a cd.yml run for the tag is still in flight.
+        # already exists — .goreleaser.yml sets `release.draft: true`, so
+        # `gh release view` matches drafts as well, and GoReleaser refuses
+        # to overwrite. Also skip if a cd.yml run for the tag is in flight.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,22 @@ jobs:
     environment: release
     env:
       GOTOOLCHAIN: local
-      GOFLAGS: "-tags=deprecated_server,deprecated_transport,nobadger,nomysql,nopgx"
     steps:
-      - name: Refuse non-main dispatch
-        # workflow_dispatch can target any ref; reject anything but main so a
-        # mis-dispatched run fails loudly instead of being silently skipped.
+      - name: Validate inputs
+        # UI-triggered dispatches bypass release.sh's preflight regex, so
+        # re-validate the version string here. Any payload that would not
+        # produce a clean semver tag is rejected before it propagates into
+        # go get / sed / tag refs and breaks the release in mid-flight.
+        env:
+          VERSION: ${{ inputs.version }}
+        # Adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         run: |
           if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
             echo "::error::release.yml must be dispatched against refs/heads/main, got ${GITHUB_REF}"
+            exit 1
+          fi
+          if [[ ! ${VERSION} =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+            echo "::error::Invalid version: '${VERSION}' (must be SemVer, no v prefix)"
             exit 1
           fi
       - uses: actions/checkout@v6
@@ -56,38 +64,57 @@ jobs:
         # otherwise it's a fresh attempt and tags must not exist.
         run: |
           set -euo pipefail
-          err=$(mktemp)
-          trap 'rm -f "${err}"' EXIT
-          # Capture stderr so we can distinguish a real 404 (tag absent → fresh
-          # attempt) from any other failure (rate limit, 5xx, auth) which must
-          # not be silently treated as "tag missing".
-          if ref=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/v${VERSION}" 2>"${err}"); then
-            sha=$(jq -r .object.sha <<<"${ref}")
-            type=$(jq -r .object.type <<<"${ref}")
+          # matching-refs returns an empty array (still HTTP 200) when the ref
+          # is absent — no need to parse error wording to distinguish 404
+          # from rate-limit/5xx/auth failures, which `gh` still surfaces as a
+          # non-zero exit through `set -e`.
+          lookup_tag() {
+            gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/$1" \
+              --jq ".[] | select(.ref == \"refs/tags/$1\") | {sha: .object.sha, type: .object.type}"
+          }
+          resolve_commit() {
+            local entry="$1"
+            local sha type
+            sha=$(jq -r .sha <<<"${entry}")
+            type=$(jq -r .type <<<"${entry}")
             if [[ "${type}" == "tag" ]]; then
-              sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${sha}" -q .object.sha)
+              gh api "repos/${GITHUB_REPOSITORY}/git/tags/${sha}" -q .object.sha
+            else
+              printf '%s\n' "${sha}"
             fi
+          }
+          main_entry=$(lookup_tag "v${VERSION}")
+          caddy_entry=$(lookup_tag "caddy/v${VERSION}")
+          if [[ -n "${main_entry}" ]]; then
+            sha=$(resolve_commit "${main_entry}")
             # Refuse to resume against a tag that isn't reachable from main:
             # protects against an orphan tag created on a side branch.
             if ! git merge-base --is-ancestor "${sha}" HEAD; then
               echo "::error::Tag v${VERSION} (${sha}) is not reachable from main; refusing to resume."
               exit 1
             fi
+            # Symmetric split-state guard: the create_tag step further down
+            # also fails if caddy/v${VERSION} points to a different commit,
+            # but flagging the inconsistency here surfaces it before any
+            # writes happen.
+            if [[ -n "${caddy_entry}" ]]; then
+              caddy_sha=$(resolve_commit "${caddy_entry}")
+              if [[ "${caddy_sha}" != "${sha}" ]]; then
+                echo "::error::caddy/v${VERSION} (${caddy_sha}) does not match v${VERSION} (${sha})."
+                exit 1
+              fi
+            fi
             echo "Resuming: v${VERSION} exists at ${sha}"
             {
               echo "resume=true"
               echo "release_commit=${sha}"
             } >> "${GITHUB_OUTPUT}"
-          elif grep -qF "(HTTP 404)" "${err}"; then
-            echo "resume=false" >> "${GITHUB_OUTPUT}"
-            if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/caddy/v${VERSION}" --silent 2>/dev/null; then
+          else
+            if [[ -n "${caddy_entry}" ]]; then
               echo "::error::caddy/v${VERSION} exists but v${VERSION} does not; refusing to release into a split state."
               exit 1
             fi
-          else
-            echo "::error::GitHub API call for tag v${VERSION} failed:"
-            cat "${err}" >&2
-            exit 1
+            echo "resume=false" >> "${GITHUB_OUTPUT}"
           fi
       - if: steps.state.outputs.resume != 'true'
         uses: actions/setup-go@v6
@@ -101,7 +128,9 @@ jobs:
         name: Install helm-docs
         # Mercure's chart README is generated; helm-docs ensures the
         # version/appVersion badges match Chart.yaml after the bump.
-        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+        # Pin the version so two re-runs of the same release produce the
+        # same README byte-for-byte.
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
       - if: steps.state.outputs.resume != 'true'
         name: Bump Caddy module
         working-directory: caddy
@@ -153,26 +182,31 @@ jobs:
             parent_sha=$(gh api "repos/${REPO}/git/refs/heads/main" -q .object.sha)
             base_tree=$(gh api "repos/${REPO}/git/commits/${parent_sha}" -q .tree.sha)
 
-            gomod_sha=$(make_blob caddy/go.mod)
-            gosum_sha=$(make_blob caddy/go.sum)
-            chart_sha=$(make_blob charts/mercure/Chart.yaml)
-            readme_sha=$(make_blob charts/mercure/README.md)
+            # Collect every tracked file modified by the bump/helm-docs
+            # steps so that, e.g., a transitive update to the top-level
+            # go.sum or a second helm-docs README doesn't get silently
+            # dropped from the release commit. Matches the old
+            # `git commit -a` behavior.
+            mapfile -t changed < <(git diff --name-only HEAD)
+            if [[ ${#changed[@]} -eq 0 ]]; then
+              echo "::error::No file changes detected after bump steps."
+              exit 1
+            fi
+            printf 'Including in release tree: %s\n' "${changed[@]}"
+
+            tree_entries=$(
+              for path in "${changed[@]}"; do
+                sha=$(make_blob "${path}")
+                jq -nc --arg path "${path}" --arg sha "${sha}" \
+                  '{path: $path, mode: "100644", type: "blob", sha: $sha}'
+              done | jq -sc .
+            )
 
             tree_sha=$(jq -nc \
               --arg base_tree "$base_tree" \
-              --arg gomod "$gomod_sha" \
-              --arg gosum "$gosum_sha" \
-              --arg chart "$chart_sha" \
-              --arg readme "$readme_sha" \
-              '{
-                base_tree: $base_tree,
-                tree: [
-                  {path: "caddy/go.mod", mode: "100644", type: "blob", sha: $gomod},
-                  {path: "caddy/go.sum", mode: "100644", type: "blob", sha: $gosum},
-                  {path: "charts/mercure/Chart.yaml", mode: "100644", type: "blob", sha: $chart},
-                  {path: "charts/mercure/README.md", mode: "100644", type: "blob", sha: $readme}
-                ]
-              }' | gh api "repos/${REPO}/git/trees" --input - -q .sha)
+              --argjson entries "${tree_entries}" \
+              '{base_tree: $base_tree, tree: $entries}' \
+              | gh api "repos/${REPO}/git/trees" --input - -q .sha)
 
             # [skip ci] keeps push-triggered workflows from firing on top of
             # the explicit downstream dispatch below.
@@ -222,13 +256,34 @@ jobs:
         # on tag/push events, so dispatch cd.yml explicitly against the new
         # tag. GoReleaser handles artifact builds and drafts the GitHub
         # release; cd-chart.yml fires automatically once the release is
-        # published. Re-dispatch on resume is harmless: it just queues
-        # another build run.
+        # published.
+        #
+        # On resume, skip dispatch if a prior cd.yml run already succeeded
+        # or is still in-flight: GoReleaser's "release" step refuses to
+        # overwrite an existing release and would fail noisily. Failed
+        # runs are eligible for retry.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
+          last_run=$(gh run list \
+            --repo "${REPO}" \
+            --workflow cd.yml \
+            --branch "v${VERSION}" \
+            --json databaseId,status,conclusion \
+            --jq '.[0] // empty')
+          if [[ -n "${last_run}" ]]; then
+            status=$(jq -r .status <<<"${last_run}")
+            conclusion=$(jq -r .conclusion <<<"${last_run}")
+            run_id=$(jq -r .databaseId <<<"${last_run}")
+            if [[ "${status}" != "completed" || "${conclusion}" == "success" ]]; then
+              echo "cd.yml run ${run_id} for v${VERSION} is ${status}/${conclusion:-none}; skipping dispatch."
+              exit 0
+            fi
+            echo "Previous cd.yml run ${run_id} ended as ${conclusion}; redispatching."
+          fi
           if ! gh workflow run cd.yml --repo "${REPO}" --ref "v${VERSION}"; then
             echo "::warning::Failed to dispatch cd.yml. Re-run it manually against v${VERSION}."
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
           if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
             echo "::error::release.yml must be dispatched against refs/heads/main, got ${GITHUB_REF}"
             exit 1
@@ -74,8 +75,9 @@ jobs:
               printf '%s\n' "${sha}"
             fi
           }
-          # Match the require entry in both `require ( ... )` block form
-          # and single-line `require x v...` form.
+          # The grep below deliberately omits the `require` keyword so
+          # it matches both `require ( ... )` block layout (where the
+          # entry is indented) and single-line `require x v...` layout.
           verify_release_content() {
             local ref="$1"
             local chart_version
@@ -243,8 +245,10 @@ jobs:
                     '{path: $path, mode: $mode, type: "blob", sha: $sha}'
                 done
                 for path in "${deleted[@]}"; do
-                  jq -nc --arg path "${path}" --arg mode "$(mode_for "${path}")" \
-                    '{path: $path, mode: $mode, type: "blob", sha: null}'
+                  # Deletions need a valid mode but it's purely formal —
+                  # the entry only removes the path from the tree.
+                  jq -nc --arg path "${path}" \
+                    '{path: $path, mode: "100644", type: "blob", sha: null}'
                 done
               } | jq -sc .
             )

--- a/release.sh
+++ b/release.sh
@@ -9,10 +9,12 @@ set -o errexit
 set -o pipefail
 trap 'echo "Aborting on line $LINENO. Exit: $?" >&2' ERR
 
-if ! command -v gh >/dev/null; then
-	echo 'The "gh" command must be installed.' >&2
-	exit 1
-fi
+for cmd in git gh; do
+	if ! command -v "$cmd" >/dev/null; then
+		echo "The \"$cmd\" command must be installed." >&2
+		exit 1
+	fi
+done
 
 if [[ $# -ne 1 ]]; then
 	echo "Usage: ./release.sh version" >&2

--- a/release.sh
+++ b/release.sh
@@ -37,8 +37,16 @@ if [[ -n "$(git status --porcelain)" ]]; then
 fi
 
 git fetch --quiet origin main
-if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
-	echo "Local main does not match origin/main. Pull/sync first; the workflow runs against origin/main." >&2
+local_head="$(git rev-parse HEAD)"
+remote_head="$(git rev-parse origin/main)"
+if [[ "$local_head" != "$remote_head" ]]; then
+	if git merge-base --is-ancestor HEAD origin/main; then
+		echo "Local main is behind origin/main. Pull first." >&2
+	elif git merge-base --is-ancestor origin/main HEAD; then
+		echo "Local main is ahead of origin/main. Push your commits or reset to origin/main before releasing." >&2
+	else
+		echo "Local main has diverged from origin/main. Reconcile with pull/rebase/reset before releasing." >&2
+	fi
 	exit 1
 fi
 

--- a/release.sh
+++ b/release.sh
@@ -19,13 +19,7 @@ if [[ $# -ne 1 ]]; then
 	exit 1
 fi
 
-# Adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-if [[ ! $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
-	echo "Invalid version number: $1" >&2
-	exit 1
-fi
-
-# Cheap operator-side guards so the workflow dispatch matches local intent.
+# Cheap operator-side guards; release.yml re-validates the version.
 if [[ "$(git branch --show-current 2>/dev/null)" != "main" ]]; then
 	echo "You must be on the main branch to dispatch a release." >&2
 	exit 1

--- a/release.sh
+++ b/release.sh
@@ -1,21 +1,16 @@
 #!/usr/bin/env bash
 
-# Creates the tags for the library and the Caddy module.
+# Dispatches the Release workflow, which does the real work
+# (Caddy module bump, Helm chart bump, helm-docs, commit, tag, push,
+# downstream build dispatch). See .github/workflows/release.yml.
 
 set -o nounset
 set -o errexit
-trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR
-set -o errtrace
 set -o pipefail
-set -o xtrace
+trap 'echo "Aborting on line $LINENO. Exit: $?" >&2' ERR
 
-if ! type "git" >/dev/null; then
-	echo "The \"git\" command must be installed."
-	exit 1
-fi
-
-if ! type "helm-docs" >/dev/null; then
-	echo "The \"helm-docs\" command (https://github.com/norwoodj/helm-docs) must be installed."
+if ! command -v gh >/dev/null; then
+	echo 'The "gh" command must be installed.' >&2
 	exit 1
 fi
 
@@ -30,9 +25,9 @@ if [[ ! $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]
 	exit 1
 fi
 
-# Pre-flight checks
-if [[ "$(git branch --show-current)" != "main" ]]; then
-	echo "You must be on the main branch to release." >&2
+# Cheap operator-side guards so the workflow dispatch matches local intent.
+if [[ "$(git branch --show-current 2>/dev/null)" != "main" ]]; then
+	echo "You must be on the main branch to dispatch a release." >&2
 	exit 1
 fi
 
@@ -41,29 +36,12 @@ if [[ -n "$(git status --porcelain)" ]]; then
 	exit 1
 fi
 
-git fetch origin
-local_head="$(git rev-parse HEAD)"
-remote_head="$(git rev-parse origin/main)"
-if [[ "$local_head" != "$remote_head" ]]; then
-	if git merge-base --is-ancestor HEAD origin/main; then
-		echo "Local main is behind origin/main. Pull first." >&2
-	elif git merge-base --is-ancestor origin/main HEAD; then
-		echo "Local main is ahead of origin/main. Push your commits or reset to origin/main before releasing." >&2
-	else
-		echo "Local main has diverged from origin/main. Reconcile with pull/rebase/reset before releasing." >&2
-	fi
+git fetch --quiet origin main
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+	echo "Local main does not match origin/main. Pull/sync first; the workflow runs against origin/main." >&2
 	exit 1
 fi
 
-cd caddy/
-go get "github.com/dunglas/mercure@v$1"
-cd -
-
-sed -i '' -e "s/^version: .*$/version: $1/" -e "s/^appVersion: .*$/appVersion: \"v$1\"/" charts/mercure/Chart.yaml
-helm-docs
-
-git commit -S -a -m "chore: prepare release $1"
-
-git tag -s -m "Version $1" "v$1"
-git tag -s -m "Version $1" "caddy/v$1"
-git push --follow-tags
+gh workflow run release.yml --ref main -f version="$1"
+echo "Release workflow dispatched for v$1."
+echo "Watch runs: gh run list --workflow=release.yml --event=workflow_dispatch"

--- a/release.sh
+++ b/release.sh
@@ -6,6 +6,7 @@
 
 set -o nounset
 set -o errexit
+set -o errtrace # so the ERR trap fires inside functions/subshells too
 set -o pipefail
 trap 'echo "Aborting on line $LINENO. Exit: $?" >&2' ERR
 
@@ -32,7 +33,7 @@ if [[ -n "$(git status --porcelain)" ]]; then
 	exit 1
 fi
 
-git fetch --quiet origin main
+git fetch --quiet --tags origin main
 local_head="$(git rev-parse HEAD)"
 remote_head="$(git rev-parse origin/main)"
 if [[ "$local_head" != "$remote_head" ]]; then


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml`, modeled after [FrankenPHP's new release workflow](https://github.com/php/frankenphp/pull/2417): bumps `caddy/go.mod`, bumps `charts/mercure/Chart.yaml`, regenerates the chart README via `helm-docs`, commits + tags `v<version>` and `caddy/v<version>` through the GitHub API (server-signed under `github-actions[bot]`), then dispatches `cd.yml` against the new tag so GoReleaser drafts the release.
- Shrink `release.sh` to a thin dispatcher that keeps the existing operator-side guards (on-main, clean tree, in-sync with `origin/main`) and calls `gh workflow run release.yml`. The semver check now lives in the workflow itself so UI-triggered dispatches are also validated.

The workflow is idempotent: re-dispatching after a partial failure detects which steps already completed (tag existence is the source of truth) and skips them. As a fallback, a release-shaped `main` HEAD without tags is also detected as resumable.

## Notes

- GITHUB_TOKEN-driven API tag creation does not trigger `push` events, so `cd.yml` is dispatched explicitly against the tag ref; `cd-chart.yml` continues to fire automatically on `release: published`.
- No PGO step (Mercure has none) and no Homebrew bump (Mercure isn't published there), unlike the FrankenPHP source workflow.