### PR TITLE
fix(chart): guard httpRoute templates against null/absent values

### DIFF
--- a/charts/mercure/templates/NOTES.txt
+++ b/charts/mercure/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Get the URL of the Mercure Hub by running these commands:
-{{- if .Values.httpRoute.enabled }}
+{{- if (.Values.httpRoute | default dict).enabled }}
 {{- if .Values.httpRoute.hostnames }}
     export APP_HOSTNAME={{ .Values.httpRoute.hostnames | first }}
 {{- else if .Values.httpRoute.parentRefs }}

--- a/charts/mercure/templates/httproute.yaml
+++ b/charts/mercure/templates/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.httpRoute.enabled -}}
+{{- if (.Values.httpRoute | default dict).enabled -}}
 {{- $fullName := include "mercure.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
The `httproute.yaml` and `NOTES.txt` templates dereference `.Values.httpRoute.enabled` directly. That is safe for `helm install` / `helm template` (the `httpRoute.enabled: false` default in `values.yaml` is present), but it panics under `helm upgrade --reset-then-reuse-values` when the effective values omit the `httpRoute` block or set it to `null`:

```
template: mercure/templates/httproute.yaml:1:14: executing "mercure/templates/httproute.yaml"
  at <.Values.httpRoute.enabled>: nil pointer evaluating interface {}.enabled
```

This happens for releases first installed before the HTTPRoute feature (ingress-path deployments) whose reconstructed value set under `--reset-then-reuse-values` does not carry an `httpRoute` block, so `.Values.httpRoute` is `nil` rather than the chart default.

## Fix

Wrap the lookups in `(.Values.httpRoute | default dict).enabled`, so a missing or null block is treated as disabled instead of crashing the render. Two call sites:

- `charts/mercure/templates/httproute.yaml`
- `charts/mercure/templates/NOTES.txt`

## Verification

```
helm template t charts/mercure --set httpRoute=null   # no error (was: nil pointer panic)
helm template t charts/mercure                         # defaults, renders empty httproute
helm template t charts/mercure --set httpRoute.enabled=true --set httpRoute.parentRefs[0].name=gw  # renders HTTPRoute
helm lint charts/mercure                               # 0 failed
```