### PR TITLE
ci: target the 0.x branch for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: "0.x"
     schedule:
       interval: weekly
     commit-message:
@@ -10,6 +11,7 @@ updates:
       default-days: 7
   - package-ecosystem: maven
     directory: /gatling
+    target-branch: "0.x"
     schedule:
       interval: weekly
     commit-message:


### PR DESCRIPTION
Make Dependabot open its update PRs against the `0.x` maintenance branch instead of `main`. The maintainer merges `0.x` up into `main`, so dependency bumps should land on `0.x` first.