### PR TITLE
ci: expand SLSA attestation coverage

### DIFF
--- a/.github/workflows/cd-chart.yml
+++ b/.github/workflows/cd-chart.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -56,6 +58,11 @@ jobs:
             --keyring "$SECRING" \
             --passphrase-file - \
             charts/mercure -d .cr-release-packages
+
+      - name: Attest Helm chart
+        uses: actions/attest@v4
+        with:
+          subject-path: .cr-release-packages/*.tgz
 
       - name: Upload Helm chart to release
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,11 +71,50 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ startsWith(github.ref, 'refs/tags/v') && steps.import_gpg.outputs.fingerprint || '' }}
 
-      - name: Attest
+      - name: Attest release artifacts
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
-          subject-path: "${{ github.workspace }}/dist/**/mercure"
+          subject-path: |
+            ${{ github.workspace }}/dist/**/mercure
+            ${{ github.workspace }}/dist/*.tar.gz
+            ${{ github.workspace }}/dist/*.zip
+            ${{ github.workspace }}/dist/*.apk
+            ${{ github.workspace }}/dist/*.deb
+            ${{ github.workspace }}/dist/*.rpm
+            ${{ github.workspace }}/dist/checksums.txt
+
+      - name: Inspect Caddy Docker manifest
+        id: caddy_image
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "dunglas/mercure:${GITHUB_REF_NAME}")
+          echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
+
+      - name: Attest Caddy Docker manifest
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest@v4
+        with:
+          # docker.io/ prefix is required: actions/attest splits subject-name
+          # on the first '/' to find the registry. We only push to Docker Hub.
+          subject-name: docker.io/dunglas/mercure
+          subject-digest: ${{ steps.caddy_image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Inspect legacy Docker image
+        id: legacy_image
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "dunglas/mercure:legacy-${GITHUB_REF_NAME}")
+          echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
+
+      - name: Attest legacy Docker image
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest@v4
+        with:
+          subject-name: docker.io/dunglas/mercure
+          subject-digest: ${{ steps.legacy_image.outputs.digest }}
+          push-to-registry: true
 
       - name: Display version
         run: dist/caddy_linux_amd64_v1/mercure version


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/dunglas/mercure/pull/1246. Aligns Mercure's SLSA attestation with FrankenPHP's coverage.

- **`cd.yml`** — switch the existing binary attestation from `actions/attest-build-provenance@v4` to the generic `actions/attest@v4` (default predicate is still SLSA build provenance). Broaden the subject glob to also cover archives (`.tar.gz`, `.zip`), nfpm packages (`.apk`, `.deb`, `.rpm`) and `checksums.txt`. Add two extra steps that resolve each Docker manifest digest with `docker buildx imagetools inspect` and attest them with `push-to-registry: true`, so the SLSA attestation lands next to the image on Docker Hub:
  - `dunglas/mercure:<tag>` (Caddy build, multi-arch manifest list)
  - `dunglas/mercure:legacy-<tag>` (legacy single-arch image)
- **`cd-chart.yml`** — grant `id-token: write` + `attestations: write` and attest the signed Helm chart `.tgz` produced by `helm package --sign`.

## Notes

- Mirrors FrankenPHP's `actions/attest@v4` usage in `static.yaml`, `windows.yaml` and `docker.yaml`, including the `docker.io/` prefix on `subject-name` (the action splits on the first `/` to find the registry).
- Docker Hub login already happens earlier in `cd.yml`, so `push-to-registry: true` can attach the attestation manifest without extra credential plumbing.