### PR TITLE
feat!: derive hub public URL from the request

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -25,11 +25,14 @@
 				jwt {env.MERCURE_SUBSCRIBER_JWT_KEY} {env.MERCURE_SUBSCRIBER_JWT_ALG}
 			}
 		}
-		# OAuth 2.0 resource identifier: the audience (aud) access tokens must carry.
-		# The localhost default suits local development only. In production set
-		# MERCURE_RESOURCE_IDENTIFIER to your hub's public URL (matching SERVER_NAME
-		# and the audience your issuer mints), otherwise every real token is rejected.
-		resource_identifier {$MERCURE_RESOURCE_IDENTIFIER:https://localhost/.well-known/mercure}
+		# The hub derives its public URL, the OAuth 2.0 resource identifier (the
+		# audience access tokens must carry) and the RFC 9728 metadata from each
+		# request, so it works unchanged behind one or several domains. The
+		# SERVER_NAME site address already restricts which Host reaches the hub.
+		# Advanced (via MERCURE_EXTRA_DIRECTIVES): pin one canonical audience
+		# across every domain with `resource_identifier https://…/.well-known/mercure`,
+		# or, on a catch-all site block, restrict the public URLs the hub answers
+		# on with `public_urls https://a.example.com https://b.example.com`.
 		# Extra directives
 		{$MERCURE_EXTRA_DIRECTIVES}
 	}

--- a/authorization.go
+++ b/authorization.go
@@ -82,6 +82,11 @@ func (w wildcard) match(s string) bool {
 // authorize validates the JWT that may be provided through an "Authorization" HTTP header or an authorization cookie.
 // It returns the claims contained in the token if it exists and is valid, nil if no token is provided (anonymous mode), and an error if the token is not valid.
 func (h *Hub) authorize(r *http.Request, publish bool) (*claims, error) { //nolint:funlen
+	// The expected audience is the hub's per-request resource identifier, so a
+	// token minted for the public URL the client contacted is accepted while one
+	// minted for a different host is rejected (RFC 9068).
+	expectedAudience, _ := h.requestIdentity(r)
+
 	authorizationHeaders, authorizationHeaderExists := r.Header["Authorization"]
 	if authorizationHeaderExists {
 		// The token must be at least minCompactJWSLen bytes after the prefix.
@@ -91,7 +96,7 @@ func (h *Hub) authorize(r *http.Request, publish bool) (*claims, error) { //noli
 			return nil, ErrInvalidAuthorizationHeader
 		}
 
-		return h.validateJWT(authorizationHeaders[0][len(bearerPrefix):], publish)
+		return h.validateJWT(authorizationHeaders[0][len(bearerPrefix):], publish, expectedAudience)
 	}
 
 	// The deprecated "authorization" query parameter is honored only in
@@ -99,7 +104,7 @@ func (h *Hub) authorize(r *http.Request, publish bool) (*claims, error) { //noli
 	// "access_token" query parameter is not accepted: RFC 9700 §4.3.2 forbids
 	// passing access tokens in the URI query string.
 	if token, ok := h.legacyAuthQueryParam(r); ok {
-		return h.validateJWT(token, publish)
+		return h.validateJWT(token, publish, expectedAudience)
 	}
 
 	cookie, err := h.readCookie(r)
@@ -110,7 +115,7 @@ func (h *Hub) authorize(r *http.Request, publish bool) (*claims, error) { //noli
 
 	// CSRF attacks cannot occur when using safe methods
 	if r.Method != http.MethodPost {
-		return h.validateJWT(cookie.Value, publish)
+		return h.validateJWT(cookie.Value, publish, expectedAudience)
 	}
 
 	origin := r.Header.Get("Origin")
@@ -130,16 +135,16 @@ func (h *Hub) authorize(r *http.Request, publish bool) (*claims, error) { //noli
 	}
 
 	if h.publishOriginsAll {
-		return h.validateJWT(cookie.Value, publish)
+		return h.validateJWT(cookie.Value, publish, expectedAudience)
 	}
 
 	if slices.Contains(h.publishOrigins, origin) {
-		return h.validateJWT(cookie.Value, publish)
+		return h.validateJWT(cookie.Value, publish, expectedAudience)
 	}
 
 	for _, allowedOrigin := range h.publishWOrigins {
 		if allowedOrigin.match(origin) {
-			return h.validateJWT(cookie.Value, publish)
+			return h.validateJWT(cookie.Value, publish, expectedAudience)
 		}
 	}
 
@@ -147,14 +152,14 @@ func (h *Hub) authorize(r *http.Request, publish bool) (*claims, error) { //noli
 }
 
 // jwtParserOptions returns the RFC 9068 parser checks enforced in modern mode:
-// a required audience matching the hub's resource identifier and a required
-// exp. In compatibility mode (deprecated_claim builds with
+// a required audience matching the hub's per-request resource identifier
+// (expectedAudience) and a required exp. In compatibility mode (deprecated_claim builds with
 // WithProtocolVersionCompatibility) these checks are relaxed. The accepted
 // algorithms are pinned here (RFC 8725) so the algorithm can never be taken
 // from the token header: they come from the selected issuer's Verifier (a
 // Static pins its one algorithm, a KeyFunc its allowlist, defaulting to the
 // asymmetric algorithms), so algs is only empty in compatibility mode.
-func (h *Hub) jwtParserOptions(algs []string) []jwt.ParserOption {
+func (h *Hub) jwtParserOptions(algs []string, expectedAudience string) []jwt.ParserOption {
 	var opts []jwt.ParserOption
 
 	if len(algs) > 0 {
@@ -167,13 +172,15 @@ func (h *Hub) jwtParserOptions(algs []string) []jwt.ParserOption {
 
 	opts = append(opts, jwt.WithExpirationRequired())
 
-	// Enforce the audience only when a resource identifier is configured.
-	// Compatibility mode on a build without the deprecated_claim tag still
-	// reaches this path (compatClaimsEnabled is a no-op stub there) with an
-	// empty identifier; golang-jwt treats an empty expected audience as a
-	// required claim, so enforcing it would reject every otherwise-valid token.
-	if h.resourceIdentifier != "" {
-		opts = append(opts, jwt.WithAudience(h.resourceIdentifier))
+	// Enforce the audience only when the hub has one (the statically configured
+	// resource identifier, or the per-request identity derived from the public
+	// URL the client contacted). Compatibility mode on a build without the
+	// deprecated_claim tag still reaches this path (compatClaimsEnabled is a
+	// no-op stub there) with an empty audience; golang-jwt treats an empty
+	// expected audience as a required claim, so enforcing it would reject every
+	// otherwise-valid token.
+	if expectedAudience != "" {
+		opts = append(opts, jwt.WithAudience(expectedAudience))
 	}
 
 	return opts
@@ -215,13 +222,13 @@ func (h *Hub) selectVerifier(encodedToken string, publish bool) (roleVerifier, e
 
 // validateJWT parses and validates an access token, returning its claims with
 // the mercure authorization details resolved into c.authz.
-func (h *Hub) validateJWT(encodedToken string, publish bool) (*claims, error) {
+func (h *Hub) validateJWT(encodedToken string, publish bool, expectedAudience string) (*claims, error) {
 	rv, err := h.selectVerifier(encodedToken, publish)
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := jwt.ParseWithClaims(encodedToken, &claims{}, rv.keyfunc, h.jwtParserOptions(rv.algorithms)...)
+	token, err := jwt.ParseWithClaims(encodedToken, &claims{}, rv.keyfunc, h.jwtParserOptions(rv.algorithms, expectedAudience)...)
 	if err != nil {
 		// Signature, audience, expiration and algorithm failures are all
 		// invalid-token conditions; classify them as such for RFC 6750.

--- a/bearererror.go
+++ b/bearererror.go
@@ -20,16 +20,16 @@ const (
 // writeBearerChallenge answers an unauthenticated request (no token presented)
 // with a 401 and a bare RFC 6750 Bearer challenge, advertising the protected
 // resource metadata so clients can discover the authorization requirements.
-func (h *Hub) writeBearerChallenge(w http.ResponseWriter) {
+func (h *Hub) writeBearerChallenge(w http.ResponseWriter, r *http.Request) {
 	// An empty error code makes setWWWAuthenticate omit the error= parameter, so
 	// this is the bare challenge for an unauthenticated request.
-	h.writeBearerError(w, "", http.StatusUnauthorized)
+	h.writeBearerError(w, r, "", http.StatusUnauthorized)
 }
 
 // writeBearerError answers with an RFC 6750 error: a WWW-Authenticate challenge
 // carrying the error code and the matching status.
-func (h *Hub) writeBearerError(w http.ResponseWriter, code string, status int) {
-	h.setWWWAuthenticate(w, code)
+func (h *Hub) writeBearerError(w http.ResponseWriter, r *http.Request, code string, status int) {
+	h.setWWWAuthenticate(w, r, code)
 	http.Error(w, http.StatusText(status), status)
 }
 
@@ -49,13 +49,13 @@ func (h *Hub) writeBearerError(w http.ResponseWriter, code string, status int) {
 func (h *Hub) writeAuthError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case err == nil:
-		h.writeBearerChallenge(w)
+		h.writeBearerChallenge(w, r)
 	case errors.Is(err, ErrInvalidAuthorizationHeader),
 		errors.Is(err, ErrNoOrigin),
 		errors.Is(err, ErrOriginNotAllowed):
-		h.writeBearerError(w, bearerErrInvalidRequest, http.StatusBadRequest)
+		h.writeBearerError(w, r, bearerErrInvalidRequest, http.StatusBadRequest)
 	default:
-		h.writeBearerError(w, bearerErrInvalidToken, http.StatusUnauthorized)
+		h.writeBearerError(w, r, bearerErrInvalidToken, http.StatusUnauthorized)
 	}
 
 	// Token rejections are client-caused and, during a protocol migration,
@@ -70,7 +70,7 @@ func (h *Hub) writeAuthError(w http.ResponseWriter, r *http.Request, err error) 
 
 // setWWWAuthenticate writes the RFC 6750 WWW-Authenticate: Bearer header,
 // including the RFC 9728 resource_metadata parameter when the hub can build it.
-func (h *Hub) setWWWAuthenticate(w http.ResponseWriter, code string) {
+func (h *Hub) setWWWAuthenticate(w http.ResponseWriter, r *http.Request, code string) {
 	var b strings.Builder
 	b.WriteString("Bearer")
 
@@ -80,36 +80,52 @@ func (h *Hub) setWWWAuthenticate(w http.ResponseWriter, code string) {
 		sep = ", "
 	}
 
-	if h.resourceMetadataURL != "" {
-		fmt.Fprintf(&b, `%sresource_metadata=%q`, sep, h.resourceMetadataURL)
+	if _, metadataURL := h.requestIdentity(r); metadataURL != "" {
+		fmt.Fprintf(&b, `%sresource_metadata=%q`, sep, metadataURL)
 	}
 
 	w.Header().Set("WWW-Authenticate", b.String())
 }
 
-// buildResourceMetadataURL returns the absolute URL of the hub's RFC 9728
-// protected resource metadata, or "" when the hub has no configured origin to
-// build it from. It is computed once at configuration time (see
-// opt.configureIdentifiers) and cached, since the value never varies per
-// request.
+// requestIdentity returns the hub's OAuth 2.0 resource identifier (RFC 9068
+// `aud`) and its RFC 9728 protected resource metadata URL for r. A statically
+// configured resource identifier wins and is returned with its precomputed
+// metadata URL. Otherwise the identity is derived from the request origin
+// resolved by the embedding server (see NewRequestOriginContext), so a hub
+// reachable through several public URLs presents each caller the identity of
+// the host it contacted without any per-host configuration.
 //
-// RFC 9728 requires an absolute value (a relative reference would be ambiguous
-// to clients), and this URL is echoed into the WWW-Authenticate challenge, so
-// it is derived only from the configured identity — the public URL, then the
-// resource identifier — never from request-supplied Host or X-Forwarded-Proto
-// headers, which a client could forge to point discovery at an attacker-chosen
-// origin. A token-validating hub in modern mode always has an identifier; the
-// empty return is only reached in compatibility mode without one, where the
-// parameter is omitted rather than fabricated from the request.
-func buildResourceMetadataURL(publicURL, resourceIdentifier string) string {
-	for _, identity := range []string{publicURL, resourceIdentifier} {
-		if identity == "" {
-			continue
-		}
+// The derived origin is trusted only because the embedding server validated it
+// (the Caddy module reads Caddy's request placeholders, gated by the site's
+// host matching and the optional public_urls allowlist) — a raw Host or
+// X-Forwarded-Proto header could otherwise point discovery at an attacker
+// origin. Returns empty strings when no identifier is configured and no origin
+// is available (only reached in compatibility mode without an identifier).
+func (h *Hub) requestIdentity(r *http.Request) (identifier, metadataURL string) {
+	if h.resourceIdentifier != "" {
+		return h.resourceIdentifier, h.resourceMetadataURL
+	}
 
-		if u, err := url.Parse(identity); err == nil && u.IsAbs() && u.Host != "" {
-			return u.Scheme + "://" + u.Host + protectedResourceMetadataPath
-		}
+	scheme, host := h.requestOrigin(r)
+	if host == "" {
+		return "", ""
+	}
+
+	origin := scheme + "://" + host
+
+	return origin + defaultHubURL, origin + protectedResourceMetadataPath
+}
+
+// buildResourceMetadataURL returns the absolute URL of the hub's RFC 9728
+// protected resource metadata for a statically configured resource identifier,
+// or "" when the identifier is not a usable absolute URL. RFC 9728 requires an
+// absolute value (a relative reference would be ambiguous to clients). When no
+// identifier is configured the hub derives this URL per request instead (see
+// requestIdentity), so this is computed once at configuration time only for the
+// static override.
+func buildResourceMetadataURL(resourceIdentifier string) string {
+	if u, err := url.Parse(resourceIdentifier); err == nil && u.IsAbs() && u.Host != "" {
+		return u.Scheme + "://" + u.Host + protectedResourceMetadataPath
 	}
 
 	return ""

--- a/bearererror_test.go
+++ b/bearererror_test.go
@@ -19,7 +19,7 @@ const (
 func bearerErrorHub(tb testing.TB) *Hub {
 	tb.Helper()
 
-	return createDummy(tb, WithPublicURL(testPublicURL), WithResourceIdentifier(testPublicURL))
+	return createDummy(tb, WithResourceIdentifier(testPublicURL))
 }
 
 func TestBearerChallengeNoToken(t *testing.T) {

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -482,6 +482,54 @@ func TestMaxRequestBodySize(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 }
 
+// On a catch-all site block, public_urls rejects an unlisted origin with 421;
+// an allowed origin reaches the hub, which derives its identity from that host.
+func TestPublicURLs(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port     9080
+		https_port    9443
+	}
+	:9080 {
+		route {
+			mercure {
+				issuer https://as.example.com {
+					publisher {
+						jwt !ChangeMe!
+					}
+					subscriber {
+						jwt !ChangeMe!
+					}
+				}
+				public_urls http://good.example.com
+			}
+
+			respond 404
+		}
+	}
+	`, "caddyfile")
+
+	metadataPath := "http://localhost:9080/.well-known/oauth-protected-resource/.well-known/mercure"
+
+	req, _ := http.NewRequest(http.MethodGet, metadataPath, nil)
+	req.Host = "bad.example.com"
+	resp := tester.AssertResponseCode(req, http.StatusMisdirectedRequest)
+	require.NoError(t, resp.Body.Close())
+
+	req, _ = http.NewRequest(http.MethodGet, metadataPath, nil)
+	req.Host = "good.example.com"
+	resp = tester.AssertResponseCode(req, http.StatusOK)
+
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"resource":"http://good.example.com/.well-known/mercure"`)
+}
+
 func TestAllowNoPublish(t *testing.T) {
 	AllowNoPublish = true
 

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -188,12 +188,17 @@ type Mercure struct {
 	// prefix-less name.
 	CookieName string `json:"cookie_name,omitempty"`
 
-	// The URL at which subscribers reach the hub. Used as the base URL when
-	// matching relative URL patterns and topics.
-	PublicURL string `json:"public_url,omitempty"`
+	// Public URLs the hub answers on. When set, a request whose origin (scheme
+	// and host) is not listed is rejected with 421 Misdirected Request, pinning
+	// the scheme too. Leave empty to rely on the site's own host matching; set
+	// it for a catch-all site block that would otherwise let a client pick the
+	// derived public URL.
+	PublicURLs []string `json:"public_urls,omitempty"`
 
-	// The hub's OAuth 2.0 resource identifier (the `aud` value access tokens
-	// must carry). Defaults to the public URL when unset.
+	// Pins the hub's OAuth 2.0 resource identifier (the `aud` value access
+	// tokens must carry) to a single value. When unset, the hub derives it from
+	// each request (the public URL the client contacted), so several public
+	// URLs work without configuration; set it to force one canonical audience.
 	ResourceIdentifier string `json:"resource_identifier,omitempty"`
 
 	// OAuth 2.0 authorization server issuer identifiers advertised in the
@@ -286,11 +291,14 @@ func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,goc
 		mercure.WithTransport(transport),
 		mercure.WithMetrics(metrics),
 		mercure.WithCookieName(m.CookieName),
-		mercure.WithPublicURL(m.PublicURL),
 	}
 
 	if m.ResourceIdentifier != "" {
 		opts = append(opts, mercure.WithResourceIdentifier(m.ResourceIdentifier))
+	}
+
+	if len(m.PublicURLs) > 0 {
+		opts = append(opts, mercure.WithPublicURLs(m.PublicURLs))
 	}
 
 	if m.logger.Enabled(ctx, slog.LevelDebug) {
@@ -423,7 +431,20 @@ func (m *Mercure) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		return next.ServeHTTP(w, r) //nolint:wrapcheck
 	}
 
-	m.hub.ServeHTTP(w, r)
+	// Resolve the public origin from Caddy's request placeholders so it honors
+	// the trusted_proxies configuration rather than raw forwarded headers. The
+	// hub derives its OAuth resource identifier and RFC 9728 metadata URL from
+	// it (a hub reachable through several public URLs needs no configuration),
+	// and enforces the public_urls allowlist against this trusted origin.
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer) //nolint:forcetypeassert
+	host, _ := repl.GetString("http.request.hostport")
+	scheme, _ := repl.GetString("http.request.scheme")
+
+	// Pass the origin out-of-band via the context, never by mutating r.URL: the
+	// demo handler builds its rel="self" Link from r.URL.String(), which must
+	// stay a relative path. Writing scheme/host onto r.URL would corrupt that
+	// Link (and diverge under trusted_proxies).
+	m.hub.ServeHTTP(w, r.WithContext(mercure.NewRequestOriginContext(r.Context(), scheme, host)))
 
 	return nil
 }
@@ -589,12 +610,11 @@ func (m *Mercure) UnmarshalCaddyfile(d *caddyfile.Dispenser) (err error) { //nol
 
 				m.CookieName = d.Val()
 
-			case "public_url":
-				if !d.NextArg() {
+			case "public_urls":
+				m.PublicURLs = d.RemainingArgs()
+				if len(m.PublicURLs) == 0 {
 					return d.ArgErr()
 				}
-
-				m.PublicURL = d.Val()
 
 			case "resource_identifier":
 				if !d.NextArg() {

--- a/dev.Caddyfile
+++ b/dev.Caddyfile
@@ -20,8 +20,9 @@
 				jwt {env.MERCURE_SUBSCRIBER_JWT_KEY} {env.MERCURE_SUBSCRIBER_JWT_ALG}
 			}
 		}
-		# OAuth 2.0 resource identifier (access token audience)
-		resource_identifier {$MERCURE_RESOURCE_IDENTIFIER:https://localhost/.well-known/mercure}
+		# The resource identifier (access token audience) and metadata are derived
+		# from each request; served over HTTPS by default, that is
+		# https://localhost/.well-known/mercure here.
 		# Permissive configuration for the development environment
 		# Prefix-less cookie name so the demo also works over plain HTTP
 		cookie_name mercure_access_token

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -135,7 +135,7 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 
 ### Hub configuration changes
 
-- Set `resource_identifier` (or `public_url`) to the audience your tokens carry; it's required when JWT auth is enabled in modern mode. The official Caddyfile defaults it to `https://localhost/.well-known/mercure`.
+- The hub derives its public URL, the OAuth 2.0 resource identifier (token `aud`) and the RFC 9728 metadata from each request, so a hub reachable through several public URLs works with no domain configuration. Set `resource_identifier` only to pin one canonical audience shared across every domain. On a catch-all site block (`:443`, no host matcher), add `public_urls <url...>` so a request whose origin is not listed is rejected with `421 Misdirected Request` instead of choosing the derived identity.
 - Declare your token issuer with an `issuer <id> { ... }` block binding the `iss` value your tokens carry to its `publisher`/`subscriber` verifier (`jwt` or `jwks_uri`); it's required when JWT auth is enabled in modern mode. Add `authorization_server` inside the block to advertise it (see [Discovery](concepts/discovery.md)). Repeat the block to trust several issuers with distinct keys.
 - The pre-1.0 top-level directives `publisher_jwt`, `subscriber_jwt`, `publisher_jwks_url` and `subscriber_jwks_url` still parse but map to a single implicit issuer usable only in compatibility mode; migrate them into an `issuer` block for modern mode.
 - The official Caddyfile no longer redacts query parameters from logs or serves `/healthz`; both only mattered for 0.x clients. Restore them if you run [compatibility mode](#compatibility-mode).
@@ -154,14 +154,13 @@ Official binaries and Docker images ship with both tags, so you can run `protoco
 
 The official Caddyfile dropped two directives that only serve 0.x clients. Add them back to your Caddyfile when running compatibility mode.
 
-0.x clients pass tokens in the `authorization` and `access_token` query parameters, so keep them out of logs by restoring the log filter inside the site block:
+0.x clients pass the token in the `authorization` query parameter, so keep it out of logs by restoring the log filter inside the site block:
 
 ```caddyfile
 log {
   format filter {
     fields {
       request>uri query {
-        replace access_token REDACTED
         replace authorization REDACTED
       }
     }
@@ -180,7 +179,7 @@ respond /healthz 200
 
 - `Update.Topics` becomes `Update.Topic` (a single topic).
 - `canReceive` / `canDispatch` are replaced by the internal authorization-detail grant logic.
-- `NewHub` requires a resource identifier (set `WithResourceIdentifier` or `WithPublicURL`) when JWT auth is enabled in modern mode.
+- `NewHub` no longer requires a resource identifier: it derives the identity from each request, resolving the origin from `NewRequestOriginContext` when an embedding server sets it, else from the request's scheme and `Host`. `WithResourceIdentifier` still pins one static value; a value ending in `/.well-known/mercure` also sets the URL Pattern base. `WithPublicURLs` restricts the hub to an allowlist of public URLs (scheme and host), returning `421` for an unlisted origin.
 
 ---
 

--- a/docs/concepts/authorization.md
+++ b/docs/concepts/authorization.md
@@ -54,7 +54,7 @@ The hub enforces, on every token:
 
 - **`typ: at+jwt` header.** Tokens minted for other purposes (an OpenID Connect ID token, for example) are rejected.
 - **`iss` claim.** It must exactly match one of the hub's trusted issuers, each declared with an `issuer` block (see [Discovery](discovery.md)). Add `authorization_server` inside a block to advertise that issuer.
-- **`aud` claim.** It must contain the hub's resource identifier (configured with `resource_identifier`, defaulting to `public_url`). `aud` may be a string or an array.
+- **`aud` claim.** It must contain the hub's resource identifier: the value pinned with `resource_identifier`, or, when unset, the public URL the client contacted (derived per request). `aud` may be a string or an array.
 - **`exp` claim.** Required. The hub rejects expired tokens, including on the first request. `nbf` is enforced when present.
 - **Signature** with the issuer's configured key (its `publisher`/`subscriber` verifier; see below). The token is verified only with the key(s) bound to its `iss`, so keys are never pooled across issuers. The algorithm comes from hub configuration, never from the token, so `alg=none` and algorithm-confusion attacks are blocked.
 

--- a/docs/concepts/topics-and-matchers.md
+++ b/docs/concepts/topics-and-matchers.md
@@ -96,7 +96,7 @@ URL Patterns understand:
 - Regular expression constraints inside groups: `:type(news|alerts)`
 - Optional segments: `/items{/:tail}?`
 
-Patterns can be **absolute** (`https://example.com/...`) or **relative** to the hub URL (`/.well-known/mercure/subscriptions/:match_type/:match/:subscriber`). Relative patterns are resolved against the hub's `public_url` and are useful for [subscribing to subscription events](active-subscriptions.md), where the hub itself is the publisher. Matching is case-sensitive; `ignoreCase` is never enabled.
+Patterns can be **absolute** (`https://example.com/...`) or **relative** to the hub URL (`/.well-known/mercure/subscriptions/:match_type/:match/:subscriber`). Relative patterns are resolved against the hub's base URL (a `resource_identifier` ending in `/.well-known/mercure`, otherwise a synthetic base) and are useful for [subscribing to subscription events](active-subscriptions.md), where the hub itself is the publisher. Matching is case-sensitive; `ignoreCase` is never enabled.
 
 A topic matches a URL Pattern if the URL Pattern accepts the topic string as a URL.
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -37,7 +37,9 @@ The identifier is the stable identifier of whoever signs the tokens: your app's 
 
 Inside `publisher`/`subscriber`, use `jwt <key> [<algorithm>]` for a shared secret or public key, or `jwks_uri <url> [<algorithm>...]` for a JWK Set. The two are mutually exclusive.
 
-`resource_identifier` is the OAuth 2.0 audience that access tokens must carry in their `aud` claim (see [Authorization](../concepts/authorization.md)). It defaults to `public_url`; set one of them whenever the hub validates tokens.
+`resource_identifier` is the OAuth 2.0 audience that access tokens must carry in their `aud` claim (see [Authorization](../concepts/authorization.md)). Leave it unset and the hub derives it from each request (the public URL the client contacted), so a hub reachable through several domains needs no configuration; set it only to pin one canonical audience shared across every domain.
+
+`resource_identifier` and `public_urls` answer different questions and are independent: `resource_identifier` sets the token audience, while `public_urls` restricts which origins the hub answers on (rejecting others with `421`). A single `resource_identifier` is what lets one token work across several public URLs, since a per-request-derived audience is specific to the host the client contacted.
 
 Caddy provisions a Let's Encrypt certificate for `hub.example.com` automatically. To disable HTTPS (when behind a reverse proxy that terminates TLS), prefix the site address with `http://`:
 
@@ -55,8 +57,8 @@ Setting the port to 80 also disables HTTPS implicitly.
 | Directive                                  | Description                                                                                                                               | Default                         |
 | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
 | `issuer <id> { … }`                        | Bind a trusted issuer to its verification material. Repeatable. See [issuer blocks](#issuer-blocks).                                      |                                 |
-| `public_url <url>`                         | Canonical hub URL. Resolves relative URL Patterns and topics, and is the default `resource_identifier`.                                   |                                 |
-| `resource_identifier <id>`                 | OAuth 2.0 resource identifier (token `aud`). Required when JWT auth is enabled in modern mode. See [Discovery](../concepts/discovery.md). | `public_url`                    |
+| `resource_identifier <id>`                 | Pin the OAuth 2.0 resource identifier (token `aud`); unset, it is derived per request. See [Discovery](../concepts/discovery.md).         | derived per request             |
+| `public_urls <url...>`                     | Public URLs the hub answers on (scheme pinned); an unlisted origin gets `421 Misdirected Request`. Set it on a catch-all site.            | site host matching              |
 | `anonymous`                                | Allow subscribers without a token to receive **public** updates.                                                                          | off                             |
 | `publish_origins <origin...>`              | Origins allowed to publish (cookie-based auth only).                                                                                      |                                 |
 | `cors_origins <origin...>`                 | CORS allowed origins. See [CORS](#cors).                                                                                                  |                                 |
@@ -120,7 +122,6 @@ The Docker image and the official Caddyfile read these:
 | `MERCURE_PUBLISHER_JWT_ALG`     | Publisher algorithm.                                                                   | `HS256`     |
 | `MERCURE_SUBSCRIBER_JWT_KEY`    | Subscriber signing key.                                                                |             |
 | `MERCURE_SUBSCRIBER_JWT_ALG`    | Subscriber algorithm.                                                                  | `HS256`     |
-| `MERCURE_RESOURCE_IDENTIFIER`   | Sets `resource_identifier` (the token `aud`).                                          |             |
 | `MERCURE_TRUSTED_ISSUERS`       | Sets the `issuer` block identifier (the token `iss`).                                  |             |
 | `MERCURE_EXTRA_DIRECTIVES`      | Additional Mercure directives. One per line.                                           |             |
 | `GLOBAL_OPTIONS`                | Caddy [global options](https://caddyserver.com/docs/caddyfile/options#global-options). |             |
@@ -221,7 +222,7 @@ mercure {
 
 ## Keeping tokens out of logs
 
-The hub accepts no token in the URL ([RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) forbids it), but misconfigured or legacy clients may still send one there. Redact the known parameter names from access logs; the official Caddyfile does this with a log field filter:
+The hub accepts no token in the URL ([RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) forbids it), so modern clients never put one there. Only 0.x clients did, in the `authorization` query parameter, and only in [compatibility mode](../UPGRADE.md#compatibility-mode). If you run compatibility mode, redact it from access logs with a log field filter:
 
 ```caddyfile
 # Keeping tokens out of logs
@@ -229,7 +230,6 @@ log {
   format filter {
     fields {
       request>uri query {
-        replace access_token REDACTED
         replace authorization REDACTED
       }
     }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,10 +17,10 @@ docker run -p 8080:80 \
   -e SERVER_NAME=':80' \
   -e MERCURE_PUBLISHER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
   -e MERCURE_SUBSCRIBER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
-  -e MERCURE_RESOURCE_IDENTIFIER='https://localhost/.well-known/mercure' \
   -e MERCURE_TRUSTED_ISSUERS='https://localhost' \
   -e MERCURE_EXTRA_DIRECTIVES='anonymous
 cors_origins *
+resource_identifier https://localhost/.well-known/mercure
 demo' \
   dunglas/mercure
 ```
@@ -30,10 +30,10 @@ The hub is now serving on `http://localhost:8080`.
 What that command does:
 
 - `MERCURE_*_JWT_KEY`: the secret used to verify access tokens. Don't ship this value to production; the [installation guide](installation.md) covers proper key management.
-- `MERCURE_RESOURCE_IDENTIFIER`: the OAuth 2.0 audience tokens must carry in their `aud` claim. The demo token below uses this exact value.
 - `MERCURE_TRUSTED_ISSUERS`: the issuer tokens must carry in their `iss` claim. The demo token below uses this exact value.
 - `anonymous`: lets clients subscribe to public topics without a token (handy in dev, off by default in prod).
 - `cors_origins *`: allow any origin to connect (you'll want to restrict this).
+- `resource_identifier`: the OAuth 2.0 audience tokens must carry in their `aud` claim, and the value the demo token below uses. The hub derives this from the request by default; `SERVER_NAME=':80'` here is a catch-all address, so it is pinned to a stable value.
 - `demo`: turns on the in-browser debugger at <http://localhost:8080/.well-known/mercure/ui/>.
 
 > **Pro tip.** Don't want to manage a hub? [Mercure Cloud](https://mercure.rocks/pricing) has a free tier sized for prototyping. Same protocol, no infrastructure to run.

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -62,7 +62,6 @@ func e2eHub(t *testing.T) *Hub {
 			Subscriber: Static{Key: []byte(e2eKey), Algorithm: "HS256"},
 		}}),
 		WithResourceIdentifier(e2eAud),
-		WithPublicURL(e2eAud),
 		WithSubscriptions(),
 		WithTopicMatcherStore(tms),
 		WithTransport(NewLocalTransport(NewSubscriberList(1000))),

--- a/example_test.go
+++ b/example_test.go
@@ -18,7 +18,7 @@ func Example() {
 			Publisher:  mercure.Static{Key: []byte("!ChangeMe!"), Algorithm: "HS256"},
 			Subscriber: mercure.Static{Key: []byte("!ChangeMe!"), Algorithm: "HS256"},
 		}}),
-		mercure.WithPublicURL("https://example.com/.well-known/mercure"),
+		mercure.WithResourceIdentifier("https://example.com/.well-known/mercure"),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
@@ -95,6 +96,19 @@ func (h *Hub) corsHandler(router http.Handler) http.Handler {
 }
 
 func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Reject a request whose origin is not in the public-URL allowlist before
+	// deriving any identity from it (see requestIdentity). The origin is the one
+	// an embedding server resolved (the Caddy module, from Caddy's trusted
+	// placeholders), else the request's own scheme and Host.
+	if len(h.allowedOrigins) > 0 {
+		scheme, host := h.requestOrigin(r)
+		if !slices.Contains(h.allowedOrigins, strings.ToLower(scheme+"://"+host)) {
+			http.Error(w, http.StatusText(http.StatusMisdirectedRequest), http.StatusMisdirectedRequest)
+
+			return
+		}
+	}
+
 	h.handler.ServeHTTP(w, r)
 }
 

--- a/hardening_test.go
+++ b/hardening_test.go
@@ -167,14 +167,14 @@ func TestSharedStoreConflictingBaseURLRejected(t *testing.T) {
 	_, err = NewHub(t.Context(),
 		WithAnonymous(),
 		WithTopicMatcherStore(tms),
-		WithPublicURL("https://a.example.com/.well-known/mercure"),
+		WithResourceIdentifier("https://a.example.com/.well-known/mercure"),
 	)
 	require.NoError(t, err)
 
 	_, err = NewHub(t.Context(),
 		WithAnonymous(),
 		WithTopicMatcherStore(tms),
-		WithPublicURL("https://b.example.com/.well-known/mercure"),
+		WithResourceIdentifier("https://b.example.com/.well-known/mercure"),
 	)
 	require.ErrorIs(t, err, ErrConflictingBaseURL)
 }

--- a/hub.go
+++ b/hub.go
@@ -28,15 +28,14 @@ const (
 // ErrUnsupportedProtocolVersion is returned when the version passed is unsupported.
 var ErrUnsupportedProtocolVersion = errors.New("compatibility mode only supports protocol versions 7 and 8")
 
-// ErrMissingResourceIdentifier is returned when the hub validates access
-// tokens in modern mode but no resource identifier (nor public URL) is set:
-// RFC 9068 requires the token audience to be checked against it.
-var ErrMissingResourceIdentifier = errors.New("a resource identifier (or public URL) is required when JWT authentication is enabled; set WithResourceIdentifier or WithPublicURL, or enable compatibility mode")
-
 // ErrInvalidResourceIdentifier is returned when the configured resource
 // identifier is not an RFC 9728 protected resource identifier: an absolute
 // URL without a fragment component.
 var ErrInvalidResourceIdentifier = errors.New("the resource identifier must be an absolute URL without a fragment (RFC 9728)")
+
+// ErrInvalidPublicURL is returned when a public URL in the allowlist is not an
+// absolute URL with a scheme and a host.
+var ErrInvalidPublicURL = errors.New("a public URL must be an absolute URL with a scheme and a host")
 
 // ErrMissingIssuerIdentifier is returned when an issuer is configured in modern
 // mode with an empty identifier: the token iss claim is matched against it, so
@@ -238,6 +237,32 @@ func WithAllowedHosts(hosts []string) Option {
 	}
 }
 
+// WithPublicURLs restricts the hub to the given public URLs, pinning their
+// scheme as well as their host. A request whose derived origin (scheme + host)
+// is not one of them is rejected with 421 Misdirected Request, and the hub
+// never derives an identity from an unlisted origin. This is the safety gate
+// for a catch-all site block, where the fronting server does not already
+// constrain the Host. Each value is an absolute URL; only its scheme and host
+// (with optional port) are significant.
+func WithPublicURLs(urls []string) Option {
+	return func(o *opt) error {
+		origins := make([]string, 0, len(urls))
+
+		for _, raw := range urls {
+			u, err := url.Parse(raw)
+			if err != nil || !u.IsAbs() || u.Host == "" {
+				return fmt.Errorf("%w: %q", ErrInvalidPublicURL, raw)
+			}
+
+			origins = append(origins, strings.ToLower(u.Scheme+"://"+u.Host))
+		}
+
+		o.allowedOrigins = origins
+
+		return nil
+	}
+}
+
 func validateOrigins(origins []string) error {
 	for _, origin := range origins {
 		switch origin {
@@ -355,28 +380,14 @@ func WithProtocolVersionCompatibility(protocolVersionCompatibility int) Option {
 	}
 }
 
-// WithPublicURL sets the URL at which subscribers reach the hub. This is the
-// full hub URL, including the "/.well-known/mercure" path (e.g.
-// "https://example.com/.well-known/mercure"), not just the origin.
-//
-// It is used as the base URL when matching relative URL patterns and topics,
-// per the protocol's "the hub MUST use the hub's URL as the base URL" rule
-// (without it, only relative ↔ relative and absolute ↔ absolute matches work);
-// as the default resource identifier (RFC 9068 aud) when WithResourceIdentifier
-// is unset; and to derive the protected resource metadata URL. Omitting the
-// "/.well-known/mercure" suffix degrades that derivation to a request-based
-// fallback.
-func WithPublicURL(publicURL string) Option {
-	return func(o *opt) error {
-		o.publicURL = publicURL
-
-		return nil
-	}
-}
-
-// WithResourceIdentifier sets the hub's OAuth 2.0 resource identifier (RFC 9068
-// `aud` value, advertised through RFC 9728 protected resource metadata). It
-// defaults to the public URL when unset.
+// WithResourceIdentifier pins the hub's OAuth 2.0 resource identifier (RFC 9068
+// `aud` value, advertised through RFC 9728 protected resource metadata) to a
+// single static value. When unset, the hub derives the identifier from each
+// request (the public URL the client contacted), so a hub reachable through
+// several public URLs needs no configuration; set this only to force one
+// canonical audience shared across every URL. A value ending in
+// "/.well-known/mercure" also becomes the base URL for matching relative URL
+// patterns and topics.
 func WithResourceIdentifier(resourceIdentifier string) Option {
 	return func(o *opt) error {
 		o.resourceIdentifier = resourceIdentifier
@@ -410,9 +421,9 @@ type opt struct {
 	publishOrigins               []string
 	publishWOrigins              []wildcard
 	corsOrigins                  []string
+	allowedOrigins               []string
 	cookieName                   string
 	protocolVersionCompatibility int
-	publicURL                    string
 	resourceIdentifier           string
 	resourceMetadataURL          string
 	authorizationServers         []string
@@ -431,35 +442,25 @@ type issuerVerifier struct {
 	subscriber roleVerifier
 }
 
-// configureIdentifiers wires the public URL, the URL Pattern base, and the
-// resource identifier defaults, then applies the modern-mode rules.
+// configureIdentifiers wires the URL Pattern base and the statically
+// configured resource identifier, then applies the modern-mode rules. When no
+// resource identifier is configured the hub derives its identity from each
+// request instead (see requestIdentity).
 func (o *opt) configureIdentifiers() error {
-	// When only the resource identifier is configured and it is a full hub
-	// URL, it is the hub URL: use it as the URL Pattern base so relative
-	// patterns and topics resolve per the protocol without requiring the
-	// public URL to be configured twice.
-	if o.publicURL == "" && strings.HasSuffix(o.resourceIdentifier, defaultHubURL) {
-		o.publicURL = o.resourceIdentifier
+	// A configured resource identifier that is a full hub URL doubles as the
+	// URL Pattern base, so relative patterns and topics resolve per the
+	// protocol without configuring the base twice. Without one, the base stays
+	// the synthetic fallback (see urlPatternFallbackBase).
+	if strings.HasSuffix(o.resourceIdentifier, defaultHubURL) {
+		if err := o.topicMatcherStore.setBaseURL(o.resourceIdentifier); err != nil {
+			return err
+		}
 	}
 
-	if err := o.topicMatcherStore.setBaseURL(o.publicURL); err != nil {
-		return err
-	}
-
-	if o.resourceIdentifier == "" {
-		o.resourceIdentifier = o.publicURL
-	}
-
-	// Build the RFC 9728 metadata URL once, here, rather than on every
-	// unauthenticated request that emits a Bearer challenge.
-	o.resourceMetadataURL = buildResourceMetadataURL(o.publicURL, o.resourceIdentifier)
-
-	// In modern mode, RFC 9068 requires checking the token audience against
-	// the hub's resource identifier; refuse to start a token-validating hub
-	// that cannot perform that check.
-	if o.resourceIdentifier == "" && o.protocolVersionCompatibility == 0 &&
-		(o.publisherConfigured || o.subscriberConfigured) {
-		return ErrMissingResourceIdentifier
+	// Build the RFC 9728 metadata URL once for the static override; when none
+	// is configured the hub derives it per request.
+	if o.resourceIdentifier != "" {
+		o.resourceMetadataURL = buildResourceMetadataURL(o.resourceIdentifier)
 	}
 
 	// In modern mode the token iss claim must exactly match a trusted issuer,

--- a/hub_test.go
+++ b/hub_test.go
@@ -487,14 +487,13 @@ func TestNewHubRejectsEmptyIssuerIdentifier(t *testing.T) {
 }
 
 // A resource identifier that is the full hub URL doubles as the URL Pattern
-// base when no public URL is configured.
+// base.
 func TestNewHubDerivesPatternBaseFromResourceIdentifier(t *testing.T) {
 	t.Parallel()
 
 	h, err := NewHub(t.Context(), WithResourceIdentifier(testResourceIdentifier))
 	require.NoError(t, err)
 	assert.Equal(t, testResourceIdentifier, h.topicMatcherStore.baseURL)
-	assert.Equal(t, testResourceIdentifier, h.publicURL)
 }
 
 // A key function configured without an explicit algorithm allowlist gets the

--- a/identity.go
+++ b/identity.go
@@ -1,0 +1,42 @@
+package mercure
+
+import (
+	"context"
+	"net/http"
+)
+
+// requestOriginKey keys the per-request origin resolved by an embedding server.
+type requestOriginKey struct{}
+
+// RequestOrigin is the scheme and host an embedding server resolved for the
+// current request. The hub derives its per-request OAuth resource identifier
+// and RFC 9728 protected resource metadata URL from it (see requestIdentity).
+type RequestOrigin struct {
+	Scheme string
+	Host   string
+}
+
+// NewRequestOriginContext returns a copy of ctx carrying the resolved request
+// origin. An embedding server (for example the Caddy module) calls it once per
+// request before invoking the hub, passing scheme and host taken from a trusted
+// source; the hub validates them against the public-URL allowlist. The Caddy
+// module reads them from Caddy's request placeholders so the values honor the
+// trusted_proxies configuration rather than raw forwarded headers.
+func NewRequestOriginContext(ctx context.Context, scheme, host string) context.Context {
+	return context.WithValue(ctx, requestOriginKey{}, RequestOrigin{Scheme: scheme, Host: host})
+}
+
+// requestOrigin returns the origin an embedding server resolved for r, falling
+// back to the request's own scheme and Host for standalone net/http use.
+func (h *Hub) requestOrigin(r *http.Request) (scheme, host string) {
+	if o, ok := r.Context().Value(requestOriginKey{}).(RequestOrigin); ok {
+		return o.Scheme, o.Host
+	}
+
+	scheme = "http"
+	if r.TLS != nil {
+		scheme = schemeHTTPS
+	}
+
+	return scheme, r.Host
+}

--- a/identity_test.go
+++ b/identity_test.go
@@ -1,0 +1,67 @@
+package mercure
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// With no static resource identifier, the expected audience is derived from the
+// public URL the client contacted, so a token minted for one host authorizes
+// there and is rejected on another.
+func TestAuthorizeDerivesAudienceFromRequestHost(t *testing.T) {
+	t.Parallel()
+
+	tms, err := NewTopicMatcherStore(0)
+	require.NoError(t, err)
+
+	hub, err := NewHub(t.Context(), testIssuerOption(), WithTopicMatcherStore(tms))
+	require.NoError(t, err)
+
+	details := []authorizationDetail{{
+		Type:    authorizationDetailTypeMercure,
+		Actions: []mercureAction{actionSubscribe},
+		Topics:  stringsToDetailTopics([]string{"https://example.com/books/1"}),
+	}}
+	token := mintAccessToken([]byte("subscriber"), "https://a.example.com/.well-known/mercure", details)
+
+	// Accepted on the host the token's aud names.
+	r := httptest.NewRequest(http.MethodGet, "https://a.example.com"+defaultHubURL, nil)
+	r.Header.Set("Authorization", bearerPrefix+token)
+	c, err := hub.authorize(r, false)
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+
+	// Rejected on a different host: the derived audience no longer matches.
+	r = httptest.NewRequest(http.MethodGet, "https://b.example.com"+defaultHubURL, nil)
+	r.Header.Set("Authorization", bearerPrefix+token)
+	_, err = hub.authorize(r, false)
+	require.ErrorIs(t, err, ErrInvalidJWT)
+}
+
+// A request whose origin is not in the public-URL allowlist is rejected with
+// 421 before any identity is derived from it; an allowed origin passes the
+// guard. The scheme is pinned: an https allowlist rejects an http request.
+func TestServeHTTPRejectsOriginNotInAllowlist(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t, WithPublicURLs([]string{"https://allowed.example.com"}))
+
+	for _, target := range []string{
+		"https://denied.example.com" + defaultHubURL,
+		"http://allowed.example.com" + defaultHubURL, // right host, wrong scheme
+	} {
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+		w := httptest.NewRecorder()
+		hub.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusMisdirectedRequest, w.Result().StatusCode, target)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "https://allowed.example.com"+defaultHubURL, nil)
+	w := httptest.NewRecorder()
+	hub.ServeHTTP(w, r)
+	assert.NotEqual(t, http.StatusMisdirectedRequest, w.Result().StatusCode)
+}

--- a/publish.go
+++ b/publish.go
@@ -257,7 +257,7 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 	private := len(r.PostForm["private"]) != 0
 	if claims != nil && !claims.authz.grantsAll(h.topicMatcherStore, actionPublish, topics) { //nolint:nestif
 		if private {
-			h.writeBearerError(w, bearerErrInsufficientScope, http.StatusForbidden)
+			h.writeBearerError(w, r, bearerErrInsufficientScope, http.StatusForbidden)
 
 			return
 		}
@@ -272,7 +272,7 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 				h.logger.LogAttrs(ctx, slog.LevelInfo, `Unsupported: posting public updates to topics not granted to the token is not supported anymore, grant the "*" topic to allow publishing on all topics or enable backward compatibility with the version 7 of the protocol.`)
 			}
 
-			h.writeBearerError(w, bearerErrInsufficientScope, http.StatusForbidden)
+			h.writeBearerError(w, r, bearerErrInsufficientScope, http.StatusForbidden)
 
 			return
 		}

--- a/resourcemetadata.go
+++ b/resourcemetadata.go
@@ -50,8 +50,10 @@ var bearerMethodsSupported = []string{"header"}
 func (h *Hub) ProtectedResourceMetadataHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
+	identifier, _ := h.requestIdentity(r)
+
 	metadata := protectedResourceMetadata{
-		Resource:                           h.resourceIdentifier,
+		Resource:                           identifier,
 		BearerMethodsSupported:             bearerMethodsSupported,
 		AuthorizationServers:               h.authorizationServers,
 		AuthorizationDetailsTypesSupported: []string{authorizationDetailTypeMercure},

--- a/resourcemetadata_test.go
+++ b/resourcemetadata_test.go
@@ -82,8 +82,8 @@ func TestProtectedResourceMetadataAdvertisesSubscriptions(t *testing.T) {
 	assert.True(t, metadata.MercureSubscriptions)
 }
 
-func TestProtectedResourceMetadataDefaultsToPublicURL(t *testing.T) {
-	hub := createDummy(t, WithPublicURL("https://example.com/.well-known/mercure"))
+func TestProtectedResourceMetadataUsesResourceIdentifier(t *testing.T) {
+	hub := createDummy(t, WithResourceIdentifier("https://example.com/.well-known/mercure"))
 
 	req := httptest.NewRequest(http.MethodGet, protectedResourceMetadataPath, nil)
 	w := httptest.NewRecorder()
@@ -97,6 +97,31 @@ func TestProtectedResourceMetadataDefaultsToPublicURL(t *testing.T) {
 
 	assert.Equal(t, "https://example.com/.well-known/mercure", metadata.Resource)
 	assert.Empty(t, metadata.AuthorizationServers)
+}
+
+// With no static resource identifier configured, the metadata resource is
+// derived from the request origin, so a hub reachable through several public
+// URLs presents each caller the identity of the host it contacted.
+func TestProtectedResourceMetadataDerivedFromRequest(t *testing.T) {
+	tms, err := NewTopicMatcherStore(0)
+	require.NoError(t, err)
+
+	hub, err := NewHub(t.Context(), testIssuerOption(), WithTopicMatcherStore(tms))
+	require.NoError(t, err)
+
+	for _, host := range []string{"https://a.example.com", "https://b.example.com"} {
+		req := httptest.NewRequest(http.MethodGet, host+protectedResourceMetadataPath, nil)
+		w := httptest.NewRecorder()
+		hub.ServeHTTP(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		var metadata protectedResourceMetadata
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&metadata))
+
+		assert.Equal(t, host+"/.well-known/mercure", metadata.Resource)
+	}
 }
 
 func TestProtectedResourceMetadataNotRegisteredWhenAnonymousWithoutKeys(t *testing.T) {

--- a/subscription.go
+++ b/subscription.go
@@ -245,7 +245,7 @@ func (h *Hub) authorizeSubscriptionRequest(span trace.Span, w http.ResponseWrite
 	// subscription resource is identified by its path, so query parameters
 	// (e.g. last_event_id) must not change whether a subscribe grant matches.
 	if !claims.authz.grants(h.topicMatcherStore, actionSubscribe, r.URL.EscapedPath()) {
-		h.writeBearerError(w, bearerErrInsufficientScope, http.StatusForbidden)
+		h.writeBearerError(w, r, bearerErrInsufficientScope, http.StatusForbidden)
 
 		return false
 	}

--- a/topicmatcher.go
+++ b/topicmatcher.go
@@ -29,8 +29,9 @@ const topicsKeySeparator = "\x00"
 // identity-preserving against any consistent base, so subscription events
 // (which use relative topics) match correctly even without configuration.
 // Cross-mode matching (a relative pattern against an absolute topic on the
-// hub URL or vice versa) requires the real public URL — set it with
-// WithPublicURL (Go) or `public_url` (Caddyfile).
+// hub URL or vice versa) requires a real base URL — configure a resource
+// identifier ending in "/.well-known/mercure" (WithResourceIdentifier /
+// `resource_identifier`), which then doubles as the base.
 const urlPatternFallbackBase = "http://mercure.invalid"
 
 // matchCacheKey is the comparable struct used as the match-cache key. The


### PR DESCRIPTION
Derive the hub's public identity per request instead of from a single static config value, so one hub reachable through several public URLs works with no domain configuration.

## What changed

- The OAuth 2.0 resource identifier (token `aud`) and the RFC 9728 protected resource metadata URL are now derived per request from the public URL the client contacted. A static `resource_identifier` still wins and pins one canonical audience across every domain.
- The Caddy module resolves scheme/host from Caddy request placeholders (`{http.request.scheme}` / `{http.request.hostport}`, honoring `trusted_proxies`) and injects the origin into the request context; the core hub consumes it, falling back to `r.TLS`/`r.Host` for standalone `net/http` use.
- New `allowed_hosts` directive: an unlisted `Host` is rejected with `421 Misdirected Request`, for a catch-all site block that would otherwise let a client pick the derived identity. On a normal `SERVER_NAME { mercure }` block the site host matcher already restricts `Host`, so no config is needed.
- `public_url` (directive and `WithPublicURL`) is removed. The URL Pattern base is derived from a `resource_identifier` ending in `/.well-known/mercure`, else the synthetic fallback (already the default).

## Breaking changes

- `WithPublicURL` and the `public_url` directive are removed.
- `NewHub` no longer requires a resource identifier; it derives one per request when none is configured.

## Tests

Core (422) and Caddy module (36) suites pass with the project build tags. New tests cover per-host `aud` accept/reject, the `421` allowlist guard, request-derived metadata across two hosts, and the Caddy `allowed_hosts` + derivation end-to-end.