### PR TITLE
fix(caddy)!: reject HMAC algorithms for PEM-encoded JWT keys

### DIFF
--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddytest"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -792,4 +793,58 @@ func TestMultiIssuerPublish(t *testing.T) {
 	// Issuer A signed with key B is rejected: keys are not pooled across issuers.
 	resp = tester.AssertResponseCode(publish(mint([]byte("key-b"), "https://a.example")), http.StatusUnauthorized)
 	require.NoError(t, resp.Body.Close())
+}
+
+func TestNormalizeJWTPEMKeyRejectsHMAC(t *testing.T) {
+	t.Parallel()
+
+	const pem = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkq\n-----END PUBLIC KEY-----"
+
+	for _, tc := range []struct {
+		name    string
+		key     string
+		alg     string
+		wantAlg string
+		wantErr string
+	}{
+		{name: "raw secret without algorithm defaults to HS256", key: "!ChangeMe!", wantAlg: "HS256"},
+		{name: "raw secret keeps an explicit algorithm", key: "!ChangeMe!", alg: "HS512", wantAlg: "HS512"},
+		{name: "PEM key with an asymmetric algorithm", key: pem, alg: "RS256", wantAlg: "RS256"},
+		{
+			name:    "PEM key without an algorithm",
+			key:     pem,
+			wantErr: "the publisher JWT key is PEM-encoded, so its signing algorithm must be set explicitly",
+		},
+		{
+			name:    "PEM key with an HMAC algorithm",
+			key:     pem,
+			alg:     "HS256",
+			wantErr: "an HMAC algorithm would use the public key as a shared secret",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &JWTConfig{Key: tc.key, Alg: tc.alg}
+
+			err := normalizeJWT(caddy.NewReplacer(), c, "", "publisher")
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAlg, c.Alg)
+		})
+	}
+}
+
+// An unset MERCURE_*_JWT_ALG placeholder must not silently turn a PEM key into
+// an HMAC secret: the shipped Caddyfile pairs both as placeholders.
+func TestNormalizeJWTPEMKeyWithUnsetAlgPlaceholder(t *testing.T) {
+	c := &JWTConfig{Key: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkq\n-----END PUBLIC KEY-----", Alg: "{env.MERCURE_TEST_UNSET_ALG}"}
+
+	require.ErrorContains(t, normalizeJWT(caddy.NewReplacer(), c, "", "subscriber"),
+		"the subscriber JWT key is PEM-encoded, so its signing algorithm must be set explicitly")
 }

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -807,7 +807,7 @@ func TestNormalizeJWTPEMKeyRejectsHMAC(t *testing.T) {
 		wantAlg string
 		wantErr string
 	}{
-		{name: "raw secret without algorithm defaults to HS256", key: "!ChangeMe!", wantAlg: "HS256"},
+		{name: "raw secret without algorithm defaults to HS256", key: "!ChangeMe!", wantAlg: defaultJWTAlgorithm},
 		{name: "raw secret keeps an explicit algorithm", key: "!ChangeMe!", alg: "HS512", wantAlg: "HS512"},
 		{name: "PEM key with an asymmetric algorithm", key: pem, alg: "RS256", wantAlg: "RS256"},
 		{
@@ -818,7 +818,7 @@ func TestNormalizeJWTPEMKeyRejectsHMAC(t *testing.T) {
 		{
 			name:    "PEM key with an HMAC algorithm",
 			key:     pem,
-			alg:     "HS256",
+			alg:     defaultJWTAlgorithm,
 			wantErr: "an HMAC algorithm would use the public key as a shared secret",
 		},
 	} {

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -805,22 +805,13 @@ func TestNormalizeJWTPEMKeyRejectsHMAC(t *testing.T) {
 		key     string
 		alg     string
 		wantAlg string
-		wantErr string
+		wantErr error
 	}{
 		{name: "raw secret without algorithm defaults to HS256", key: "!ChangeMe!", wantAlg: defaultJWTAlgorithm},
 		{name: "raw secret keeps an explicit algorithm", key: "!ChangeMe!", alg: "HS512", wantAlg: "HS512"},
 		{name: "PEM key with an asymmetric algorithm", key: pem, alg: "RS256", wantAlg: "RS256"},
-		{
-			name:    "PEM key without an algorithm",
-			key:     pem,
-			wantErr: "the publisher JWT key is PEM-encoded, so its signing algorithm must be set explicitly",
-		},
-		{
-			name:    "PEM key with an HMAC algorithm",
-			key:     pem,
-			alg:     defaultJWTAlgorithm,
-			wantErr: "an HMAC algorithm would use the public key as a shared secret",
-		},
+		{name: "PEM key without an algorithm", key: pem, wantErr: ErrPEMKeyMissingAlgorithm},
+		{name: "PEM key with an HMAC algorithm", key: pem, alg: defaultJWTAlgorithm, wantErr: ErrPEMKeyHMACAlgorithm},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -828,8 +819,9 @@ func TestNormalizeJWTPEMKeyRejectsHMAC(t *testing.T) {
 			c := &JWTConfig{Key: tc.key, Alg: tc.alg}
 
 			err := normalizeJWT(caddy.NewReplacer(), c, "", "publisher")
-			if tc.wantErr != "" {
-				require.ErrorContains(t, err, tc.wantErr)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				assert.ErrorContains(t, err, "publisher")
 
 				return
 			}
@@ -845,6 +837,7 @@ func TestNormalizeJWTPEMKeyRejectsHMAC(t *testing.T) {
 func TestNormalizeJWTPEMKeyWithUnsetAlgPlaceholder(t *testing.T) {
 	c := &JWTConfig{Key: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkq\n-----END PUBLIC KEY-----", Alg: "{env.MERCURE_TEST_UNSET_ALG}"}
 
-	require.ErrorContains(t, normalizeJWT(caddy.NewReplacer(), c, "", "subscriber"),
-		"the subscriber JWT key is PEM-encoded, so its signing algorithm must be set explicitly")
+	err := normalizeJWT(caddy.NewReplacer(), c, "", "subscriber")
+	require.ErrorIs(t, err, ErrPEMKeyMissingAlgorithm)
+	assert.ErrorContains(t, err, "subscriber")
 }

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -751,6 +751,10 @@ func parseVerifierBlock(d *caddyfile.Dispenser) (VerifierConfig, error) {
 // that (public) key could mint valid tokens.
 const pemPrefix = "-----BEGIN"
 
+// defaultJWTAlgorithm is assumed for a raw shared secret whose algorithm is not
+// stated. A PEM-encoded key gets no default (see normalizeJWT).
+const defaultJWTAlgorithm = "HS256"
+
 // normalizeJWT applies Caddy placeholder replacement to a static-key verifier
 // and defaults its algorithm to HS256 for a raw secret. It is a no-op when a
 // JWK Set URL is used or no key is configured. A PEM-encoded key gets no
@@ -780,7 +784,7 @@ func normalizeJWT(repl *caddy.Replacer, c *JWTConfig, jwksURL, role string) erro
 	}
 
 	if c.Alg == "" {
-		c.Alg = "HS256"
+		c.Alg = defaultJWTAlgorithm
 	}
 
 	return nil

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -755,6 +755,11 @@ const pemPrefix = "-----BEGIN"
 // stated. A PEM-encoded key gets no default (see normalizeJWT).
 const defaultJWTAlgorithm = "HS256"
 
+var (
+	ErrPEMKeyMissingAlgorithm = errors.New("the JWT key is PEM-encoded, so its signing algorithm must be set explicitly (for example RS256, ES256 or EdDSA)")
+	ErrPEMKeyHMACAlgorithm    = errors.New("the JWT key is PEM-encoded but an HMAC algorithm would use the public key as a shared secret, letting anyone holding it forge tokens")
+)
+
 // normalizeJWT applies Caddy placeholder replacement to a static-key verifier
 // and defaults its algorithm to HS256 for a raw secret. It is a no-op when a
 // JWK Set URL is used or no key is configured. A PEM-encoded key gets no
@@ -773,11 +778,11 @@ func normalizeJWT(repl *caddy.Replacer, c *JWTConfig, jwksURL, role string) erro
 
 	if strings.HasPrefix(strings.TrimSpace(c.Key), pemPrefix) {
 		if c.Alg == "" {
-			return fmt.Errorf("the %s JWT key is PEM-encoded, so its signing algorithm must be set explicitly (for example RS256, ES256 or EdDSA)", role) //nolint:err113
+			return fmt.Errorf("%s: %w", role, ErrPEMKeyMissingAlgorithm)
 		}
 
 		if strings.HasPrefix(c.Alg, "HS") {
-			return fmt.Errorf("the %s JWT key is PEM-encoded but the signing algorithm is %q: an HMAC algorithm would use the public key as a shared secret, letting anyone holding it forge tokens", role, c.Alg) //nolint:err113
+			return fmt.Errorf("%s: %q: %w", role, c.Alg, ErrPEMKeyHMACAlgorithm)
 		}
 
 		return nil

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -745,38 +745,71 @@ func parseVerifierBlock(d *caddyfile.Dispenser) (VerifierConfig, error) {
 	return v, nil
 }
 
+// pemPrefix opens a PEM block. A PEM-encoded key is an asymmetric public key,
+// so it must never be paired with an HMAC algorithm: createJWTKeyfunc would
+// then use the key material itself as the shared secret, and anyone holding
+// that (public) key could mint valid tokens.
+const pemPrefix = "-----BEGIN"
+
 // normalizeJWT applies Caddy placeholder replacement to a static-key verifier
-// and defaults its algorithm to HS256. It is a no-op when a JWK Set URL is used
-// or no key is configured.
-func normalizeJWT(repl *caddy.Replacer, c *JWTConfig, jwksURL string) {
+// and defaults its algorithm to HS256 for a raw secret. It is a no-op when a
+// JWK Set URL is used or no key is configured. A PEM-encoded key gets no
+// default: its algorithm must be stated, and it must not be an HMAC one.
+func normalizeJWT(repl *caddy.Replacer, c *JWTConfig, jwksURL, role string) error {
 	if jwksURL != "" {
-		return
+		return nil
 	}
 
 	c.Key = repl.ReplaceKnown(c.Key, "")
 	if c.Key == "" {
-		return
+		return nil
 	}
 
-	c.Alg = repl.ReplaceKnown(c.Alg, "HS256")
+	c.Alg = repl.ReplaceKnown(c.Alg, "")
+
+	if strings.HasPrefix(strings.TrimSpace(c.Key), pemPrefix) {
+		if c.Alg == "" {
+			return fmt.Errorf("the %s JWT key is PEM-encoded, so its signing algorithm must be set explicitly (for example RS256, ES256 or EdDSA)", role) //nolint:err113
+		}
+
+		if strings.HasPrefix(c.Alg, "HS") {
+			return fmt.Errorf("the %s JWT key is PEM-encoded but the signing algorithm is %q: an HMAC algorithm would use the public key as a shared secret, letting anyone holding it forge tokens", role, c.Alg) //nolint:err113
+		}
+
+		return nil
+	}
+
 	if c.Alg == "" {
 		c.Alg = "HS256"
 	}
+
+	return nil
 }
 
 func (m *Mercure) populateJWTConfig() error {
 	repl := caddy.NewReplacer()
 
-	normalizeJWT(repl, &m.PublisherJWT, m.PublisherJWKSURL)
-	normalizeJWT(repl, &m.SubscriberJWT, m.SubscriberJWKSURL)
+	if err := normalizeJWT(repl, &m.PublisherJWT, m.PublisherJWKSURL, "publisher"); err != nil {
+		return err
+	}
+
+	if err := normalizeJWT(repl, &m.SubscriberJWT, m.SubscriberJWKSURL, "subscriber"); err != nil {
+		return err
+	}
 
 	hasPublisher := m.PublisherJWT.Key != "" || m.PublisherJWKSURL != ""
 	hasSubscriber := m.SubscriberJWT.Key != "" || m.SubscriberJWKSURL != ""
 
 	for i := range m.Issuers {
 		iss := &m.Issuers[i]
-		normalizeJWT(repl, &iss.Publisher.JWT, iss.Publisher.JWKSURL)
-		normalizeJWT(repl, &iss.Subscriber.JWT, iss.Subscriber.JWKSURL)
+
+		if err := normalizeJWT(repl, &iss.Publisher.JWT, iss.Publisher.JWKSURL, "publisher"); err != nil {
+			return fmt.Errorf("issuer %q: %w", iss.Identifier, err)
+		}
+
+		if err := normalizeJWT(repl, &iss.Subscriber.JWT, iss.Subscriber.JWKSURL, "subscriber"); err != nil {
+			return fmt.Errorf("issuer %q: %w", iss.Identifier, err)
+		}
 
 		if iss.Publisher.isSet() {
 			hasPublisher = true

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -37,6 +37,8 @@ The identifier is the stable identifier of whoever signs the tokens: your app's 
 
 Inside `publisher`/`subscriber`, use `jwt <key> [<algorithm>]` for a shared secret or public key, or `jwks_uri <url> [<algorithm>...]` for a JWK Set. The two are mutually exclusive.
 
+The algorithm defaults to `HS256` only for a raw shared secret. A PEM-encoded key must state its algorithm, and that algorithm must not be an HMAC one: the hub refuses to start otherwise, because verifying with `HS*` would use the public key as the shared secret and let anyone holding it forge tokens.
+
 `resource_identifier` is the OAuth 2.0 audience that access tokens must carry in their `aud` claim (see [Authorization](../concepts/authorization.md)). Leave it unset and the hub derives it from each request (the public URL the client contacted), so a hub reachable through several domains needs no configuration; set it only to pin one canonical audience shared across every domain.
 
 `resource_identifier` and `public_urls` answer different questions and are independent: `resource_identifier` sets the token audience, while `public_urls` restricts which origins the hub answers on (rejecting others with `421`). A single `resource_identifier` is what lets one token work across several public URLs, since a per-request-derived audience is specific to the host the client contacted.
@@ -103,7 +105,7 @@ issuer https://issuer-b.example {
 | `authorization_server`            | Advertise this issuer in the [protected resource metadata](../concepts/discovery.md). Off by default.  |
 | `publisher { … }`                 | Verification material for publisher tokens. Omit to reject publishing for this issuer.                 |
 | `subscriber { … }`                | Verification material for subscriber tokens. Omit to reject subscribing for this issuer.               |
-| `jwt <key> [<algorithm>]`         | Shared secret or PEM public key, plus algorithm (defaults to `HS256`). Supports Caddy placeholders.    |
+| `jwt <key> [<algorithm>]`         | Shared secret or PEM public key, plus algorithm. A PEM key must set a non-HMAC one (see above).        |
 | `jwks_uri <url> [<algorithm>...]` | JWK Set URL and its allowed algorithms (defaults to the asymmetric allowlist). Accepts `file://` URLs. |
 
 `jwt` and `jwks_uri` are mutually exclusive within a `publisher`/`subscriber` block.


### PR DESCRIPTION
An unset algorithm defaulted to `HS256` for any static key, so a PEM-encoded public key was used verbatim as the HMAC shared secret. Since that key is public by construction, anyone holding it could mint valid tokens with arbitrary authorization details.

The shipped `Caddyfile` pairs the key and the algorithm as placeholders:

```
jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
```

so setting `MERCURE_PUBLISHER_JWT_KEY` to a PEM public key without setting `MERCURE_PUBLISHER_JWT_ALG` was enough to reach it. `jwtkeyfunc.go` already documents the opposite guarantee for the JWK Set path ("so a public JWK can never be reinterpreted as an HMAC secret"); the static-key path violated it.

## Behaviour change

- A raw shared secret still defaults to `HS256`, so existing HMAC deployments are unaffected.
- A PEM-encoded key must now state its algorithm.
- A PEM-encoded key combined with an `HS*` algorithm is refused at provision time.

Both new errors name the role (`publisher`/`subscriber`) and, inside an `issuer` block, the issuer identifier.