### PR TITLE
docs: the replay cursor response field is Mercure-Last-Event-ID

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -128,6 +128,7 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 - `mercureAuthorization` cookie -> `mercure_access_token`; `authorization=` query param -> `Authorization` header or cookie (no query parameter)
 - A second `topic=` on a publish request -> publish to one topic; scope per-user access in the token
 - Hardcoded `subscriptions/{topic}/{subscriber}` paths -> add the `{match_type}` segment
+- `Last-Event-ID` read from a **response** -> `Mercure-Last-Event-ID` (the request header keeps its name; see [Reconnection and history](concepts/reconnection-and-history.md))
 
 - JSON-LD subscription documents (`application/ld+json`, `@context`) -> plain JSON served as `application/json`
 - `type` values lowercased: `Subscription` -> `subscription`, `Subscriptions` -> `subscriptions`

--- a/docs/concepts/reconnection-and-history.md
+++ b/docs/concepts/reconnection-and-history.md
@@ -61,7 +61,9 @@ This is the right way to seed an event-sourced view from the hub.
 
 ## Detecting data loss in Mercure replay
 
-If the requested event ID is no longer in the hub's history (it was evicted), the hub sets the `Last-Event-ID` HTTP **response** header to the ID of the event preceding the first one it actually sent. By comparing what you asked for with what you got, you can tell whether you missed updates.
+Whenever a request carries a resumption cursor, the hub sets the `Mercure-Last-Event-ID` HTTP **response** header to the ID of the event preceding the first one it actually sent, or `earliest` when there is no preceding event. By comparing what you asked for with what you got, you can tell whether you missed updates.
+
+The response field is `Mercure-Last-Event-ID`, not `Last-Event-ID`: the latter is registered for request semantics only, so the protocol defines a distinct name for the response direction.
 
 ```javascript
 // Native EventSource doesn't expose response headers; use fetch-event-source
@@ -69,7 +71,7 @@ import { fetchEventSource } from "@microsoft/fetch-event-source";
 
 await fetchEventSource(url, {
   onopen: (response) => {
-    const replayedFrom = response.headers.get("Last-Event-ID");
+    const replayedFrom = response.headers.get("Mercure-Last-Event-ID");
     if (replayedFrom !== expectedLastEventID) {
       // Possibly missed events, refetch the resource from the origin
     }
@@ -132,7 +134,7 @@ Browsers wait at least that many milliseconds before reconnecting after a discon
 
 ## Native `EventSource` doesn't expose response headers
 
-This catches people. If you need to read the `Last-Event-ID` response header (to detect data loss), you have to use a polyfill or library: `fetch-event-source` exposes it; native `EventSource` does not. Most server-side SSE clients also expose it.
+This catches people. If you need to read the `Mercure-Last-Event-ID` response header (to detect data loss), you have to use a polyfill or library: `fetch-event-source` exposes it; native `EventSource` does not. Most server-side SSE clients also expose it.
 
 ## Header-based polyfills send the cursor as a query parameter
 

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -49,6 +49,11 @@ paths:
       responses:
         "200":
           description: Event stream opened.
+          headers:
+            Mercure-Last-Event-ID:
+              description: The id of the event preceding the first one sent, or the reserved value earliest when there is none. Set whenever the request carried a resumption cursor; compare it with the requested id to detect data loss.
+              schema:
+                type: string
           content:
             "text/event-stream": {}
         "401":


### PR DESCRIPTION
The reconnection guide told clients to read a `Last-Event-ID` **response** header:

```javascript
const replayedFrom = response.headers.get("Last-Event-ID");
```

The hub sends `Mercure-Last-Event-ID` ([subscribe.go](https://github.com/dunglas/mercure/blob/main/subscribe.go)), so that lookup always returned `null` and the documented data-loss check never fired. The distinct name is deliberate: `Last-Event-ID` is registered for request semantics only, which the spec notes when registering the response field.

Three occurrences fixed, keeping `Last-Event-ID` where the *request* header is meant. Also:

- added the rename to the find-and-replace checklist in the upgrade guide, which listed the query-parameter and cookie renames but not this one
- declared the field on the subscribe `200` response in `spec/openapi.yaml`, where it was missing entirely

Checked the rest of `docs/`, `README.md` and `llms.txt`: every other `Last-Event-ID` mention is the request header, and the subscription-API sample correctly reads the cursor from the `rel="mercure"` Link header.