### PR TITLE
ci: run Dependabot auto-merge in the release environment

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    environment: dependabot
+    environment: release
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
Follow-up to https://github.com/dunglas/mercure/pull/1288.

`RELEASE_APP_ID` (variable) and `RELEASE_APP_PRIVATE_KEY` (secret) are scoped to the `release` environment. The auto-merge job declared a placeholder `dependabot` environment, so `vars.RELEASE_APP_ID` resolved empty and `create-github-app-token` failed with *"The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string"*. Point the job at `release` (no protection rules, so auto-merge stays unattended) to reach the credentials, which also satisfies zizmor `secrets-outside-env`.