### PR TITLE
fix(security): pin the JWT algorithm allowlist in compatibility mode

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -37,8 +37,8 @@ var ErrInvalidResourceIdentifier = errors.New("the resource identifier must be a
 // schemeHTTPS is the URL scheme required by RFC 9728 resource identifiers.
 const schemeHTTPS = "https"
 
-// defaultJWTAlgorithms is the signature-algorithm allowlist applied in modern
-// mode when a JWT key function is configured without an explicit list (the
+// defaultJWTAlgorithms is the signature-algorithm allowlist applied, in every
+// mode, when a JWT key function is configured without an explicit list (the
 // JWKS path). It contains only asymmetric algorithms: allowing an HMAC
 // algorithm next to public keys would enable algorithm-confusion attacks.
 //
@@ -437,10 +437,25 @@ func (o *opt) configureIdentifiers() error {
 	return o.applyModernDefaults()
 }
 
-// applyModernDefaults enforces the modern-mode (non-compatibility) config
-// rules: an RFC 9728-shaped resource identifier and an explicit JWS
-// algorithm allowlist for every configured key function.
+// applyModernDefaults enforces the config invariants: an explicit JWS
+// algorithm allowlist for every configured key function (in every mode) and,
+// in modern mode only, an RFC 9728-shaped resource identifier.
 func (o *opt) applyModernDefaults() error {
+	// The protocol requires an explicit signature-algorithm allowlist that is
+	// never derived from the token. Key functions configured without one (the
+	// JWKS path) get the documented default: asymmetric algorithms only, so a
+	// public JWK can never be reinterpreted as an HMAC secret. This holds in
+	// compatibility mode too: a relaxed protocol version must never relax the
+	// algorithm allowlist. Operators pinning a symmetric algorithm on a bare
+	// key function opt in explicitly via WithPublisher/SubscriberJWTAlgorithms.
+	if o.publisherJWTKeyFunc != nil && len(o.publisherJWTAlgorithms) == 0 {
+		o.publisherJWTAlgorithms = defaultJWTAlgorithms
+	}
+
+	if o.subscriberJWTKeyFunc != nil && len(o.subscriberJWTAlgorithms) == 0 {
+		o.subscriberJWTAlgorithms = defaultJWTAlgorithms
+	}
+
 	if o.protocolVersionCompatibility != 0 {
 		return nil
 	}
@@ -457,18 +472,6 @@ func (o *opt) applyModernDefaults() error {
 		if u.Scheme != schemeHTTPS {
 			o.logger.Warn(`The resource identifier does not use the "https" scheme; strict RFC 9728 clients will ignore the hub's protected resource metadata.`)
 		}
-	}
-
-	// The protocol requires an explicit signature-algorithm allowlist that is
-	// never derived from the token. Key functions configured without one (the
-	// JWKS path) get the documented default: asymmetric algorithms only, so a
-	// public JWK can never be reinterpreted as an HMAC secret.
-	if o.publisherJWTKeyFunc != nil && len(o.publisherJWTAlgorithms) == 0 {
-		o.publisherJWTAlgorithms = defaultJWTAlgorithms
-	}
-
-	if o.subscriberJWTKeyFunc != nil && len(o.subscriberJWTAlgorithms) == 0 {
-		o.subscriberJWTAlgorithms = defaultJWTAlgorithms
 	}
 
 	return nil

--- a/hub_test.go
+++ b/hub_test.go
@@ -470,6 +470,28 @@ func TestNewHubDefaultJWTAlgorithms(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidJWT)
 }
 
+// TestCompatModeDefaultJWTAlgorithms ensures the asymmetric-only default
+// allowlist is applied to a bare key function in compatibility mode too: a
+// relaxed protocol version must not reopen the algorithm-confusion hole.
+func TestCompatModeDefaultJWTAlgorithms(t *testing.T) {
+	t.Parallel()
+
+	h, err := NewHub(t.Context(),
+		WithProtocolVersionCompatibility(7),
+		WithSubscriberJWTKeyFunc(func(*jwt.Token) (any, error) { return []byte("subscriber"), nil }),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, defaultJWTAlgorithms, h.subscriberJWTAlgorithms)
+
+	// An HS256 token is rejected at parse time even though the key function
+	// would return the matching secret: the algorithm is not in the allowlist.
+	r, _ := http.NewRequest(http.MethodGet, defaultHubURL, nil)
+	r.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(roleSubscriber, []string{"foo"}))
+
+	_, err = h.authorize(r, false)
+	require.ErrorIs(t, err, ErrInvalidJWT)
+}
+
 const testResourceIdentifier = "https://example.com/.well-known/mercure"
 
 func createDummyAuthorizedJWT(r role, topics []string) string {


### PR DESCRIPTION
From the 1.0 auth-surface security review.

## Problem

`applyModernDefaults` (`hub.go`) returned early whenever a protocol-version compatibility was configured, **before** assigning the default asymmetric-only JWS algorithm allowlist. A hub built with a bare key function (the JWKS path, `WithPublisher/SubscriberJWTKeyFunc`) and no explicit algorithms therefore left the allowlist empty in compatibility mode, so `jwtParserOptions` never applied `jwt.WithValidMethods`. The parser then accepted whatever `alg` the token header declared.

Failure scenario: an operator on compatibility mode (v7/v8) wiring a JWKS keyfunc that returns a parsed public key, with no explicit algorithms — an attacker forges an `HS256` token signed with the RSA/EC public-key bytes as the HMAC secret. Not exploitable against the built-in `WithPublisherJWT`/`WithSubscriberJWT` configs (they always set `algs=[alg]`) or a keyfunc that pins `t.Method`; it bites the bare-JWKS-in-compat-mode path.

## Fix

Apply the asymmetric-only default allowlist to every configured key function in **all** modes; a relaxed protocol version must not relax the signature-algorithm check. Operators pinning a symmetric algorithm on a bare key function still opt in explicitly via `WithPublisher/SubscriberJWTAlgorithms`.

Added `TestCompatModeDefaultJWTAlgorithms`: a compat-mode hub with a bare HMAC keyfunc now rejects an HS256 token at parse time.

## Not changed

The review also flagged the per-detail `actions` array as having no explicit element cap (INFO). The loop is O(n), bounded by the transport request-body limit, with no compilation or amplification, and `maxMercureDetails`/`maxDetailTopics` remain enforced. No change warranted.

Tests pass with `-race` on both tag combos; `go vet` and `golangci-lint` clean.