### PR TITLE
ci: release from maintenance branches; suppress rolling Docker tags on prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ on:
 permissions: {}
 concurrency:
   # Per-version: different versions race safely (the API parent_sha
-  # check rejects a stale main HEAD update); same-version dispatches
-  # serialize so resume logic isn't blocked by a pending approval.
+  # check rejects a stale release-branch HEAD update); same-version
+  # dispatches serialize so resume logic isn't blocked by a pending approval.
   group: ${{ github.workflow }}-${{ inputs.version }}
   cancel-in-progress: false
 jobs:
@@ -26,18 +26,28 @@ jobs:
       GOTOOLCHAIN: local
     steps:
       - name: Validate inputs
-        # Reject non-main refs and non-semver versions before they reach
-        # go get / sed / tag refs. https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        # Reject non-release refs and non-semver versions before they reach
+        # go get / sed / tag refs. Release dispatches must run against main
+        # or a maintenance branch named `<major>.x` (e.g. `0.x`, `1.x`); a
+        # maintenance branch may only release its own major to prevent a
+        # 1.0.0 dispatch against 0.x (or vice versa) from corrupting tags.
+        # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         env:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
-            echo "::error::release.yml must be dispatched against refs/heads/main, got ${GITHUB_REF}"
+          if [[ ! "${GITHUB_REF}" =~ ^refs/heads/(main|([0-9]+)\.x)$ ]]; then
+            echo "::error::release.yml must be dispatched against refs/heads/main or refs/heads/<major>.x, got ${GITHUB_REF}"
             exit 1
           fi
+          branch_major="${BASH_REMATCH[2]:-}"
           if [[ ! ${VERSION} =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
             echo "::error::Invalid version: '${VERSION}' (must be SemVer, no v prefix)"
+            exit 1
+          fi
+          version_major="${BASH_REMATCH[1]}"
+          if [[ -n "${branch_major}" && "${branch_major}" != "${version_major}" ]]; then
+            echo "::error::Branch ${GITHUB_REF#refs/heads/} can only release ${branch_major}.y.z versions, got ${VERSION}"
             exit 1
           fi
       - uses: actions/create-github-app-token@v3
@@ -55,11 +65,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           VERSION: ${{ inputs.version }}
-        # Tag existence is the resume signal — main HEAD may have moved
-        # past the release commit, so a HEAD message check is too narrow.
-        # As a fallback, also detect a release-shaped commit already on
-        # main without tags (a previous run that pushed main but failed
-        # before create_tag).
+        # Tag existence is the resume signal — the release branch HEAD
+        # may have moved past the release commit, so a HEAD message check
+        # is too narrow. As a fallback, also detect a release-shaped
+        # commit already on the release branch without tags (a previous
+        # run that pushed the branch but failed before create_tag).
         run: |
           set -euo pipefail
           # matching-refs returns [] (HTTP 200) for absent tags; real
@@ -103,7 +113,7 @@ jobs:
             sha=$(resolve_commit "${main_entry}")
             # Reject orphan tags created on a side branch.
             if ! git merge-base --is-ancestor "${sha}" HEAD; then
-              echo "::error::Tag v${VERSION} (${sha}) is not reachable from main; refusing to resume."
+              echo "::error::Tag v${VERSION} (${sha}) is not reachable from ${GITHUB_REF#refs/heads/}; refusing to resume."
               exit 1
             fi
             # Catch a mismatched caddy/v${VERSION} before any writes.
@@ -130,7 +140,7 @@ jobs:
               exit 1
             fi
             sha=$(git rev-parse HEAD)
-            echo "Resuming: main HEAD (${sha}) already matches v${VERSION}; tags will be created."
+            echo "Resuming: ${GITHUB_REF#refs/heads/} HEAD (${sha}) already matches v${VERSION}; tags will be created."
             {
               echo "resume=true"
               echo "release_commit=${sha}"
@@ -184,6 +194,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Release commit and ref-update target the dispatched branch
+          # (main for stable, <major>.x for maintenance), so the parent_sha
+          # check and the fast-forward PATCH both stay on the line we
+          # actually released from.
+          BRANCH="${GITHUB_REF#refs/heads/}"
+
           if [[ "${RESUME}" == "true" ]]; then
             commit_sha="${RELEASE_COMMIT}"
             echo "Reusing existing release commit ${commit_sha}"
@@ -200,12 +216,13 @@ jobs:
             )
 
             # Concurrency is per-version, so a different version could
-            # land on main while this run is in flight. Abort rather than
-            # overlay our locally-bumped files on top of unseen commits.
+            # land on the release branch while this run is in flight.
+            # Abort rather than overlay our locally-bumped files on top
+            # of unseen commits.
             checkout_sha=$(git rev-parse HEAD)
-            parent_sha=$(gh api "repos/${REPO}/git/refs/heads/main" -q .object.sha)
+            parent_sha=$(gh api "repos/${REPO}/git/refs/heads/${BRANCH}" -q .object.sha)
             if [[ "${checkout_sha}" != "${parent_sha}" ]]; then
-              echo "::error::main advanced from ${checkout_sha} to ${parent_sha} during the run; refusing to overlay locally-modified files on a newer base_tree."
+              echo "::error::${BRANCH} advanced from ${checkout_sha} to ${parent_sha} during the run; refusing to overlay locally-modified files on a newer base_tree."
               exit 1
             fi
             base_tree=$(gh api "repos/${REPO}/git/commits/${parent_sha}" -q .tree.sha)
@@ -219,7 +236,7 @@ jobs:
             mapfile -t deleted < <(git diff --no-renames --name-only --diff-filter=D HEAD)
             mapfile -t untracked < <(git ls-files --others --exclude-standard)
             if [[ ${#modified[@]} -eq 0 && ${#deleted[@]} -eq 0 && ${#untracked[@]} -eq 0 ]]; then
-              echo "::error::No file changes after bump/helm-docs. Is v${VERSION} already on main? Delete the local tags and pick a different version, or recreate the tags manually."
+              echo "::error::No file changes after bump/helm-docs. Is v${VERSION} already on ${BRANCH}? Delete the local tags and pick a different version, or recreate the tags manually."
               exit 1
             fi
             present=("${modified[@]}" "${untracked[@]}")
@@ -272,7 +289,7 @@ jobs:
               '{message: $message, tree: $tree, parents: [$parent]}' \
               | gh api "repos/${REPO}/git/commits" --input - -q .sha)
 
-            gh api "repos/${REPO}/git/refs/heads/main" -X PATCH -f sha="$commit_sha" --silent
+            gh api "repos/${REPO}/git/refs/heads/${BRANCH}" -X PATCH -f sha="$commit_sha" --silent
           fi
 
           # Idempotent: skip if tag already points at the release commit,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           fi
           version_major="${BASH_REMATCH[1]}"
           if [[ -n "${branch_major}" && "${branch_major}" != "${version_major}" ]]; then
-            echo "::error::Branch ${GITHUB_REF#refs/heads/} can only release ${branch_major}.y.z versions, got ${VERSION}"
+            echo "::error::Branch ${GITHUB_REF#refs/heads/} can only release versions with major ${branch_major} (e.g. ${branch_major}.0.0), got ${VERSION}"
             exit 1
           fi
       - uses: actions/create-github-app-token@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -102,10 +102,13 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
+      # Rolling tags (vN, vN.M, latest) are suppressed on prereleases so
+      # a 1.0.0-beta.X cut does not move :latest/:v1 off the stable line.
+      # GoReleaser drops empty entries, so the {{ if }} blocks emit no tag.
       - "dunglas/mercure:{{ .Tag }}-amd64"
-      - "dunglas/mercure:v{{ .Major }}-amd64"
-      - "dunglas/mercure:v{{ .Major }}.{{ .Minor }}-amd64"
-      - "dunglas/mercure:latest-amd64"
+      - "{{ if not .Prerelease }}dunglas/mercure:v{{ .Major }}-amd64{{ end }}"
+      - "{{ if not .Prerelease }}dunglas/mercure:v{{ .Major }}.{{ .Minor }}-amd64{{ end }}"
+      - "{{ if not .Prerelease }}dunglas/mercure:latest-amd64{{ end }}"
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
@@ -118,9 +121,9 @@ dockers:
     goarch: arm64
     image_templates:
       - "dunglas/mercure:{{ .Tag }}-arm64v8"
-      - "dunglas/mercure:v{{ .Major }}-arm64v8"
-      - "dunglas/mercure:v{{ .Major }}.{{ .Minor }}-arm64v8"
-      - "dunglas/mercure:latest-arm64v8"
+      - "{{ if not .Prerelease }}dunglas/mercure:v{{ .Major }}-arm64v8{{ end }}"
+      - "{{ if not .Prerelease }}dunglas/mercure:v{{ .Major }}.{{ .Minor }}-arm64v8{{ end }}"
+      - "{{ if not .Prerelease }}dunglas/mercure:latest-arm64v8{{ end }}"
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64/v8"
@@ -132,23 +135,28 @@ dockers:
     dockerfile: Dockerfile.legacy
     image_templates:
       - "dunglas/mercure:legacy-{{ .Tag }}"
-      - "dunglas/mercure:legacy-v{{ .Major }}"
-      - "dunglas/mercure:legacy-v{{ .Major }}.{{ .Minor }}"
-      - "dunglas/mercure:legacy-latest"
+      - "{{ if not .Prerelease }}dunglas/mercure:legacy-v{{ .Major }}{{ end }}"
+      - "{{ if not .Prerelease }}dunglas/mercure:legacy-v{{ .Major }}.{{ .Minor }}{{ end }}"
+      - "{{ if not .Prerelease }}dunglas/mercure:legacy-latest{{ end }}"
 docker_manifests:
   - name_template: dunglas/mercure:{{ .Tag }}
     image_templates:
       - dunglas/mercure:{{ .Tag }}-amd64
       - dunglas/mercure:{{ .Tag }}-arm64v8
+  # Rolling manifests are skipped on prereleases (name_template cannot
+  # be empty, so use skip_push instead of an {{ if }} wrap).
   - name_template: dunglas/mercure:v{{ .Major }}
+    skip_push: "{{ .Prerelease }}"
     image_templates:
       - dunglas/mercure:v{{ .Major }}-amd64
       - dunglas/mercure:v{{ .Major }}-arm64v8
   - name_template: dunglas/mercure:v{{ .Major }}.{{ .Minor }}
+    skip_push: "{{ .Prerelease }}"
     image_templates:
       - dunglas/mercure:v{{ .Major }}.{{ .Minor }}-amd64
       - dunglas/mercure:v{{ .Major }}.{{ .Minor }}-arm64v8
   - name_template: dunglas/mercure:latest
+    skip_push: "{{ .Prerelease }}"
     image_templates:
       - dunglas/mercure:latest-amd64
       - dunglas/mercure:latest-arm64v8


### PR DESCRIPTION
Two changes in support of cutting `1.0.0-beta.1` from `main` while keeping the `0.x` line patchable from a maintenance branch.

## `release.yml`

- Accept dispatches from `refs/heads/main` or `refs/heads/<major>.x` (e.g. `0.x`, `1.x`).
- Enforce major-match: a maintenance branch can only release its own major (`0.x` rejects `1.0.0-beta.1`, `1.x` rejects `0.24.2`). Stops a misclick from cross-contaminating tag history.
- The branch-fixed API operations (`refs/heads/main` reads/PATCH) now follow the dispatched branch via `BRANCH=${GITHUB_REF#refs/heads/}`, so the parent-SHA freshness check and the fast-forward commit target the line the release is for.

## `.goreleaser.yml`

A prerelease cut must not move `:latest`, `:v{Major}`, `:v{Major}.{Minor}` (or their `legacy-` twins) off the latest stable release.

- Rolling tags in `image_templates` are gated behind `{{ if not .Prerelease }}…{{ end }}` (GoReleaser drops empty template results).
- Rolling `docker_manifests` use `skip_push: "{{ .Prerelease }}"` because `name_template` cannot be empty.
- The exact-tag image (`:{{ .Tag }}` / `:legacy-{{ .Tag }}`) is unconditional, so `:1.0.0-beta.1` and `:legacy-1.0.0-beta.1` still publish on a prerelease run.

## Verification

- `actionlint .github/workflows/release.yml` — clean.
- `goreleaser check` — clean.
- The cd.yml PR pipeline runs `goreleaser build --single-target --snapshot`, which will catch any template error against this branch.