### PR TITLE
ci: fix Playwright install timeout and backport 0.x maintenance commits

### DIFF
--- a/.github/workflows/cd-chart.yml
+++ b/.github/workflows/cd-chart.yml
@@ -16,7 +16,7 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -16,7 +16,7 @@ jobs:
     environment: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,7 @@ jobs:
     environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci-chart.yml
+++ b/.github/workflows/ci-chart.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
@@ -40,7 +40,7 @@ jobs:
       CT_TARGET_BRANCH: main
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
             caddy/go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@v9.2.1
         with:
           version: latest
           args: --timeout=30m
 
       - name: golangci-lint (caddy module)
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@v9.2.1
         with:
           version: latest
           args: --timeout=30m --config ../.golangci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,23 @@ jobs:
         working-directory: conformance-tests/
         run: npm ci
 
-      - name: Install playwright browsers
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('conformance-tests/package-lock.json') }}
+
+      - name: Install Playwright system dependencies
         working-directory: conformance-tests/
-        timeout-minutes: 5
-        run: npx playwright install --with-deps
+        timeout-minutes: 10
+        run: npx playwright install-deps
+
+      - name: Install playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: conformance-tests/
+        timeout-minutes: 10
+        run: npx playwright install
 
       - name: Run Playwright tests
         working-directory: conformance-tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/docs/hub/cluster.md
+++ b/docs/hub/cluster.md
@@ -138,6 +138,47 @@ GLOBAL_OPTIONS="storage redis"
 
 <!-- markdownlint-enable MD010 -->
 
+###### Storing the Redis Password Securely (Helm)
+
+The Helm chart writes `GLOBAL_OPTIONS` into a ConfigMap (`templates/configmap.yaml`). Putting the Redis password directly in a `storage redis { ... password "..." ... }` block exposes it to anyone with `get configmap` permission on the namespace, while the rest of the credentials path (`MERCURE_EXTRA_DIRECTIVES`, JWT keys, license) already lives in a Secret.
+
+Keep the password out of the ConfigMap by referencing it via Caddy's `{env.NAME}` placeholder and sourcing the env var from a Secret:
+
+1. Create the Secret:
+
+   ```console
+   kubectl create secret generic mercure-redis \
+     --from-literal=password='<your Redis password>'
+   ```
+
+2. Reference it from the chart values:
+
+   <!-- markdownlint-disable MD010 -->
+
+   ```yaml
+   # values.yaml
+   globalOptions: |
+     storage redis {
+         host redis.example.com
+         port 6380
+         username default
+         password "{env.REDIS_PASSWORD}"
+         tls_enabled true
+     }
+   extraEnvs:
+     - name: REDIS_PASSWORD
+       valueFrom:
+         secretKeyRef:
+           name: mercure-redis
+           key: password
+   ```
+
+   <!-- markdownlint-enable MD010 -->
+
+Caddy expands `{env.REDIS_PASSWORD}` when it loads the configuration, so the storage module receives the value already substituted and the ConfigMap holds only the structure of the block. Note that env vars sourced from a Secret are injected at Pod start: updating the Secret does not propagate to running Pods, so rotating the password requires rolling the Deployment (`kubectl rollout restart`) or using a secret-reloader controller.
+
+The same `{env.NAME}` placeholder works inside `MERCURE_EXTRA_DIRECTIVES` if you prefer to keep all Redis references pointing at a single env var rather than embedding the password twice.
+
 ###### Legacy Redis URL
 
 **This feature is deprecated: use the new `transport` directive instead**.

--- a/gatling/pom.xml
+++ b/gatling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <gatling.version>3.15.0</gatling.version>
-    <gatling-maven-plugin.version>4.21.5</gatling-maven-plugin.version>
+    <gatling-maven-plugin.version>4.21.6</gatling-maven-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>

--- a/gatling/pom.xml
+++ b/gatling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <gatling.version>3.15.1</gatling.version>
-    <gatling-maven-plugin.version>4.21.6</gatling-maven-plugin.version>
+    <gatling-maven-plugin.version>4.21.7</gatling-maven-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>

--- a/gatling/pom.xml
+++ b/gatling/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <gatling.version>3.15.0</gatling.version>
+    <gatling.version>3.15.1</gatling.version>
     <gatling-maven-plugin.version>4.21.6</gatling-maven-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>


### PR DESCRIPTION
## CI fix

The `Install playwright browsers` step in `.github/workflows/ci.yml` timed out at `timeout-minutes: 5`: the ~170 MiB Chromium-for-Testing download plus the `--with-deps` apt install regularly overran the limit (the cause of the red `Test` job on recent PRs).

- Cache `~/.cache/ms-playwright` (`actions/cache@v4`, key `${{ runner.os }}-playwright-${{ hashFiles('conformance-tests/package-lock.json') }}`), invalidated when the Playwright version changes.
- Split system libs into `npx playwright install-deps` (apt, always run, not cacheable).
- Gate the browser download on a cache miss; raise the timeout 5 → 10 min.

All browsers are kept: `conformance-tests/playwright.config.ts` runs chromium, firefox and webkit, so restricting to chromium would drop coverage.

## Backports (main → 0.x)

Maintenance commits `main` had beyond `0.x`, cherry-picked with `-x` (none are 1.0/protocol-rework):

- db7ddde docs: store Redis password securely (#1251)
- 5abe8fe ci: bump golangci/golangci-lint-action 9.2.0 → 9.2.1
- ea81170 ci: bump docker/login-action 4.1.0 → 4.2.0
- 5993389 ci: bump gatling-maven-plugin 4.21.5 → 4.21.6
- 1cbb6b0 ci: bump actions/checkout 6 → 6.0.2
- 9f349ab ci: bump gatling-charts-highcharts 3.15.0 → 3.15.1
- 4ad7558 ci: bump gatling-maven-plugin 4.21.6 → 4.21.7

## Verification

Build tags `deprecated_server,deprecated_transport,nobadger,nomysql,nopgx`: root build + 293 tests pass, caddy build + 24 tests pass. No Go changes on this branch (`git diff origin/0.x..HEAD -- '*.go'` is empty); the two pre-existing `testifylint` warnings are untouched.