### PR TITLE
fix(caddy)!: error on unknown directives in the mercure block

### DIFF
--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddytest"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -840,4 +841,66 @@ func TestNormalizeJWTPEMKeyWithUnsetAlgPlaceholder(t *testing.T) {
 	err := normalizeJWT(caddy.NewReplacer(), c, "", "subscriber")
 	require.ErrorIs(t, err, ErrPEMKeyMissingAlgorithm)
 	assert.ErrorContains(t, err, "subscriber")
+}
+
+func TestUnmarshalCaddyfileRejectsUnknownDirective(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		block   string
+		wantErr string
+	}{
+		{name: "typo of a boolean directive", block: "anonymus", wantErr: `unknown mercure directive "anonymus"`},
+		{name: "typo of cors_origins", block: "cors_origin *", wantErr: `unknown mercure directive "cors_origin"`},
+		{name: "typo of publish_origins", block: "publish_origin *", wantErr: `unknown mercure directive "publish_origin"`},
+		{name: "wholly unknown directive", block: "totally_bogus foo bar", wantErr: `unknown mercure directive "totally_bogus"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := caddyfile.NewTestDispenser("mercure {\n\t" + tc.block + "\n}")
+
+			require.ErrorContains(t, new(Mercure).UnmarshalCaddyfile(d), tc.wantErr)
+		})
+	}
+}
+
+func TestUnmarshalCaddyfileAcceptsKnownDirectives(t *testing.T) {
+	t.Parallel()
+
+	d := caddyfile.NewTestDispenser(`mercure {
+		name test
+		anonymous
+		demo
+		ui
+		subscriptions
+		write_timeout 1m
+		dispatch_timeout 5s
+		heartbeat 40s
+		max_request_body_size 1MB
+		cookie_name mercure_access_token
+		cors_origins *
+		publish_origins *
+		public_urls https://example.com
+		resource_identifier https://example.com/.well-known/mercure
+		topic_matcher_cache 10
+		subscriber_list_cache_size 10
+		protocol_version_compatibility 8
+		issuer https://example.com {
+			authorization_server
+			publisher {
+				jwt !ChangeMe!
+			}
+			subscriber {
+				jwt !ChangeMe!
+			}
+		}
+	}`)
+
+	m := new(Mercure)
+	require.NoError(t, m.UnmarshalCaddyfile(d))
+	assert.True(t, m.Anonymous)
+	assert.Equal(t, []string{"*"}, m.CORSOrigins)
+	assert.Len(t, m.Issuers, 1)
 }

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -648,6 +648,12 @@ func (m *Mercure) UnmarshalCaddyfile(d *caddyfile.Dispenser) (err error) { //nol
 				}
 
 				m.ProtocolVersionCompatibility = v
+
+			default:
+				// Fail loudly: silently ignoring a typo would disable whatever
+				// the operator meant to configure, including the origin and
+				// CORS allowlists.
+				return d.Errf("unknown mercure directive %q", d.Val())
 			}
 		}
 	}

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -140,6 +140,7 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 - The pre-1.0 top-level directives `publisher_jwt`, `subscriber_jwt`, `publisher_jwks_url` and `subscriber_jwks_url` still parse but map to a single implicit issuer usable only in compatibility mode. When one is set without `protocol_version_compatibility`, the hub enables `protocol_version_compatibility 8` automatically and logs a warning; migrate them into an `issuer` block for modern mode.
 - The official Caddyfile no longer redacts query parameters from logs or serves `/healthz`; both only mattered for 0.x clients. Restore them if you run [compatibility mode](#compatibility-mode).
 - `transport_url` (deprecated since 0.17) is removed; use `transport <name> { ... }`. The legacy non-Caddy server is removed.
+- An unrecognized directive inside the `mercure` block is now a configuration error instead of being ignored. A typo previously disabled whatever it was meant to configure, silently, so check your `MERCURE_EXTRA_DIRECTIVES` if the hub refuses to start after the upgrade.
 
 ### Compatibility mode
 


### PR DESCRIPTION
The top-level `switch` of `UnmarshalCaddyfile` had no `default` case, so an unrecognized directive was silently dropped.

```
mercure {
    anonymus
    cors_origin *
    totally_bogus foo bar
}
```

That config previously parsed cleanly and the hub started with `Anonymous=false` and no CORS at all. A typo in `cors_origins` or `publish_origins` disabled the allowlist it was meant to configure, silently.

The nested `issuer` and `publisher`/`subscriber` block parsers in the same file already reject unknown directives, so this only makes the top level consistent with them.

Verified that every directive used by the shipped `Caddyfile` and `dev.Caddyfile` is covered by the switch.

## Behaviour change

An unrecognized directive is now a config error. Worth checking `MERCURE_EXTRA_DIRECTIVES` on upgrade; noted in the upgrade guide.