### PR TITLE
ci: introduce release app to restore main branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-# Bumps caddy/go.mod and the Helm chart, commits as github-actions[bot],
+# Bumps caddy/go.mod and the Helm chart, commits as dunglas-release[bot],
 # tags v<version> and caddy/v<version>, and dispatches cd.yml.
 # Idempotent: a re-dispatch after a partial failure resumes by tag.
 on:
@@ -10,9 +10,7 @@ on:
         description: "Version to release (e.g. 0.25.0, no v prefix)"
         required: true
         type: string
-permissions:
-  contents: write
-  actions: write # to dispatch cd.yml
+permissions: {}
 concurrency:
   # Per-version: different versions race safely (the API parent_sha
   # check rejects a stale main HEAD update); same-version dispatches
@@ -42,14 +40,20 @@ jobs:
             echo "::error::Invalid version: '${VERSION}' (must be SemVer, no v prefix)"
             exit 1
           fi
+      - uses: actions/create-github-app-token@v3
+        id: release-app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ steps.release-app-token.outputs.token }}
       - name: Determine release state
         id: state
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           VERSION: ${{ inputs.version }}
         # Tag existence is the resume signal — main HEAD may have moved
         # past the release commit, so a HEAD message check is too narrow.
@@ -170,9 +174,9 @@ jobs:
           helm-docs
       - name: Commit and tag via GitHub API
         # API-created commits/tags are signed server-side and show as
-        # Verified under github-actions[bot].
+        # Verified under dunglas-release[bot].
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
           RESUME: ${{ steps.state.outputs.resume }}
@@ -313,7 +317,7 @@ jobs:
         # `gh release view` matches drafts as well, and GoReleaser refuses
         # to overwrite. Also skip if a cd.yml run for the tag is in flight.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           REPO: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
         run: |


### PR DESCRIPTION
Mirror of https://github.com/php/frankenphp/pull/2439.

## Summary

- `permissions:` block at the workflow level is reduced to `{}`; the release commit and tag writes, plus the cd.yml dispatch, now go through a GitHub App token instead of `GITHUB_TOKEN`.
- New `actions/create-github-app-token@v3` step mints the token from `vars.RELEASE_APP_ID` + `secrets.RELEASE_APP_PRIVATE_KEY`.
- Every `secrets.GITHUB_TOKEN` reference (`Determine release state`, `Commit and tag via GitHub API`, `Trigger downstream release build`) and the checkout `token:` now use the app token.

## Why

With a default-token-only workflow, restoring branch protection on `main` blocks the API-driven commit (the workflow's identity is `github-actions[bot]`, which cannot bypass the rules). Using a dedicated app whose installation can bypass protection lets us re-enable the rules without losing the release automation.

## Setup

Repo needs:
- `RELEASE_APP_ID` variable: the app's numeric ID.
- `RELEASE_APP_PRIVATE_KEY` secret: the app's PEM private key.
- The app installed on `dunglas/mercure` with at least `contents: write` and `actions: write` permissions, and on the allowlist for the protected branch.