### PR TITLE
fix(security): export Update.Validate and document the transport contract

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -44,8 +44,15 @@ var (
 // let a publisher inject arbitrary SSE fields into subscribers' streams.
 const sseFieldForbiddenChars = "\x00\r\n"
 
-// validate is the single source of truth for publish-side input rules.
-func (u *Update) validate() error {
+// Validate enforces the publish-side input rules that protect subscribers
+// from update forgery and SSE field injection. Hub.Publish calls it, so the
+// bundled hub and PublishHandler are already covered.
+//
+// Callers that dispatch updates through a Transport directly, bypassing
+// Hub.Publish, MUST call Validate first and reject the update on error.
+// Skipping it lets a CR, LF, or NUL in ID or Type inject arbitrary SSE
+// fields into subscribers' streams (CWE-93).
+func (u *Update) Validate() error {
 	if len(u.Topics) > maxPublishTopics {
 		return ErrTooManyTopics
 	}
@@ -80,7 +87,7 @@ func (h *Hub) Publish(ctx context.Context, update *Update) error {
 		span.End()
 	}()
 
-	if err := update.validate(); err != nil {
+	if err := update.Validate(); err != nil {
 		if h.logger.Enabled(ctx, slog.LevelInfo) {
 			h.logger.LogAttrs(ctx, slog.LevelInfo, "Rejected invalid update", slog.Any("error", err))
 		}

--- a/publish.go
+++ b/publish.go
@@ -48,10 +48,13 @@ const sseFieldForbiddenChars = "\x00\r\n"
 // from update forgery and SSE field injection. Hub.Publish calls it, so the
 // bundled hub and PublishHandler are already covered.
 //
-// Callers that dispatch updates through a Transport directly, bypassing
+// A caller that builds an Update from untrusted input (e.g. a publisher
+// request) and dispatches it through a Transport directly, bypassing
 // Hub.Publish, MUST call Validate first and reject the update on error.
 // Skipping it lets a CR, LF, or NUL in ID or Type inject arbitrary SSE
-// fields into subscribers' streams (CWE-93).
+// fields into subscribers' streams (CWE-93). Validate also rejects the
+// reserved "/.well-known/mercure" topic namespace, so it is meant for
+// publisher input, not hub-internal updates such as subscription events.
 func (u *Update) Validate() error {
 	if len(u.Topics) > maxPublishTopics {
 		return ErrTooManyTopics

--- a/publish_test.go
+++ b/publish_test.go
@@ -1,6 +1,7 @@
 package mercure
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -467,6 +468,53 @@ func FuzzPublish(f *testing.F) {
 
 		assert.Equal(t, id, string(body))
 	})
+}
+
+func TestUpdateValidate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		update Update
+		want   error
+	}{
+		{"valid", Update{Event: Event{ID: "id", Type: "type"}, Topics: []string{"https://example.com/books/1"}}, nil},
+		{"empty", Update{}, nil},
+		{"reserved topic", Update{Topics: []string{"https://example.com/.well-known/mercure/subscriptions/foo"}}, ErrReservedTopic},
+		{"id LF", Update{Event: Event{ID: "foo\nevent: injected"}}, ErrInvalidEventID},
+		{"id CR", Update{Event: Event{ID: "foo\rinjected"}}, ErrInvalidEventID},
+		{"id NUL", Update{Event: Event{ID: "foo\x00bar"}}, ErrInvalidEventID},
+		{"type LF", Update{Event: Event{Type: "foo\nid: injected"}}, ErrInvalidEventType},
+		{"type CR", Update{Event: Event{Type: "foo\rinjected"}}, ErrInvalidEventType},
+		{"type NUL", Update{Event: Event{Type: "foo\x00bar"}}, ErrInvalidEventType},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.update.Validate()
+			if tc.want == nil {
+				assert.NoError(t, err)
+
+				return
+			}
+
+			assert.True(t, errors.Is(err, tc.want), "got %v, want %v", err, tc.want)
+		})
+	}
+}
+
+func TestUpdateValidateTooManyTopics(t *testing.T) {
+	t.Parallel()
+
+	topics := make([]string, maxPublishTopics+1)
+	for i := range topics {
+		topics[i] = "https://example.com/books/1"
+	}
+
+	err := (&Update{Topics: topics}).Validate()
+	assert.True(t, errors.Is(err, ErrTooManyTopics), "got %v, want %v", err, ErrTooManyTopics)
 }
 
 func TestPublishHandlerReservedTopicNamespace(t *testing.T) {

--- a/transport.go
+++ b/transport.go
@@ -12,6 +12,11 @@ const EarliestLastEventID = "earliest"
 // Transport provides methods to dispatch and persist updates.
 type Transport interface {
 	// Dispatch dispatches an update to all subscribers.
+	//
+	// It trusts u to be well-formed: callers invoking Dispatch directly
+	// instead of through Hub.Publish MUST call u.Validate first and reject
+	// the update on error, otherwise a CR, LF, or NUL in ID or Type can
+	// inject arbitrary SSE fields into subscribers' streams (CWE-93).
 	Dispatch(ctx context.Context, u *Update) error
 
 	// AddSubscriber adds a new subscriber to the transport.

--- a/transport.go
+++ b/transport.go
@@ -13,10 +13,13 @@ const EarliestLastEventID = "earliest"
 type Transport interface {
 	// Dispatch dispatches an update to all subscribers.
 	//
-	// It trusts u to be well-formed: callers invoking Dispatch directly
-	// instead of through Hub.Publish MUST call u.Validate first and reject
-	// the update on error, otherwise a CR, LF, or NUL in ID or Type can
-	// inject arbitrary SSE fields into subscribers' streams (CWE-93).
+	// It trusts u to be well-formed. A caller that builds u from untrusted
+	// input (e.g. a publisher request) and dispatches it directly instead of
+	// through Hub.Publish MUST call u.Validate first and reject the update on
+	// error, otherwise a CR, LF, or NUL in ID or Type can inject arbitrary SSE
+	// fields into subscribers' streams (CWE-93). Hub-internal updates such as
+	// subscription events are trusted and skip Validate (they use reserved
+	// topics that Validate rejects by design).
 	Dispatch(ctx context.Context, u *Update) error
 
 	// AddSubscriber adds a new subscriber to the transport.


### PR DESCRIPTION
The CR/LF/NUL validation added in https://github.com/dunglas/mercure/pull/1259 lives in `Hub.Publish`, which the bundled hub and `PublishHandler` route through. That closes SSE field injection (CWE-93) for the shipped server.

Callers embedding Mercure as a library can dispatch through a `Transport` directly, bypassing `Hub.Publish`. The validation never runs on that path, so a CR, LF, or NUL in `Event.ID` or `Event.Type` can still inject arbitrary SSE fields into subscribers' streams.

## Change

- Export the check as `Update.Validate` (was unexported `validate`).
- Document on `Update.Validate` and `Transport.Dispatch` that direct callers must call it and reject on error.

Go cannot enforce this while `Update`/`Event` fields stay exported, so this is a documented contract, not a compiler guarantee. The unexport-fields alternative is a breaking API change and was rejected. The hub path is unchanged; no runtime overhead is added.