### PR TITLE
fix(security): reject reserved topic namespace and SSE field injection

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -22,6 +22,13 @@ const BoltDefaultCleanupFrequency = 0.3
 
 const defaultBoltBucketName = "updates"
 
+// maxHistoryScan caps how many history events a single subscriber
+// reconnection can force the transport to walk before giving up on
+// finding the requested Last-Event-ID. The cap is a denial-of-service
+// guard: without it, an attacker sending an ancient or non-existent
+// Last-Event-ID forces an O(history-size) scan on every request.
+const maxHistoryScan = 10000
+
 // BoltTransport implements the TransportInterface using the Bolt database.
 type BoltTransport struct {
 	sync.RWMutex
@@ -238,6 +245,7 @@ func (t *BoltTransport) dispatchHistory(ctx context.Context, s *LocalSubscriber,
 		c := b.Cursor()
 		responseLastEventID := EarliestLastEventID
 		afterFromID := s.RequestLastEventID == EarliestLastEventID
+		scanned := 0
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			// Keys written after the subscribe snapshot (concurrent Dispatch
@@ -248,10 +256,39 @@ func (t *BoltTransport) dispatchHistory(ctx context.Context, s *LocalSubscriber,
 				break
 			}
 
+			if scanned >= maxHistoryScan {
+				// DoS guard: bound the per-request backward scan so an
+				// attacker cannot force unbounded history walks by sending
+				// an ancient or non-existent Last-Event-ID. responseLast-
+				// EventID stays at the most recent authorized id seen so
+				// far (or "earliest" if none).
+				break
+			}
+
+			scanned++
+
 			if !afterFromID {
-				responseLastEventID = string(k[8:])
-				if responseLastEventID == s.RequestLastEventID {
+				id := string(k[8:])
+				if id == s.RequestLastEventID {
 					afterFromID = true
+					// The subscriber already knows this id; echoing it
+					// is not a disclosure.
+					responseLastEventID = s.RequestLastEventID
+
+					continue
+				}
+
+				// Only disclose the id of an event the subscriber is
+				// authorized to read. We must deserialize to evaluate
+				// Match against the update's topics and Private flag.
+				var update *Update
+				if err := json.Unmarshal(v, &update); err != nil {
+					// Skip silently — do not disclose this id.
+					continue
+				}
+
+				if s.Match(update) {
+					responseLastEventID = id
 				}
 
 				continue

--- a/bolt.go
+++ b/bolt.go
@@ -256,18 +256,16 @@ func (t *BoltTransport) dispatchHistory(ctx context.Context, s *LocalSubscriber,
 				break
 			}
 
-			if scanned >= maxHistoryScan {
-				// DoS guard: bound the per-request backward scan so an
-				// attacker cannot force unbounded history walks by sending
-				// an ancient or non-existent Last-Event-ID. responseLast-
-				// EventID stays at the most recent authorized id seen so
-				// far (or "earliest" if none).
-				break
-			}
-
-			scanned++
-
 			if !afterFromID {
+				// DoS guard: cap the search-for-requested-ID phase only.
+				// Once afterFromID is true the loop is dispatching legitimate
+				// authorized history and must not be truncated.
+				if scanned >= maxHistoryScan {
+					break
+				}
+
+				scanned++
+
 				id := string(k[8:])
 				if id == s.RequestLastEventID {
 					afterFromID = true

--- a/event.go
+++ b/event.go
@@ -8,6 +8,17 @@ import (
 //nolint:gochecknoglobals
 var dataReplacer = strings.NewReplacer("\r\n", "\ndata: ", "\r", "\ndata: ", "\n", "\ndata: ")
 
+// sseFieldForbiddenChars are characters that, if present in an SSE
+// header field such as id: or event:, would let a publisher inject
+// arbitrary SSE fields into the stream seen by subscribers.
+const sseFieldForbiddenChars = "\x00\r\n"
+
+// containsSSEFieldForbiddenChar reports whether s contains a character
+// that must not appear in an SSE header field (id, event, retry).
+func containsSSEFieldForbiddenChar(s string) bool {
+	return strings.ContainsAny(s, sseFieldForbiddenChars)
+}
+
 // Event is the actual Server Sent Event that will be dispatched.
 type Event struct {
 	// The updates' data, encoded in the sever-sent event format: every line starts with the string "data: "

--- a/event.go
+++ b/event.go
@@ -8,17 +8,6 @@ import (
 //nolint:gochecknoglobals
 var dataReplacer = strings.NewReplacer("\r\n", "\ndata: ", "\r", "\ndata: ", "\n", "\ndata: ")
 
-// sseFieldForbiddenChars are characters that, if present in an SSE
-// header field such as id: or event:, would let a publisher inject
-// arbitrary SSE fields into the stream seen by subscribers.
-const sseFieldForbiddenChars = "\x00\r\n"
-
-// containsSSEFieldForbiddenChar reports whether s contains a character
-// that must not appear in an SSE header field (id, event, retry).
-func containsSSEFieldForbiddenChar(s string) bool {
-	return strings.ContainsAny(s, sseFieldForbiddenChars)
-}
-
 // Event is the actual Server Sent Event that will be dispatched.
 type Event struct {
 	// The updates' data, encoded in the sever-sent event format: every line starts with the string "data: "

--- a/publish.go
+++ b/publish.go
@@ -2,10 +2,13 @@ package mercure
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"go.opentelemetry.io/otel/trace"
 )
@@ -13,6 +16,53 @@ import (
 type updateContextKeyType struct{}
 
 var UpdateContextKey updateContextKeyType //nolint:gochecknoglobals
+
+// reservedTopicSubstring is the substring whose presence in any topic
+// (canonical or alternate) identifies the hub's own resources, such as
+// subscription events. Publishers must not be able to forge those.
+const reservedTopicSubstring = "/.well-known/mercure"
+
+// Sentinel errors returned by Publish for invalid Update payloads.
+// PublishHandler maps them to HTTP status codes; library callers can
+// inspect them with errors.Is.
+var (
+	// ErrReservedTopic is returned when an Update contains a topic
+	// whose value references the reserved "/.well-known/mercure"
+	// namespace, which only the hub itself is allowed to publish to.
+	ErrReservedTopic = errors.New(`topic value references the reserved "/.well-known/mercure" namespace`)
+
+	// ErrInvalidEventID is returned when an Update's event id contains
+	// a character that would let the publisher inject arbitrary SSE
+	// fields into the subscriber's stream.
+	ErrInvalidEventID = errors.New(`"id" field contains a forbidden control character`)
+
+	// ErrInvalidEventType is returned when an Update's event type
+	// contains a character that would let the publisher inject
+	// arbitrary SSE fields into the subscriber's stream.
+	ErrInvalidEventType = errors.New(`"type" field contains a forbidden control character`)
+)
+
+// validateUpdate enforces the publish-side input rules that protect
+// subscribers from update forgery and SSE field injection. It is the
+// single source of truth for these checks; PublishHandler does not
+// re-validate.
+func validateUpdate(u *Update) error {
+	for _, t := range u.Topics {
+		if strings.Contains(t, reservedTopicSubstring) {
+			return fmt.Errorf("%q: %w", t, ErrReservedTopic)
+		}
+	}
+
+	if containsSSEFieldForbiddenChar(u.Event.ID) {
+		return ErrInvalidEventID
+	}
+
+	if containsSSEFieldForbiddenChar(u.Event.Type) {
+		return ErrInvalidEventType
+	}
+
+	return nil
+}
 
 // Publish broadcasts the given update to all subscribers.
 // The id field of the Update instance can be updated by the underlying Transport.
@@ -26,6 +76,16 @@ func (h *Hub) Publish(ctx context.Context, update *Update) error {
 
 		span.End()
 	}()
+
+	if err := validateUpdate(update); err != nil {
+		if h.logger.Enabled(ctx, slog.LevelInfo) {
+			h.logger.LogAttrs(ctx, slog.LevelInfo, "Rejected invalid update", slog.Any("error", err))
+		}
+
+		recordSpanError(span, err)
+
+		return err
+	}
 
 	ctx = context.WithValue(ctx, UpdateContextKey, update)
 
@@ -138,18 +198,18 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 		Event:   Event{r.PostForm.Get("data"), r.PostForm.Get("id"), r.PostForm.Get("type"), retry},
 	}
 
-	ctx = context.WithValue(ctx, UpdateContextKey, u)
 	dispatchCtx := context.WithoutCancel(ctx)
 
-	// Broadcast the update
-	if err := h.transport.Dispatch(dispatchCtx, u); err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-
-		if h.logger.Enabled(ctx, slog.LevelError) {
-			h.logger.LogAttrs(ctx, slog.LevelError, "Failed to dispatch update", slog.Any("error", err))
+	// Validation, dispatch, logging and metrics live in Hub.Publish.
+	if err := h.Publish(dispatchCtx, u); err != nil {
+		switch {
+		case errors.Is(err, ErrReservedTopic):
+			http.Error(w, err.Error(), http.StatusForbidden)
+		case errors.Is(err, ErrInvalidEventID), errors.Is(err, ErrInvalidEventType):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
-
-		recordSpanError(span, err)
 
 		return
 	}
@@ -160,11 +220,5 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		return
-	}
-
-	h.metrics.UpdatePublished(u)
-
-	if h.logger.Enabled(ctx, slog.LevelInfo) {
-		h.logger.LogAttrs(ctx, slog.LevelInfo, "Update published")
 	}
 }

--- a/publish.go
+++ b/publish.go
@@ -218,6 +218,11 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
 
+		// Mirror the error onto the handler span too; Hub.Publish's child
+		// span already records it, but leaving the parent span as success
+		// is misleading.
+		recordSpanError(span, err)
+
 		return
 	}
 

--- a/publish.go
+++ b/publish.go
@@ -42,22 +42,29 @@ var (
 	ErrInvalidEventType = errors.New(`"type" field contains a forbidden control character`)
 )
 
-// validateUpdate enforces the publish-side input rules that protect
+// sseFieldForbiddenChars are characters that, if copied into an SSE
+// header field such as id: or event:, would let a publisher inject
+// arbitrary SSE fields into subscribers' streams.
+const sseFieldForbiddenChars = "\x00\r\n"
+
+// validate enforces the publish-side input rules that protect
 // subscribers from update forgery and SSE field injection. It is the
 // single source of truth for these checks; PublishHandler does not
-// re-validate.
-func validateUpdate(u *Update) error {
+// re-validate. The sentinel errors returned (ErrReservedTopic,
+// ErrInvalidEventID, ErrInvalidEventType) are exported so callers of
+// Hub.Publish can branch on them via errors.Is.
+func (u *Update) validate() error {
 	for _, t := range u.Topics {
 		if strings.Contains(t, reservedTopicSubstring) {
 			return fmt.Errorf("%q: %w", t, ErrReservedTopic)
 		}
 	}
 
-	if containsSSEFieldForbiddenChar(u.Event.ID) {
+	if strings.ContainsAny(u.ID, sseFieldForbiddenChars) {
 		return ErrInvalidEventID
 	}
 
-	if containsSSEFieldForbiddenChar(u.Event.Type) {
+	if strings.ContainsAny(u.Type, sseFieldForbiddenChars) {
 		return ErrInvalidEventType
 	}
 
@@ -77,7 +84,7 @@ func (h *Hub) Publish(ctx context.Context, update *Update) error {
 		span.End()
 	}()
 
-	if err := validateUpdate(update); err != nil {
+	if err := update.validate(); err != nil {
 		if h.logger.Enabled(ctx, slog.LevelInfo) {
 			h.logger.LogAttrs(ctx, slog.LevelInfo, "Rejected invalid update", slog.Any("error", err))
 		}

--- a/publish_test.go
+++ b/publish_test.go
@@ -503,58 +503,30 @@ func TestPublishHandlerReservedTopicNamespace(t *testing.T) {
 	}
 }
 
-func TestPublishHandlerRejectsSSEControlCharsInID(t *testing.T) {
+func TestPublishHandlerRejectsSSEControlChars(t *testing.T) {
 	t.Parallel()
 
-	for _, id := range []string{
-		"foo\nevent: injected",
-		"foo\revent: injected",
-		"foo\x00bar",
-	} {
-		t.Run(id, func(t *testing.T) {
-			t.Parallel()
-
-			hub := createDummy(t)
-
-			form := url.Values{}
-			form.Add("topic", "https://example.com/books/1")
-			form.Add("id", id)
-			form.Add("data", "Hello!")
-
-			req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
-			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-			req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
-
-			w := httptest.NewRecorder()
-			hub.PublishHandler(w, req)
-
-			resp := w.Result()
-
-			t.Cleanup(func() {
-				assert.NoError(t, resp.Body.Close())
-			})
-
-			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		})
+	cases := []struct {
+		field string
+		value string
+	}{
+		{"id", "foo\nevent: injected"},
+		{"id", "foo\revent: injected"},
+		{"id", "foo\x00bar"},
+		{"type", "foo\nid: injected"},
+		{"type", "foo\rdata: injected"},
+		{"type", "foo\x00bar"},
 	}
-}
 
-func TestPublishHandlerRejectsSSEControlCharsInType(t *testing.T) {
-	t.Parallel()
-
-	for _, eventType := range []string{
-		"foo\nid: injected",
-		"foo\rdata: injected",
-		"foo\x00bar",
-	} {
-		t.Run(eventType, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.field+"/"+tc.value, func(t *testing.T) {
 			t.Parallel()
 
 			hub := createDummy(t)
 
 			form := url.Values{}
 			form.Add("topic", "https://example.com/books/1")
-			form.Add("type", eventType)
+			form.Add(tc.field, tc.value)
 			form.Add("data", "Hello!")
 
 			req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))

--- a/publish_test.go
+++ b/publish_test.go
@@ -467,3 +467,110 @@ func FuzzPublish(f *testing.F) {
 		assert.Equal(t, id, string(body))
 	})
 }
+
+func TestPublishHandlerReservedTopicNamespace(t *testing.T) {
+	t.Parallel()
+
+	for _, topic := range []string{
+		"/.well-known/mercure/subscriptions/foo",
+		"https://example.com/.well-known/mercure/subscriptions/foo",
+		"foo/.well-known/mercure/bar",
+	} {
+		t.Run(topic, func(t *testing.T) {
+			t.Parallel()
+
+			hub := createDummy(t)
+
+			form := url.Values{}
+			form.Add("topic", topic)
+			form.Add("data", "Hello!")
+
+			req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
+
+			w := httptest.NewRecorder()
+			hub.PublishHandler(w, req)
+
+			resp := w.Result()
+
+			t.Cleanup(func() {
+				assert.NoError(t, resp.Body.Close())
+			})
+
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		})
+	}
+}
+
+func TestPublishHandlerRejectsSSEControlCharsInID(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{
+		"foo\nevent: injected",
+		"foo\revent: injected",
+		"foo\x00bar",
+	} {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			hub := createDummy(t)
+
+			form := url.Values{}
+			form.Add("topic", "https://example.com/books/1")
+			form.Add("id", id)
+			form.Add("data", "Hello!")
+
+			req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
+
+			w := httptest.NewRecorder()
+			hub.PublishHandler(w, req)
+
+			resp := w.Result()
+
+			t.Cleanup(func() {
+				assert.NoError(t, resp.Body.Close())
+			})
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}
+
+func TestPublishHandlerRejectsSSEControlCharsInType(t *testing.T) {
+	t.Parallel()
+
+	for _, eventType := range []string{
+		"foo\nid: injected",
+		"foo\rdata: injected",
+		"foo\x00bar",
+	} {
+		t.Run(eventType, func(t *testing.T) {
+			t.Parallel()
+
+			hub := createDummy(t)
+
+			form := url.Values{}
+			form.Add("topic", "https://example.com/books/1")
+			form.Add("type", eventType)
+			form.Add("data", "Hello!")
+
+			req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
+
+			w := httptest.NewRecorder()
+			hub.PublishHandler(w, req)
+
+			resp := w.Result()
+
+			t.Cleanup(func() {
+				assert.NoError(t, resp.Body.Close())
+			})
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}

--- a/publish_test.go
+++ b/publish_test.go
@@ -1,6 +1,7 @@
 package mercure
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -519,7 +520,7 @@ func TestPublishHandlerRejectsSSEControlChars(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.field+"/"+tc.value, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s/%q", tc.field, tc.value), func(t *testing.T) {
 			t.Parallel()
 
 			hub := createDummy(t)

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -883,6 +883,66 @@ func TestUnknownLastEventID(t *testing.T) {
 	})
 }
 
+func TestUnknownLastEventIDDoesNotLeakPrivateEventID(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		transport := createBoltTransport(t, 0, 0)
+		hub := createAnonymousDummy(t, WithLogger(transport.logger), WithTransport(transport))
+
+		// Public event the anonymous subscriber is authorized to read.
+		require.NoError(t, transport.Dispatch(t.Context(), &Update{
+			Topics: []string{"https://example.com/foos/a"},
+			Event:  Event{ID: "a", Data: "d1"},
+		}))
+		// Private event the anonymous subscriber is NOT authorized to
+		// read. Its id must not appear in the Last-Event-ID response.
+		require.NoError(t, transport.Dispatch(t.Context(), &Update{
+			Topics:  []string{"https://example.com/foos/b"},
+			Private: true,
+			Event:   Event{ID: "b", Data: "secret"},
+		}))
+
+		ctx := t.Context()
+
+		go func(ctx context.Context) {
+			c, cancel := context.WithCancel(ctx)
+			req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?topic=https://example.com/foos/{id}&lastEventID=unknown", nil).WithContext(c)
+
+			w := &responseTester{
+				header:             http.Header{},
+				expectedStatusCode: http.StatusOK,
+				expectedBody:       ":\nid: c\ndata: d3\n\n",
+				tb:                 t,
+				cancel:             cancel,
+			}
+
+			hub.SubscribeHandler(w, req)
+			// Authorized "a" leaks back as the recovery anchor; the
+			// private "b" does not, even though it is the most recent
+			// in-history event.
+			assert.Equal(t, "a", w.Header().Get("Last-Event-ID"))
+		}(ctx)
+
+		for {
+			transport.RLock()
+			done := transport.subscribers.Len() == 1
+			transport.RUnlock()
+
+			if done {
+				break
+			}
+		}
+
+		require.NoError(t, transport.Dispatch(ctx, &Update{
+			Topics: []string{"https://example.com/foos/c"},
+			Event:  Event{ID: "c", Data: "d3"},
+		}))
+
+		synctest.Wait()
+	})
+}
+
 func TestUnknownLastEventIDEmptyHistory(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Three hardening fixes against publisher-side abuse and an information leak in history replay.

### Publish-side input validation (moved into `Hub.Publish`)

* **Reserved topic namespace.** A publish request whose canonical or alternate topic contained `/.well-known/mercure` was accepted and dispatched. The hub uses that path namespace for its own subscription events; an authorized publisher with broad scope could therefore forge subscription lifecycle events to other subscribers. The hub now rejects such requests with `403 Forbidden`.
* **SSE field injection via `id` and `type`.** The form fields were copied verbatim into the outgoing SSE stream. Values containing CR (U+000D), LF (U+000A), or NUL (U+0000) injected arbitrary `event:` / `id:` / `data:` lines into every subscriber's stream. The hub now rejects such values with `400 Bad Request`. (`data` was already escaped by `dataReplacer`.)

Validation lives in `Hub.Publish` so both `PublishHandler` and direct library callers are covered without a double-check. New sentinel errors (`ErrReservedTopic`, `ErrInvalidEventID`, `ErrInvalidEventType`) let callers branch on the failure.

### History replay (Bolt)

* **Last-Event-ID disclosure.** When a subscriber reconnected with an unknown `Last-Event-ID`, the response `Last-Event-ID` header was set to the most recent in-history event ID — even when that event was a private update the subscriber was not authorized to read. The history scan now only updates `responseLastEventID` after evaluating `s.Match` against each candidate.
* **Backward-scan DoS.** An ancient or non-existent `Last-Event-ID` forced an unbounded history walk on every request. The per-request scan is now capped at `maxHistoryScan = 10000` events.

## Severity

These are hardening / defense-in-depth improvements. The publish-side fixes mitigate abuse-of-scope by an already-authorized publisher; the Last-Event-ID changes close a low-impact metadata leak (subscriber learns the ID — but not content — of one unreadable event) and a DoS amplification (bounded by hub history-size config anyway). No CVE filed.

## Files

* `publish.go` — sentinel errors, validation in `Hub.Publish`, `PublishHandler` routes through it.
* `event.go` — shared `containsSSEFieldForbiddenChar` helper.
* `bolt.go` — auth filter on `responseLastEventID`, per-request scan cap.
* `publish_test.go`, `subscribe_test.go` — regression tests.

## Test plan

- [x] `go test -tags "deprecated_server,deprecated_transport,nobadger,nomysql,nopgx" ./...` (279 passed)
- [x] New tests cover: `/.well-known/mercure` rejection (3 forms), CR/LF/NUL in `id` (3 forms), CR/LF/NUL in `type` (3 forms), private event ID is not disclosed via `Last-Event-ID` response header when subscriber's requested ID is unknown.