### PR TITLE
feat(caddy): auto-enable compatibility mode for legacy JWT directives

### DIFF
--- a/caddy/caddy_deprecated_test.go
+++ b/caddy/caddy_deprecated_test.go
@@ -347,3 +347,72 @@ localhost:9080 {
 
 	assert.FileExists(t, "test.db")
 }
+
+// The deprecated top-level publisher_jwt directive maps to the implicit issuer,
+// which is rejected in modern mode. Without protocol_version_compatibility the
+// hub must auto-enable compatibility mode so a 0.x bare-claim token still
+// publishes, instead of failing to provision.
+func TestMercureDeprecatedAutoCompat(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`{
+	skip_install_trust
+	admin localhost:2999
+	http_port     9080
+	https_port    9443
+}
+
+localhost:9080 {
+	route {
+		mercure {
+			anonymous
+			publisher_jwt !ChangeMe!
+			transport local
+		}
+
+		respond 404
+	}
+}`, "caddyfile")
+
+	var connected, received sync.WaitGroup
+
+	connected.Add(1)
+	received.Go(func() {
+		cx, cancel := context.WithCancel(t.Context())
+		req, _ := http.NewRequest(http.MethodGet, "http://localhost:9080/.well-known/mercure?topic=https%3A%2F%2Fexample.com%2Ffoo%2F1", nil)
+		req = req.WithContext(cx)
+		resp := tester.AssertResponseCode(req, http.StatusOK)
+
+		connected.Done()
+
+		var receivedBody strings.Builder
+
+		buf := make([]byte, 1024)
+		for {
+			_, err := resp.Body.Read(buf)
+			require.NoError(t, err)
+
+			receivedBody.Write(buf)
+
+			if strings.Contains(receivedBody.String(), "data: bar\n") {
+				cancel()
+
+				break
+			}
+		}
+
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	connected.Wait()
+
+	body := url.Values{"topic": {"https://example.com/foo/1"}, "data": {"bar"}, "id": {"bar"}}
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:9080/.well-known/mercure", strings.NewReader(body.Encode()))
+	require.NoError(t, err)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Authorization", bearerPrefix+publisherJWTDeprecated)
+
+	resp := tester.AssertResponseCode(req, http.StatusOK)
+	require.NoError(t, resp.Body.Close())
+
+	received.Wait()
+}

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -260,6 +260,16 @@ func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,goc
 
 	m.logger = slog.New(mercure.NewSlogHandler(ctx.Slogger().Handler()))
 
+	// The deprecated top-level JWT directives map to an implicit issuer that is
+	// only usable in compatibility mode. Enable it automatically so these
+	// directives keep working instead of failing at provision, and warn to
+	// steer users toward an issuer block. Requires a binary built with the
+	// deprecated_claim tag to actually accept 0.x tokens.
+	if m.ProtocolVersionCompatibility == 0 && m.hasLegacyVerifiers() {
+		m.ProtocolVersionCompatibility = 8
+		m.logger.Warn("Deprecated top-level JWT directives detected; enabling protocol_version_compatibility 8. Migrate them into an issuer block to run in modern mode.")
+	}
+
 	var transport mercure.Transport
 	if transport, err = m.createTransportDeprecated(); err != nil {
 		return err
@@ -810,6 +820,20 @@ func (m *Mercure) buildIssuer(ctx context.Context, id string, authServer bool, p
 	return issuer, nil
 }
 
+// legacyVerifiers returns the publisher and subscriber verifiers configured
+// through the deprecated top-level directives (the single implicit issuer).
+func (m *Mercure) legacyVerifiers() (VerifierConfig, VerifierConfig) {
+	return VerifierConfig{JWT: m.PublisherJWT, JWKSURL: m.PublisherJWKSURL},
+		VerifierConfig{JWT: m.SubscriberJWT, JWKSURL: m.SubscriberJWKSURL}
+}
+
+// hasLegacyVerifiers reports whether any deprecated top-level JWT directive is set.
+func (m *Mercure) hasLegacyVerifiers() bool {
+	pub, sub := m.legacyVerifiers()
+
+	return pub.isSet() || sub.isSet()
+}
+
 // buildIssuers assembles the hub's issuer bindings from the explicit issuer
 // blocks and the deprecated top-level directives (a single implicit issuer).
 func (m *Mercure) buildIssuers(ctx context.Context) ([]mercure.Issuer, error) {
@@ -824,8 +848,7 @@ func (m *Mercure) buildIssuers(ctx context.Context) ([]mercure.Issuer, error) {
 		issuers = append(issuers, issuer)
 	}
 
-	legacyPub := VerifierConfig{JWT: m.PublisherJWT, JWKSURL: m.PublisherJWKSURL}
-	legacySub := VerifierConfig{JWT: m.SubscriberJWT, JWKSURL: m.SubscriberJWKSURL}
+	legacyPub, legacySub := m.legacyVerifiers()
 
 	if legacyPub.isSet() || legacySub.isSet() {
 		issuer, err := m.buildIssuer(ctx, "", false, legacyPub, legacySub)

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -137,7 +137,7 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 
 - Set `resource_identifier` (or `public_url`) to the audience your tokens carry; it's required when JWT auth is enabled in modern mode. The official Caddyfile defaults it to `https://localhost/.well-known/mercure`.
 - Declare your token issuer with an `issuer <id> { ... }` block binding the `iss` value your tokens carry to its `publisher`/`subscriber` verifier (`jwt` or `jwks_uri`); it's required when JWT auth is enabled in modern mode. Add `authorization_server` inside the block to advertise it (see [Discovery](concepts/discovery.md)). Repeat the block to trust several issuers with distinct keys.
-- The pre-1.0 top-level directives `publisher_jwt`, `subscriber_jwt`, `publisher_jwks_url` and `subscriber_jwks_url` still parse but map to a single implicit issuer usable only in compatibility mode; migrate them into an `issuer` block for modern mode.
+- The pre-1.0 top-level directives `publisher_jwt`, `subscriber_jwt`, `publisher_jwks_url` and `subscriber_jwks_url` still parse but map to a single implicit issuer usable only in compatibility mode. When one is set without `protocol_version_compatibility`, the hub enables `protocol_version_compatibility 8` automatically and logs a warning; migrate them into an `issuer` block for modern mode.
 - The official Caddyfile no longer redacts query parameters from logs or serves `/healthz`; both only mattered for 0.x clients. Restore them if you run [compatibility mode](#compatibility-mode).
 - `transport_url` (deprecated since 0.17) is removed; use `transport <name> { ... }`. The legacy non-Caddy server is removed.
 


### PR DESCRIPTION
## What

When a deprecated top-level JWT directive (`publisher_jwt`, `subscriber_jwt`, `publisher_jwks_url`, `subscriber_jwks_url`) is set without `protocol_version_compatibility`, the hub now enables `protocol_version_compatibility 8` automatically and logs a warning pointing to the `issuer` block.

## Why

These directives build an implicit issuer with an empty identifier. Modern mode rejects an empty-id issuer at provision time (`ErrMissingIssuerIdentifier`), so a 0.x config that only sets `publisher_jwt` failed to start. Auto-enabling compatibility mode keeps those configs working during migration.

Requires a binary built with the `deprecated_claim` tag to actually accept 0.x tokens (official binaries and Docker images ship it).

## Notes

- Behavior change: a legacy-only config that used to fail fast now boots in compatibility mode with a warning.
- `docs/UPGRADE.md` updated.