### PR TITLE
ci: pin Actions to SHAs, harden workflow permissions and secrets

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -1,9 +1,5 @@
 ---
 rules:
-  unpinned-uses:
-    config:
-      policies:
-        "*": ref-pin
   # Dependabot auto-merge requires pull_request_target to access repo-write
   # permissions; the workflow is guarded by an `if:` check on the PR author.
   dangerous-triggers:

--- a/.github/workflows/cd-chart.yml
+++ b/.github/workflows/cd-chart.yml
@@ -16,7 +16,7 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -28,11 +28,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
@@ -60,7 +60,7 @@ jobs:
             charts/mercure -d .cr-release-packages
 
       - name: Attest Helm chart
-        uses: actions/attest@v4
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: .cr-release-packages/*.tgz
 
@@ -72,7 +72,7 @@ jobs:
           gh release upload "$RELEASE_TAG" .cr-release-packages/* --clobber
 
       - name: Update Helm chart repo index
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           skip_packaging: true
           skip_existing: true

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -22,7 +22,9 @@ jobs:
           fetch-depth: 2
 
       - name: Revalidate changed pages
+        env:
+          REVALIDATE_TOKEN: ${{ secrets.REVALIDATE_TOKEN }}
         run: |
           shopt -s globstar
           FILES=$(git --no-pager diff --name-only HEAD~1 -- docs/**/*.md | awk 'BEGIN{RS="\n"} {printf "%s%s",sep,$0; sep="&files="}')
-          curl --silent --fail-with-body "https://mercure.rocks/api/revalidate?secret=${{ secrets.REVALIDATE_TOKEN }}&files=$FILES"
+          curl --silent --fail-with-body "https://mercure.rocks/api/revalidate?secret=${REVALIDATE_TOKEN}&files=$FILES"

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -16,7 +16,7 @@ jobs:
     environment: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,13 +26,13 @@ jobs:
     environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           cache: false
           go-version: "1.26"
@@ -43,7 +43,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -51,7 +51,7 @@ jobs:
       - name: Import GPG key
         if: startsWith(github.ref, 'refs/tags/v')
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
@@ -63,7 +63,7 @@ jobs:
           echo "GORELEASER_PREVIOUS_TAG=$(awk 'NR==2 {print;exit}' <<< "$tags")"  >> "$GITHUB_ENV"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7.2.2
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: latest
           args: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || 'build --single-target --snapshot' }} --clean --timeout 60m
@@ -73,7 +73,7 @@ jobs:
 
       - name: Attest release artifacts
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest@v4
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: |
             ${{ github.workspace }}/dist/**/mercure
@@ -93,7 +93,7 @@ jobs:
 
       - name: Attest Caddy Docker manifest
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest@v4
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           # docker.io/ prefix is required: actions/attest splits subject-name
           # on the first '/' to find the registry. We only push to Docker Hub.
@@ -110,7 +110,7 @@ jobs:
 
       - name: Attest legacy Docker image
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest@v4
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: docker.io/dunglas/mercure
           subject-digest: ${{ steps.legacy_image.outputs.digest }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload snapshot
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: snapshot
           path: dist/*

--- a/.github/workflows/ci-chart.yml
+++ b/.github/workflows/ci-chart.yml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - name: Regenerate values.schema.json
-        uses: losisin/helm-values-schema-json-action@v3
+        uses: losisin/helm-values-schema-json-action@cfefdf4241da6dbe17f3378e3cd0e863d4a4c3c8 # v3.0.1
         with:
           working-directory: charts/mercure
           fail-on-diff: true
@@ -40,20 +40,20 @@ jobs:
       CT_TARGET_BRANCH: main
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -69,7 +69,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
       - name: Install Gateway API CRDs
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
           cache-dependency-path: |
@@ -33,13 +33,13 @@ jobs:
             caddy/go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
           args: --timeout=30m
 
       - name: golangci-lint (caddy module)
-        uses: golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
           args: --timeout=30m --config ../.golangci.yml
@@ -54,12 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go }}
           cache-dependency-path: |
@@ -79,7 +79,7 @@ jobs:
           sed '1d' profile.cov >> ../profile.cov
 
       - name: Upload coverage results
-        uses: shogo82148/actions-goveralls@v1
+        uses: shogo82148/actions-goveralls@9606dbc5ac5cf888a0e9ef901515c3cd516a2790 # v1.11.0
         with:
           path-to-profile: profile.cov
           parallel: true
@@ -88,7 +88,7 @@ jobs:
         working-directory: caddy/mercure/
         run: sudo MERCURE_PUBLISHER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' MERCURE_SUBSCRIBER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' go run main.go start --config ../../dev.Caddyfile
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "lts/*"
           cache: "npm"
@@ -100,7 +100,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('conformance-tests/package-lock.json') }}
@@ -133,6 +133,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: shogo82148/actions-goveralls@v1
+      - uses: shogo82148/actions-goveralls@9606dbc5ac5cf888a0e9ef901515c3cd516a2790 # v1.11.0
         with:
           parallel-finished: true

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    environment: dependabot
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,17 +5,23 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
       - name: Enable auto-merge
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,14 +8,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  packages: read
-  statuses: write
+permissions: {}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,12 +17,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8.6.0
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: .*gatling/mvnw.*|conformance-tests/.*\.ts$|examples/chat/chart/mercure-example-chat/README.md$

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,14 @@ jobs:
             echo "::error::Branch ${GITHUB_REF#refs/heads/} can only release versions with major ${branch_major} (e.g. ${branch_major}.0.0), got ${VERSION}"
             exit 1
           fi
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: release-app-token
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v7.0.0
+          permission-contents: write
+          permission-actions: write
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -153,7 +155,7 @@ jobs:
             echo "resume=false" >> "${GITHUB_OUTPUT}"
           fi
       - if: steps.state.outputs.resume != 'true'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           check-latest: true


### PR DESCRIPTION
Hardens GitHub Actions security after a Dependabot auto-merge run failed on a workflow-touching PR.

## Changes
- Pin every workflow `uses:` to a full commit SHA (with a version comment Dependabot keeps current). Drop the zizmor `unpinned-uses: ref-pin` override so the default hash-pin policy enforces it. Mitigates the tag-mutation supply-chain class (e.g. tj-actions).
- Fix Dependabot auto-merge: the default `GITHUB_TOKEN` lacks the `workflows` scope and refused to enable auto-merge on PRs that touch `.github/workflows/`. Use the release GitHub App token instead, scoped per step to least privilege.
- Scope the release token to `contents: write` + `actions: write`; scope the auto-merge token to `contents`/`pull-requests`/`workflows: write`.
- Pass the docs revalidate secret through step `env` instead of inline `${{ }}` expansion in the run command (template-injection).
- Move `lint.yml` write permission down to the job level.

## Notes
- Requires `Pull requests: write` on the `dunglas-release` GitHub App (added).
- Go dependency security updates stay handled by Dependabot security updates (repo setting); no `gomod` version-update entry added.
- `zizmor` (default persona) reports no findings.