### PR TITLE
docs: complete RFC 9068 token example

### DIFF
--- a/docs/concepts/authorization.md
+++ b/docs/concepts/authorization.md
@@ -22,8 +22,12 @@ A Mercure access token is a JWT access token as defined by [RFC 9068](https://ww
 // payload
 {
   "iss": "https://example.com",
+  "sub": "https://example.com/users/42",
+  "client_id": "https://example.com",
+  "iat": 4102441200,
   "aud": "https://hub.example.com/.well-known/mercure",
   "exp": 4102444800,
+  "jti": "urn:uuid:e70ff8d7-59d5-4a92-b0b7-505e8f6d09fa",
   "authorization_details": [
     {
       "type": "https://mercure.rocks/authorization-detail",


### PR DESCRIPTION
## Summary

Add the four RFC 9068 claims still missing from the main JWT access token example in `docs/concepts/authorization.md`:

- `sub`
- `client_id`
- `iat`
- `jti`

The surrounding text already states that RFC 9068 requires issuers to populate these claims, and the specification example was completed in #1297. This keeps the user-facing documentation example consistent with both RFC 9068 §2.2 and `spec/mercure.md`.

## Scope

Documentation only. No runtime behavior changes.