### PR TITLE
feat!: carry subscription API cursor in the rel="mercure" Link header

### DIFF
--- a/docs/concepts/active-subscriptions.md
+++ b/docs/concepts/active-subscriptions.md
@@ -138,7 +138,7 @@ const es = new EventSource(url, { withCredentials: true });
 The hub returns the cursor in the `Link` header and the subscriptions in the body:
 
 ```http
-Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
+Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"; type="mercure"; content-type="application/json"
 ```
 
 ```jsonc

--- a/docs/concepts/active-subscriptions.md
+++ b/docs/concepts/active-subscriptions.md
@@ -110,28 +110,36 @@ Once subscription events are enabled, the hub also exposes a JSON-LD API. Use it
 
 Authorization rules are the same as for events: the request URL must be covered by a `subscribe` grant in the caller's token.
 
-Each response carries `last_event_id`. Pass it to your SSE connection so you don't miss any subscription event between the snapshot and the live stream:
+Each response carries the reconciliation cursor as the `last-event-id` attribute of its `rel="mercure"` [`Link` header](reconnection-and-history.md#bootstrapping-after-page-load), the same mechanism used at discovery time. Pass it to your SSE connection so you don't miss any subscription event between the snapshot and the live stream:
 
 ```javascript
 // Subscription API
-const snapshot = await fetch(
+const resp = await fetch(
   "https://hub.example.com/.well-known/mercure/subscriptions",
   { credentials: "include" },
-).then((r) => r.json());
+);
+const lastEventId = resp.headers
+  .get("Link")
+  .match(/rel="mercure".*?last-event-id="([^"]*)"/)?.[1];
+const snapshot = await resp.json();
 
 const url = new URL("https://hub.example.com/.well-known/mercure");
 url.searchParams.append(
   "match_urlpattern",
   "/.well-known/mercure/subscriptions/:match_type/:match/:subscriber",
 );
-url.searchParams.append("last_event_id", snapshot.last_event_id);
+if (lastEventId) url.searchParams.append("last_event_id", lastEventId);
 
 const es = new EventSource(url, { withCredentials: true });
 // snapshot.subscriptions is the initial list
 // es.onmessage applies deltas as subscribers come and go
 ```
 
-The hub returns:
+The hub returns the cursor in the `Link` header and the subscriptions in the body:
+
+```http
+Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
+```
 
 ```jsonc
 // Subscription API
@@ -139,7 +147,6 @@ The hub returns:
   "@context": "https://mercure.rocks/",
   "id": "/.well-known/mercure/subscriptions",
   "type": "Subscriptions",
-  "last_event_id": "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb",
   "subscriptions": [
     {
       "id": "/.well-known/mercure/subscriptions/urlpattern/https%3A%2F%2Fexample.com%2F%3Aselector/urn%3Auuid%3Abb3de268",

--- a/examples/chat/static/chat.js
+++ b/examples/chat/static/chat.js
@@ -21,6 +21,10 @@ let userList;
   const resp = await fetch(new URL(subscriptionsTopic, hubURL), {
     credentials: "include",
   });
+  // The cursor is carried by the rel="mercure" Link header, not the body.
+  const lastEventId = (resp.headers.get("Link") ?? "").match(
+    /rel="mercure".*?last-event-id="([^"]*)"/,
+  )?.[1];
   const subscriptionCollection = await resp.json();
   userList = new Map(
     subscriptionCollection.subscriptions
@@ -33,10 +37,7 @@ let userList;
   updateUserListView();
 
   const subscribeURL = new URL(hubURL);
-  subscribeURL.searchParams.append(
-    "last_event_id",
-    subscriptionCollection.last_event_id,
-  );
+  if (lastEventId) subscribeURL.searchParams.append("last_event_id", lastEventId);
   subscribeURL.searchParams.append("match_urlpattern", messagePattern);
   subscribeURL.searchParams.append("match_urlpattern", presencePattern);
 

--- a/examples/chat/static/chat.js
+++ b/examples/chat/static/chat.js
@@ -37,7 +37,8 @@ let userList;
   updateUserListView();
 
   const subscribeURL = new URL(hubURL);
-  if (lastEventId) subscribeURL.searchParams.append("last_event_id", lastEventId);
+  if (lastEventId)
+    subscribeURL.searchParams.append("last_event_id", lastEventId);
   subscribeURL.searchParams.append("match_urlpattern", messagePattern);
   subscribeURL.searchParams.append("match_urlpattern", presencePattern);
 

--- a/handler.go
+++ b/handler.go
@@ -87,7 +87,10 @@ func (h *Hub) corsHandler(router http.Handler) http.Handler {
 		AllowCredentials: allowCredentials,
 		AllowedMethods:   []string{http.MethodGet, http.MethodHead, http.MethodPost, methodQuery},
 		AllowedHeaders:   []string{authorizationHeader, "cache-control", "last-event-id"},
-		Debug:            h.debug,
+		// Exposed so cross-origin subscribers can read the subscription API's
+		// rel="mercure" Link header, which carries the last-event-id cursor.
+		ExposedHeaders: []string{"Link"},
+		Debug:          h.debug,
 	}).Handler(router)
 }
 

--- a/handler_deprecated.go
+++ b/handler_deprecated.go
@@ -195,6 +195,7 @@ func (h *Hub) chainHandlers() http.Handler { //nolint:funlen
 			AllowCredentials: true,
 			AllowedMethods:   []string{http.MethodGet, http.MethodHead, http.MethodPost, methodQuery},
 			AllowedHeaders:   []string{authorizationHeader, "cache-control", "last-event-id"},
+			ExposedHeaders:   []string{"Link"},
 		}).Handler(r)
 	} else {
 		corsHandler = r

--- a/public/app.js
+++ b/public/app.js
@@ -289,6 +289,11 @@ foo`;
         opt,
       );
       if (!resp.ok) throw new Error(resp.statusText);
+      // The snapshot cursor is carried by the rel="mercure" Link header's
+      // last-event-id attribute, not the JSON body.
+      const lastEventId = (resp.headers.get("Link") ?? "").match(
+        /rel="mercure".*?last-event-id="([^"]*)"/,
+      )?.[1];
       const json = await resp.json();
 
       json.subscriptions.forEach(addSubscription);
@@ -299,7 +304,7 @@ foo`;
         "match_urlpattern",
         "/.well-known/mercure/subscriptions/:match_type/:match/:subscriber",
       );
-      u.searchParams.append("last_event_id", json.last_event_id);
+      if (lastEventId) u.searchParams.append("last_event_id", lastEventId);
 
       subscriptionEventSource = openEventSource(u);
 

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -1071,22 +1071,22 @@ properties:
 *   `type`: the fixed value `subscriptions`.
 *   `subscriptions`: an array of subscription documents as described in (#subscription-events).
 
-In addition, every endpoint **MUST** carry the reconciliation cursor on the `rel="mercure"` Link
-header [@!RFC8288] it sends, as a `last-event-id` target attribute — the same mechanism used at
-discovery (see (#discovery)), rather than a property of the JSON body:
+In addition, every endpoint **MUST** carry the reconciliation cursor as a `last-event-id` target
+attribute on the `rel="mercure"` Link header [@!RFC8288], following the same mechanism as
+discovery (see (#discovery)):
 
 *   `last-event-id`: the identifier of the last event dispatched by the hub at the time of this
     request (see (#reconciliation)). The value **MUST** be `earliest` if no events have been
-    dispatched yet. This value **SHOULD** be passed back to the hub, as the `last_event_id` query
-    parameter (see (#reconciliation)), when subscribing to subscription events to prevent data
-    loss. Carrying it on the Link header lets a single-subscription response body be exactly the
-    subscription event document of (#subscription-events), as required above.
+    dispatched yet. This value **SHOULD** be passed back to the hub as the `last_event_id` query
+    parameter (see (#reconciliation)) when subscribing to subscription events, to prevent data
+    loss. Because the cursor is carried on the Link header, a single-subscription response body
+    is the subscription event document of (#subscription-events) without modification.
 
-Subscription events form a homogeneous stream — they are always delivered under the reserved
+Subscription events are a homogeneous stream: they are always delivered under the reserved
 `mercure` event type with a JSON body (see (#subscription-events)). For consistency with
-discovery (see (#discovery)) and to save the subscriber from assuming these values, the hub
-**SHOULD** also set the `type` and `content-type` attributes on the same `rel="mercure"` Link
-header, with the values `mercure` and `application/json` respectively.
+discovery (see (#discovery)), the hub **SHOULD** also set the `type` and `content-type`
+attributes on the same `rel="mercure"` Link header, with the values `mercure` and
+`application/json` respectively.
 
 Active subscription collections can be large. Hubs **MAY** truncate or paginate collection
 responses according to an implementation-defined policy; each returned document **MUST** remain
@@ -1243,21 +1243,21 @@ The publisher **MAY** provide the following target attributes in the Link Header
     pushed, in formats such as JSON Patch [@RFC6902] or JSON Merge Patch [@RFC7396]. Because the
     `data` field of a Server-Sent Event carries no content type of its own, this attribute lets a
     subscriber process the payload without content sniffing.
-*   `type`: the Server-Sent Events event type (the SSE `event` field, see (#subscription)) the
-    updates pushed for this resource will carry. A subscriber using the `EventSource` interface
-    [@!HTML] can register a listener for this type; if omitted, the subscriber **MUST** assume
-    the default event type (the events delivered to the `EventSource` `message` handler). It is
+*   `type`: the Server-Sent Events `event` field value (see (#subscription)) that the updates
+    pushed for this resource will carry. A subscriber using the `EventSource` interface [@!HTML]
+    can register a listener for this type; if omitted, the subscriber **MUST** assume the default
+    event type (the events delivered to the `EventSource` `message` handler). It is
     subject to the same character constraints as the publication `type` field (see
     (#publication)). A publisher advertising its own resource **MUST NOT** use the reserved
-    `mercure` type, which the hub generates for subscription events; the hub itself does advertise
-    `mercure` on the subscription API, where the stream is exactly those events (see
-    (#subscription-api) and (#subscription-events)).
+    `mercure` type, which the hub generates for subscription events; the hub advertises `mercure`
+    on the subscription API, where the stream consists of those events (see (#subscription-api)
+    and (#subscription-events)).
 
 The `content-type` and `type` attributes each describe a single, homogeneous update stream: a
 publisher whose updates for a resource use more than one content type, or more than one event
 type, **MUST** omit the corresponding attribute, and the subscriber then determines that value
-from each individual update. These attributes are hints for the common case; they never alter
-routing, which is governed solely by topic matchers (see (#subscription)).
+from each individual update. These attributes are hints; they do not affect routing, which is
+governed solely by topic matchers (see (#subscription)).
 
 All these attributes are optional.
 

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -1073,14 +1073,12 @@ properties:
 
 In addition, every endpoint **MUST** carry the reconciliation cursor as a `last-event-id` target
 attribute on the `rel="mercure"` Link header [@!RFC8288], following the same mechanism as
-discovery (see (#discovery)):
-
-*   `last-event-id`: the identifier of the last event dispatched by the hub at the time of this
-    request (see (#reconciliation)). The value **MUST** be `earliest` if no events have been
-    dispatched yet. This value **SHOULD** be passed back to the hub as the `last_event_id` query
-    parameter (see (#reconciliation)) when subscribing to subscription events, to prevent data
-    loss. Because the cursor is carried on the Link header, a single-subscription response body
-    is the subscription event document of (#subscription-events) without modification.
+discovery (see (#discovery)). The value is the identifier of the last event dispatched by the hub
+at the time of this request (see (#reconciliation)), or `earliest` if no events have been
+dispatched yet. It **SHOULD** be passed back to the hub as the `last_event_id` query parameter
+(see (#reconciliation)) when subscribing to subscription events, to prevent data loss. Because
+the cursor is carried on the Link header, a single-subscription response body is the subscription
+event document of (#subscription-events) without modification.
 
 Subscription events are a homogeneous stream: they are always delivered under the reserved
 `mercure` event type with a JSON body (see (#subscription-events)). For consistency with

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -895,9 +895,10 @@ Subscribers using the hub as an event store can use the returned identifier as a
 anchor; subscribers that only need to detect data loss can compare it against the requested
 value (a different value indicates that loss may have occurred).
 
-Note: Event identifiers are cursors, and the hub exposes them to subscribers, both through the
-`last_event_id` value provided during discovery and through the `Mercure-Last-Event-ID` response
-field.
+Note: Event identifiers are cursors, and the hub exposes them to subscribers through the
+`last-event-id` attribute of the `rel="mercure"` Link header provided during discovery
+(see (#discovery)) and by the subscription API (see (#subscription-api)), and through the
+`Mercure-Last-Event-ID` response field.
 The field value can be the identifier of an event immediately preceding one the subscriber is
 not authorized to receive. A subscriber can therefore infer the existence of such an event and,
 when the hub uses time-ordered identifiers (e.g., UUIDv7 [@RFC9562]), its approximate timing
@@ -1048,7 +1049,10 @@ a broader set (for example a `urlpattern` covering the subscriptions namespace, 
 `*`) grants access to the corresponding endpoints. If no detail grants `subscribe` on the
 requested URL, the hub **MUST** answer `403` as defined in (#authorization).
 
-The web API **MUST** set the `Content-Type` HTTP header to `application/json`.
+The web API **MUST** set the `Content-Type` HTTP header to `application/json`. When the hub
+serves cross-origin subscribers, it **MUST** expose the `Link` response header to them (for
+example, through the `Access-Control-Expose-Headers` header [@!FETCH]) so they can read the
+`last-event-id` attribute defined below; see (#subscription).
 
 URLs returning a single subscription (following the pattern
 `/.well-known/mercure/subscriptions/{match_type}/{match}/{subscriber}`) **MUST** expose the same
@@ -1067,13 +1071,16 @@ properties:
 *   `type`: the fixed value `subscriptions`.
 *   `subscriptions`: an array of subscription documents as described in (#subscription-events).
 
-In addition, all endpoints **MUST** set the `last_event_id` property at the root of the returned
-JSON document:
+In addition, every endpoint **MUST** carry the reconciliation cursor on the `rel="mercure"` Link
+header [@!RFC8288] it sends, as a `last-event-id` target attribute — the same mechanism used at
+discovery (see (#discovery)), rather than a property of the JSON body:
 
-*   `last_event_id`: the identifier of the last event dispatched by the hub at the time of this
+*   `last-event-id`: the identifier of the last event dispatched by the hub at the time of this
     request (see (#reconciliation)). The value **MUST** be `earliest` if no events have been
-    dispatched yet. This value **SHOULD** be passed back to the hub when subscribing to
-    subscription events to prevent data loss.
+    dispatched yet. This value **SHOULD** be passed back to the hub, as the `last_event_id` query
+    parameter (see (#reconciliation)), when subscribing to subscription events to prevent data
+    loss. Carrying it on the Link header lets a single-subscription response body be exactly the
+    subscription event document of (#subscription-events), as required above.
 
 Active subscription collections can be large. Hubs **MAY** truncate or paginate collection
 responses according to an implementation-defined policy; each returned document **MUST** remain
@@ -1090,14 +1097,13 @@ Host: example.com
 
 HTTP/1.1 200 OK
 Content-Type: application/json
-Link: <https://example.com/.well-known/mercure>; rel="mercure"
+Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 ETag: "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 Cache-Control: must-revalidate
 
 {
    "id": "/.well-known/mercure/subscriptions",
    "type": "subscriptions",
-   "last_event_id": "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb",
    "subscriptions": [
       {
          "id": "/.well-known/mercure/subscriptions/urlpattern/https%3A%2F%2Fexample.com%2F%3Aselector/urn%3Auuid%3Abb3de268-05b0-4c65-b44e-8f9acefc29d6",
@@ -1136,14 +1142,13 @@ Host: example.com
 
 HTTP/1.1 200 OK
 Content-Type: application/json
-Link: <https://example.com/.well-known/mercure>; rel="mercure"
+Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 ETag: "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 Cache-Control: must-revalidate
 
 {
    "id": "/.well-known/mercure/subscriptions/urlpattern/https%3A%2F%2Fexample.com%2F%3Aselector",
    "type": "subscriptions",
-   "last_event_id": "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb",
    "subscriptions": [
       {
          "id": "/.well-known/mercure/subscriptions/urlpattern/https%3A%2F%2Fexample.com%2F%3Aselector/urn%3Auuid%3Abb3de268-05b0-4c65-b44e-8f9acefc29d6",
@@ -1173,7 +1178,7 @@ Host: example.com
 
 HTTP/1.1 200 OK
 Content-Type: application/json
-Link: <https://example.com/.well-known/mercure>; rel="mercure"
+Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 ETag: "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 Cache-Control: must-revalidate
 
@@ -1184,8 +1189,7 @@ Cache-Control: must-revalidate
    "match_type": "urlpattern",
    "subscriber": "urn:uuid:bb3de268-05b0-4c65-b44e-8f9acefc29d6",
    "active": true,
-   "payload": {"foo": "bar"},
-   "last_event_id": "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
+   "payload": {"foo": "bar"}
 }
 ~~~
 

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -1082,6 +1082,12 @@ discovery (see (#discovery)), rather than a property of the JSON body:
     loss. Carrying it on the Link header lets a single-subscription response body be exactly the
     subscription event document of (#subscription-events), as required above.
 
+Subscription events form a homogeneous stream — they are always delivered under the reserved
+`mercure` event type with a JSON body (see (#subscription-events)). For consistency with
+discovery (see (#discovery)) and to save the subscriber from assuming these values, the hub
+**SHOULD** also set the `type` and `content-type` attributes on the same `rel="mercure"` Link
+header, with the values `mercure` and `application/json` respectively.
+
 Active subscription collections can be large. Hubs **MAY** truncate or paginate collection
 responses according to an implementation-defined policy; each returned document **MUST** remain
 valid as described above. Pagination mechanisms are out of scope for this specification.
@@ -1097,7 +1103,7 @@ Host: example.com
 
 HTTP/1.1 200 OK
 Content-Type: application/json
-Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
+Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"; type="mercure"; content-type="application/json"
 ETag: "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 Cache-Control: must-revalidate
 
@@ -1142,7 +1148,7 @@ Host: example.com
 
 HTTP/1.1 200 OK
 Content-Type: application/json
-Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
+Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"; type="mercure"; content-type="application/json"
 ETag: "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 Cache-Control: must-revalidate
 
@@ -1178,7 +1184,7 @@ Host: example.com
 
 HTTP/1.1 200 OK
 Content-Type: application/json
-Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
+Link: <https://example.com/.well-known/mercure>; rel="mercure"; last-event-id="urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"; type="mercure"; content-type="application/json"
 ETag: "urn:uuid:5e94c686-2c0b-4f9b-958c-92ccc3bbb4eb"
 Cache-Control: must-revalidate
 
@@ -1234,7 +1240,24 @@ The publisher **MAY** provide the following target attributes in the Link Header
 *   `content-type`: the content type of the updates that will be pushed by the hub. If omitted,
     the subscriber **MUST** assume that the content type matches that of the original resource.
     The `content-type` attribute is especially useful to indicate that partial updates will be
-    pushed, in formats such as JSON Patch [@RFC6902] or JSON Merge Patch [@RFC7396].
+    pushed, in formats such as JSON Patch [@RFC6902] or JSON Merge Patch [@RFC7396]. Because the
+    `data` field of a Server-Sent Event carries no content type of its own, this attribute lets a
+    subscriber process the payload without content sniffing.
+*   `type`: the Server-Sent Events event type (the SSE `event` field, see (#subscription)) the
+    updates pushed for this resource will carry. A subscriber using the `EventSource` interface
+    [@!HTML] can register a listener for this type; if omitted, the subscriber **MUST** assume
+    the default event type (the events delivered to the `EventSource` `message` handler). It is
+    subject to the same character constraints as the publication `type` field (see
+    (#publication)). A publisher advertising its own resource **MUST NOT** use the reserved
+    `mercure` type, which the hub generates for subscription events; the hub itself does advertise
+    `mercure` on the subscription API, where the stream is exactly those events (see
+    (#subscription-api) and (#subscription-events)).
+
+The `content-type` and `type` attributes each describe a single, homogeneous update stream: a
+publisher whose updates for a resource use more than one content type, or more than one event
+type, **MUST** omit the corresponding attribute, and the subscriber then determines that value
+from each individual update. These attributes are hints for the common case; they never alter
+routing, which is governed solely by topic matchers (see (#subscription)).
 
 All these attributes are optional.
 

--- a/subscription.go
+++ b/subscription.go
@@ -139,7 +139,7 @@ func (h *Hub) SubscriptionsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	span, currentURL, _, subscribers, ok := h.initSubscription(w, r)
+	span, currentURL, subscribers, ok := h.initSubscription(w, r)
 	defer span.End()
 
 	if !ok {
@@ -192,7 +192,7 @@ func (h *Hub) SubscriptionHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	span, _, _, subscribers, ok := h.initSubscription(w, r)
+	span, _, subscribers, ok := h.initSubscription(w, r)
 	defer span.End()
 
 	if !ok {
@@ -253,7 +253,7 @@ func (h *Hub) authorizeSubscriptionRequest(span trace.Span, w http.ResponseWrite
 	return true
 }
 
-func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span trace.Span, currentURL, lastEventID string, subscribers []*Subscriber, ok bool) {
+func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span trace.Span, currentURL string, subscribers []*Subscriber, ok bool) {
 	ctx, span := startSpan(r.Context(), "mercure.subscriptions", trace.WithSpanKind(trace.SpanKindInternal))
 	// The topic to authorize (and the collection id) is the absolute path in
 	// relative form; RequestURI() would append the query string (e.g.
@@ -262,7 +262,7 @@ func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span tra
 	currentURL = r.URL.EscapedPath()
 
 	if !h.authorizeSubscriptionRequest(span, w, r) {
-		return span, "", "", nil, false
+		return span, "", nil, false
 	}
 
 	transport, isSubTransport := h.transport.(TransportSubscribers)
@@ -270,9 +270,7 @@ func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span tra
 		panic("The transport isn't an instance of hub.TransportSubscribers")
 	}
 
-	var err error
-
-	lastEventID, subscribers, err = transport.GetSubscribers(ctx)
+	lastEventID, subscribers, err := transport.GetSubscribers(ctx)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 
@@ -282,7 +280,7 @@ func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span tra
 
 		recordSpanError(span, err)
 
-		return span, currentURL, lastEventID, subscribers, false
+		return span, currentURL, subscribers, false
 	}
 
 	// ETags are entity-tags (RFC 9110 §8.8.3): DQUOTE-wrapped etagc bytes.
@@ -297,7 +295,7 @@ func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span tra
 	if r.Header.Get("If-None-Match") == etag {
 		w.WriteHeader(http.StatusNotModified)
 
-		return span, "", "", nil, false
+		return span, "", nil, false
 	}
 
 	header["Content-Type"] = subscriptionContentType
@@ -311,5 +309,5 @@ func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span tra
 		`"; type="` + reservedEventType +
 		`"; content-type="` + subscriptionContentType[0] + `"`}
 
-	return span, currentURL, lastEventID, subscribers, true
+	return span, currentURL, subscribers, true
 }

--- a/subscription.go
+++ b/subscription.go
@@ -52,22 +52,41 @@ func etagValue(lastEventID string) string {
 	return b.String()
 }
 
+// linkQuote escapes a value for an RFC 8288 Link header quoted-string. Only
+// DQUOTE and backslash need escaping; publish-time validation already forbids
+// control characters in event identifiers (see etagValue).
+func linkQuote(v string) string {
+	if !strings.ContainsAny(v, `"\`) {
+		return v
+	}
+
+	var b strings.Builder
+
+	for i := range len(v) {
+		if c := v[i]; c == '"' || c == '\\' {
+			b.WriteByte('\\')
+		}
+
+		b.WriteByte(v[i])
+	}
+
+	return b.String()
+}
+
 type subscription struct {
-	ID          string `json:"id"`
-	Type        string `json:"type"`
-	Subscriber  string `json:"subscriber"`
-	Topic       string `json:"topic,omitempty"`
-	Match       string `json:"match,omitempty"`
-	MatchType   string `json:"match_type,omitempty"`
-	Active      bool   `json:"active"`
-	LastEventID string `json:"last_event_id,omitempty"`
-	Payload     any    `json:"payload,omitempty"`
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Subscriber string `json:"subscriber"`
+	Topic      string `json:"topic,omitempty"`
+	Match      string `json:"match,omitempty"`
+	MatchType  string `json:"match_type,omitempty"`
+	Active     bool   `json:"active"`
+	Payload    any    `json:"payload,omitempty"`
 }
 
 type subscriptionCollection struct {
 	ID            string         `json:"id"`
 	Type          string         `json:"type"`
-	LastEventID   string         `json:"last_event_id"`
 	Subscriptions []subscription `json:"subscriptions"`
 }
 
@@ -120,7 +139,7 @@ func (h *Hub) SubscriptionsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	span, currentURL, lastEventID, subscribers, ok := h.initSubscription(w, r)
+	span, currentURL, _, subscribers, ok := h.initSubscription(w, r)
 	defer span.End()
 
 	if !ok {
@@ -132,7 +151,6 @@ func (h *Hub) SubscriptionsHandler(w http.ResponseWriter, r *http.Request) {
 	subscriptionCollection := subscriptionCollection{
 		ID:            currentURL,
 		Type:          "subscriptions",
-		LastEventID:   lastEventID,
 		Subscriptions: make([]subscription, 0),
 	}
 
@@ -174,7 +192,7 @@ func (h *Hub) SubscriptionHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	span, _, lastEventID, subscribers, ok := h.initSubscription(w, r)
+	span, _, _, subscribers, ok := h.initSubscription(w, r)
 	defer span.End()
 
 	if !ok {
@@ -189,8 +207,6 @@ func (h *Hub) SubscriptionHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, subscription := range subscriber.getSubscriptions(filter, true) {
-			subscription.LastEventID = lastEventID
-
 			j, err := json.MarshalIndent(subscription, "", "  ")
 			if err != nil {
 				panic(err)
@@ -285,6 +301,10 @@ func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span tra
 	}
 
 	header["Content-Type"] = subscriptionContentType
+	// The reconciliation cursor is carried as the last-event-id attribute of the
+	// rel="mercure" Link header, mirroring discovery, rather than a JSON body
+	// property. Subscribers pass it back as the last_event_id query parameter.
+	header["Link"] = []string{hubLink + `; last-event-id="` + linkQuote(lastEventID) + `"`}
 
 	return span, currentURL, lastEventID, subscribers, true
 }

--- a/subscription.go
+++ b/subscription.go
@@ -304,7 +304,12 @@ func (h *Hub) initSubscription(w http.ResponseWriter, r *http.Request) (span tra
 	// The reconciliation cursor is carried as the last-event-id attribute of the
 	// rel="mercure" Link header, mirroring discovery, rather than a JSON body
 	// property. Subscribers pass it back as the last_event_id query parameter.
-	header["Link"] = []string{hubLink + `; last-event-id="` + linkQuote(lastEventID) + `"`}
+	// Subscription events are a homogeneous stream (reserved "mercure" type, JSON
+	// body), so the type and content-type attributes are advertised too.
+	header["Link"] = []string{hubLink +
+		`; last-event-id="` + linkQuote(lastEventID) +
+		`"; type="` + reservedEventType +
+		`"; content-type="` + subscriptionContentType[0] + `"`}
 
 	return span, currentURL, lastEventID, subscribers, true
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -170,7 +170,10 @@ func TestSubscriptionsHandler(t *testing.T) {
 
 	lastEventID, subscribers, _ := hub.transport.(TransportSubscribers).GetSubscribers(t.Context())
 
-	assert.Equal(t, lastEventID, subscriptions.LastEventID)
+	// The reconciliation cursor is carried by the rel="mercure" Link header, not
+	// a JSON body property.
+	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"`, res.Header.Get("Link"))
+	assert.NotContains(t, w.Body.String(), "last_event_id")
 	require.NotEmpty(t, subscribers)
 
 	for _, s := range subscribers {
@@ -252,6 +255,7 @@ func TestSubscriptionHandlerMatchRoute(t *testing.T) {
 	router.ServeHTTP(w, req)
 	res := w.Result()
 	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, hubLink+`; last-event-id="`+EarliestLastEventID+`"`, res.Header.Get("Link"))
 	require.NoError(t, res.Body.Close())
 
 	var got subscription
@@ -260,6 +264,7 @@ func TestSubscriptionHandlerMatchRoute(t *testing.T) {
 	assert.Equal(t, "https://example.com/:id", got.Match)
 	assert.Equal(t, "urlpattern", got.MatchType)
 	assert.Empty(t, got.Topic, "modern subscriptions must not emit the deprecated `topic` field")
+	assert.NotContains(t, w.Body.String(), "last_event_id", "the cursor lives in the Link header, not the body")
 }
 
 // TestEscapeSubscriptionSegmentRoundTrip verifies the segment encoder

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -172,7 +172,7 @@ func TestSubscriptionsHandler(t *testing.T) {
 
 	// The reconciliation cursor is carried by the rel="mercure" Link header, not
 	// a JSON body property.
-	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"`, res.Header.Get("Link"))
+	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"; type="mercure"; content-type="application/json"`, res.Header.Get("Link"))
 	assert.NotContains(t, w.Body.String(), "last_event_id")
 	require.NotEmpty(t, subscribers)
 
@@ -255,7 +255,7 @@ func TestSubscriptionHandlerMatchRoute(t *testing.T) {
 	router.ServeHTTP(w, req)
 	res := w.Result()
 	assert.Equal(t, http.StatusOK, res.StatusCode)
-	assert.Equal(t, hubLink+`; last-event-id="`+EarliestLastEventID+`"`, res.Header.Get("Link"))
+	assert.Equal(t, hubLink+`; last-event-id="`+EarliestLastEventID+`"; type="mercure"; content-type="application/json"`, res.Header.Get("Link"))
 	require.NoError(t, res.Body.Close())
 
 	var got subscription

--- a/subscriptiontopic_deprecated_test.go
+++ b/subscriptiontopic_deprecated_test.go
@@ -58,7 +58,7 @@ func TestSubscriptionsHandlerForTopic(t *testing.T) {
 
 	lastEventID, subscribers, _ := hub.transport.(TransportSubscribers).GetSubscribers(t.Context())
 
-	assert.Equal(t, lastEventID, subscriptions.LastEventID)
+	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"`, res.Header.Get("Link"))
 	require.NotEmpty(t, subscribers)
 
 	for _, s := range subscribers {
@@ -108,8 +108,10 @@ func TestSubscriptionHandlerForTopic(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &subscription))
 
 	expectedSub := s.getSubscriptions(subscriptionFilter{topic: sTopics[1]}, true)[0]
-	expectedSub.LastEventID, _, _ = hub.transport.(TransportSubscribers).GetSubscribers(t.Context())
 	assert.Equal(t, expectedSub, subscription)
+
+	lastEventID, _, _ := hub.transport.(TransportSubscribers).GetSubscribers(t.Context())
+	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"`, res.Header.Get("Link"))
 
 	req = httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath+"/notexist/"+s.EscapedID, nil)
 	req.AddCookie(&http.Cookie{Name: defaultCookieName, Value: createDeprecatedAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions{/topic}{/subscriber}"})})

--- a/subscriptiontopic_deprecated_test.go
+++ b/subscriptiontopic_deprecated_test.go
@@ -58,7 +58,7 @@ func TestSubscriptionsHandlerForTopic(t *testing.T) {
 
 	lastEventID, subscribers, _ := hub.transport.(TransportSubscribers).GetSubscribers(t.Context())
 
-	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"`, res.Header.Get("Link"))
+	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"; type="mercure"; content-type="application/json"`, res.Header.Get("Link"))
 	require.NotEmpty(t, subscribers)
 
 	for _, s := range subscribers {
@@ -111,7 +111,7 @@ func TestSubscriptionHandlerForTopic(t *testing.T) {
 	assert.Equal(t, expectedSub, subscription)
 
 	lastEventID, _, _ := hub.transport.(TransportSubscribers).GetSubscribers(t.Context())
-	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"`, res.Header.Get("Link"))
+	assert.Equal(t, hubLink+`; last-event-id="`+lastEventID+`"; type="mercure"; content-type="application/json"`, res.Header.Get("Link"))
 
 	req = httptest.NewRequest(http.MethodGet, defaultHubURL+subscriptionsPath+"/notexist/"+s.EscapedID, nil)
 	req.AddCookie(&http.Cookie{Name: defaultCookieName, Value: createDeprecatedAuthorizedJWT(roleSubscriber, []string{"/.well-known/mercure/subscriptions{/topic}{/subscriber}"})})


### PR DESCRIPTION
Simplifies and unifies the discovery/subscription receive contract carried on the `rel="mercure"` `Link` header.

## Commit 1 — move the cursor to the Link header (BREAKING)

The reconciliation cursor was exposed two ways: a `last-event-id` `Link` attribute at discovery, and a `last_event_id` JSON body property on the subscription API. This moves the API cursor onto the `rel="mercure"` `Link` header the responses already advertise.

- One mechanism for one concept.
- A single-subscription response body is now exactly the subscription event document (was event doc **plus** `last_event_id`).
- The hub previously emitted **no** `Link` header on subscription API responses despite the spec examples showing one; fixed.
- `handler.go` / `handler_deprecated.go`: `ExposedHeaders: ["Link"]` so cross-origin subscribers can read it (moving it off the always-readable body would otherwise regress them).

### BREAKING CHANGE

The subscription API no longer returns the `last_event_id` JSON property. Read the `last-event-id` attribute of the `rel="mercure"` `Link` response header instead.

## Commit 2 — advertise `type` and `content-type` (additive)

Rounds out the receive contract advertised at discovery:

- **`type`** (new, optional): the SSE `event` name updates will carry, so a native `EventSource` client can `addEventListener` the right name at bootstrap instead of silently dropping named events (the per-event `event:` field cannot be used for a name you do not yet know). Default `message` if omitted.
- **`content-type`** (kept): fills the gap that an SSE `data` field carries no content type of its own, letting a subscriber process the payload without sniffing.
- Both are single-valued hints and **MUST** be omitted for heterogeneous streams; the subscriber then reads the value per event. Neither alters routing, which stays governed by topic matchers.
- The hub sets both on the subscription API `Link` header, where the stream is homogeneous by definition (reserved `mercure` type, JSON body).

## Consumers

`public/app.js`, `examples/chat/static/chat.js`, `docs/concepts/active-subscriptions.md` read the cursor from the `Link` header.

## Tests

`go test` full suite green (442), `go vet` and `gofmt` clean.