### PR TITLE
fix(bolt): cleanup_frequency ran cleanup with the inverse probability

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -370,12 +370,21 @@ func (t *BoltTransport) persist(updateID string, updateJSON []byte) error {
 	return nil
 }
 
+// shouldCleanup reports whether this publish runs a cleanup pass. cleanupFrequency
+// is the probability of doing so, from 0 (never) to 1 (every publish): drawing
+// below it is what triggers the pass. There is nothing to remove while the
+// history is still within the size limit.
+func (t *BoltTransport) shouldCleanup(lastID uint64) bool {
+	if t.size == 0 || t.size >= lastID {
+		return false
+	}
+
+	return rand.Float64() < t.cleanupFrequency //nolint:gosec
+}
+
 // cleanup removes entries in the history above the size limit, triggered probabilistically.
 func (t *BoltTransport) cleanup(bucket *bolt.Bucket, lastID uint64) error {
-	if t.size == 0 ||
-		t.cleanupFrequency == 0 ||
-		t.size >= lastID ||
-		(t.cleanupFrequency != 1 && rand.Float64() < t.cleanupFrequency) { //nolint:gosec
+	if !t.shouldCleanup(lastID) {
 		return nil
 	}
 

--- a/bolt_test.go
+++ b/bolt_test.go
@@ -358,3 +358,52 @@ func TestBoltLastEventID(t *testing.T) {
 	lastEventID, _, _ := transport.GetSubscribers(t.Context())
 	assert.Equal(t, "foo", lastEventID)
 }
+
+// cleanup_frequency is documented as the probability of running a cleanup pass
+// on each publish, so a higher value must clean more often, not less.
+func TestBoltTransportCleanupFrequencyIsAProbability(t *testing.T) {
+	t.Parallel()
+
+	const samples = 20000
+
+	for _, tc := range []struct {
+		frequency float64
+		want      float64
+	}{
+		{frequency: 0, want: 0},
+		{frequency: 0.1, want: 0.1},
+		{frequency: 0.3, want: 0.3},
+		{frequency: 0.9, want: 0.9},
+		{frequency: 1, want: 1},
+	} {
+		t.Run(strconv.FormatFloat(tc.frequency, 'f', -1, 64), func(t *testing.T) {
+			t.Parallel()
+
+			transport := &BoltTransport{size: 5, cleanupFrequency: tc.frequency}
+
+			var runs int
+
+			for range samples {
+				// lastID is past the size limit, so only the probability decides.
+				if transport.shouldCleanup(100) {
+					runs++
+				}
+			}
+
+			assert.InDelta(t, tc.want, float64(runs)/samples, 0.02)
+		})
+	}
+}
+
+func TestBoltTransportCleanupSkippedWithinSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	// Always-on frequency, but the history has not reached the limit yet.
+	transport := &BoltTransport{size: 5, cleanupFrequency: 1}
+	assert.False(t, transport.shouldCleanup(5))
+	assert.True(t, transport.shouldCleanup(6))
+
+	// An unlimited history is never cleaned.
+	unlimited := &BoltTransport{size: 0, cleanupFrequency: 1}
+	assert.False(t, unlimited.shouldCleanup(1_000_000))
+}


### PR DESCRIPTION
The guard skipped cleanup when the draw fell **below** `cleanupFrequency`, so a pass ran with probability `1 - cleanupFrequency`.

Measured over 200k trials against the old code:

| configured | documented | actual |
| ---------- | ---------- | ------ |
| `0.1`      | 10%        | 89.9%  |
| `0.3` (default) | 30%   | 69.9%  |
| `0.9`      | 90%        | 10.1%  |
| `1`        | 100%       | 100%   |
| `0`        | 0%         | 0%     |

`docs/deployment/configuration.md` documents it as "Probability per publish of running history cleanup. `0` (never) to `1` (always)." Only the two endpoints matched, because both were special-cased; everything between was inverted, so operators tuning the knob got the opposite write amplification.

Drawing below the frequency handles the endpoints on its own — `Float64` returns a value in `[0,1)`, so `0` never triggers a pass and `1` always does — which removes both special cases:

```go
return rand.Float64() < t.cleanupFrequency
```

The decision moves into `shouldCleanup` so the probability can be asserted directly rather than inferred from history size after a batch of publishes. The new test fails against the old comparison (0.9 measured 0.101, 0.1 measured 0.900) and the existing `TestBoltTransportPurgeHistory` still passes unchanged.