### PR TITLE
docs: add SECURITY.md with maintenance policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ Do not open public issues or PRs for suspected vulnerabilities.
 | Version | Branch | Status                                                                                                              |
 | ------- | ------ | ------------------------------------------------------------------------------------------------------------------- |
 | 1.0.x   | `main` | Active development. `1.0.0-beta.x` prereleases are shipped from `main`; not recommended for production until 1.0.0. |
-| 0.24.x  | `0.x`  | Security and critical bug fixes only, until `1.0.0` ships.                                                          |
+| 0.24.x  | `0.x`  | Security and critical bugfixes only, until `1.0.0` ships.                                                           |
 | < 0.24  | —      | Unsupported. Upgrade to 0.24.x.                                                                                     |
 
 Patches for the 0.x line land on the `0.x` branch and are released from
-there (e.g. `0.24.2`). Fixes that also apply to v1 are cherry-picked to
+there (e.g., `0.24.2`). Fixes that also apply to v1 are cherry-picked to
 `main`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report security issues through GitHub's private vulnerability reporting:
+<https://github.com/dunglas/mercure/security/advisories/new>.
+
+Do not open public issues or PRs for suspected vulnerabilities.
+
+## Supported versions
+
+| Version | Branch | Status                                                                                                              |
+| ------- | ------ | ------------------------------------------------------------------------------------------------------------------- |
+| 1.0.x   | `main` | Active development. `1.0.0-beta.x` prereleases are shipped from `main`; not recommended for production until 1.0.0. |
+| 0.24.x  | `0.x`  | Security and critical bug fixes only, until `1.0.0` ships.                                                          |
+| < 0.24  | —      | Unsupported. Upgrade to 0.24.x.                                                                                     |
+
+Patches for the 0.x line land on the `0.x` branch and are released from
+there (e.g. `0.24.2`). Fixes that also apply to v1 are cherry-picked to
+`main`.


### PR DESCRIPTION
Adds a `SECURITY.md` that:

- Points reporters at GitHub's private vulnerability reporting (`/security/advisories/new`).
- Documents the supported lines: `1.0.x` (active dev on `main`, beta prereleases not recommended for production), `0.24.x` (security and critical bug fixes only on the new `0.x` branch until 1.0.0 ships), `< 0.24` (unsupported).

Paired with #1256, which teaches `release.yml` to dispatch from `0.x`, this gives the 0.x line a documented, automated patch path while the v1 beta ships from `main`.