### PR TITLE
chore: improve mercure maintenance path

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,29 @@
+//go:build deprecated_server && deprecated_transport
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/dunglas/mercure/common"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootCmdVersion(t *testing.T) {
+	assert.NotEmpty(t, rootCmd.Version)
+	assert.Equal(t, common.AppVersion.Shortline(), rootCmd.Version)
+}
+
+func TestExecutePanicsOnError(t *testing.T) {
+	orig := rootCmd
+	t.Cleanup(func() { rootCmd = orig })
+
+	rootCmd = &cobra.Command{
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return assert.AnError
+		},
+	}
+
+	assert.Panics(t, Execute)
+}

--- a/hub_test.go
+++ b/hub_test.go
@@ -44,6 +44,7 @@ func TestNewHub(t *testing.T) {
 	assert.Equal(t, 40*time.Second, h.heartbeat)
 	assert.Equal(t, 5*time.Second, h.dispatchTimeout)
 	assert.Equal(t, 600*time.Second, h.writeTimeout)
+	assert.IsType(t, NopMetrics{}, h.metrics)
 }
 
 func TestNewHubWithConfig(t *testing.T) {


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in cmd/root.go, hub_test.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.