### PR TITLE
fix: don't close a connection whose write deadline is near

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -80,10 +80,25 @@ func (rc *responseController) flush(ctx context.Context) bool {
 func (h *Hub) newResponseController(w http.ResponseWriter, s *LocalSubscriber) *responseController {
 	wd := h.getWriteDeadline(s)
 
+	// Disconnect one dispatch before the write deadline so the client sees a
+	// clean end of stream instead of a failed write. That subtraction lands in
+	// the past when the deadline is nearer than dispatchTimeout — a token
+	// expiring within it, or a dispatchTimeout larger than writeTimeout — which
+	// would close the connection as soon as it opened and put the subscriber in
+	// a reconnect loop. Fall back to the deadline itself: less margin, but the
+	// subscriber gets the time its token grants. A zero deadline means no
+	// deadline at all, and SubscribeHandler then arms no timer.
+	dt := wd
+	if !wd.IsZero() {
+		if d := wd.Add(-h.dispatchTimeout); d.After(time.Now()) {
+			dt = d
+		}
+	}
+
 	return &responseController{
 		*http.NewResponseController(w), // nolint:bodyclose
 		w,
-		wd.Add(-h.dispatchTimeout),
+		dt,
 		wd,
 		h,
 		s,

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1347,3 +1347,54 @@ func TestShutdownClosesSubscribersWhenWriteTimeoutDisabled(t *testing.T) {
 		assert.Equal(t, 0, n, "subscriber must exit on hub shutdown when writeTimeout is 0")
 	})
 }
+
+// The disconnection timer is armed with time.Until(disconnectionTime), so a
+// disconnectionTime in the past closes the connection as soon as it opens.
+// Reachable whenever the write deadline is nearer than dispatchTimeout.
+func TestNewResponseControllerDisconnectionTimeStaysInTheFuture(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		writeTimeout    time.Duration
+		dispatchTimeout time.Duration
+		tokenExpiresIn  time.Duration
+	}{
+		{name: "token expiring sooner than dispatchTimeout", writeTimeout: 600 * time.Second, dispatchTimeout: 5 * time.Second, tokenExpiresIn: 2 * time.Second},
+		{name: "token expiring at exactly dispatchTimeout", writeTimeout: 600 * time.Second, dispatchTimeout: 5 * time.Second, tokenExpiresIn: 5 * time.Second},
+		{name: "dispatchTimeout larger than writeTimeout", writeTimeout: 5 * time.Second, dispatchTimeout: 10 * time.Second},
+		{name: "healthy defaults", writeTimeout: DefaultWriteTimeout, dispatchTimeout: DefaultDispatchTimeout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &Hub{opt: &opt{writeTimeout: tc.writeTimeout, dispatchTimeout: tc.dispatchTimeout}}
+
+			s := &LocalSubscriber{}
+			if tc.tokenExpiresIn != 0 {
+				s.Claims = &claims{RegisteredClaims: jwt.RegisteredClaims{
+					ExpiresAt: jwt.NewNumericDate(time.Now().Add(tc.tokenExpiresIn)),
+				}}
+			}
+
+			rc := h.newResponseController(httptest.NewRecorder(), s)
+
+			assert.True(t, rc.disconnectionTime.After(time.Now()),
+				"disconnectionTime is %v in the past, the connection would close immediately", time.Until(rc.disconnectionTime))
+			assert.False(t, rc.disconnectionTime.After(rc.writeDeadline),
+				"disconnectionTime must not outlive the write deadline")
+		})
+	}
+}
+
+// With neither a write timeout nor a token expiry there is no deadline, so no
+// disconnection timer is armed and the zero time must be preserved.
+func TestNewResponseControllerNoDeadline(t *testing.T) {
+	t.Parallel()
+
+	h := &Hub{opt: &opt{writeTimeout: 0, dispatchTimeout: DefaultDispatchTimeout}}
+	rc := h.newResponseController(httptest.NewRecorder(), &LocalSubscriber{})
+
+	assert.True(t, rc.writeDeadline.IsZero())
+	assert.True(t, rc.disconnectionTime.IsZero())
+}


### PR DESCRIPTION
`disconnectionTime` is the write deadline minus `dispatchTimeout`, and `SubscribeHandler` arms the timer with `time.Until(rc.disconnectionTime)`. A value in the past fires on the first `select` iteration, so the connection closes right after the headers are written.

Measured on the current code with the defaults (`write_timeout 600s`, `dispatch_timeout 5s`):

| case | `time.Until(disconnectionTime)` | result |
| ---- | ------------------------------- | ------ |
| token `exp` in 2s | −3.417s | fires immediately |
| token `exp` in 5s | −211ms  | fires immediately |
| `dispatch_timeout 10s` > `write_timeout 5s` | −5.985s | fires immediately, every connection |
| no token | +8m39s | ok |

Two reachable configurations:

- A token expiring within `dispatchTimeout` is accepted by `authorize` and then dropped instantly, so the subscriber reconnects in a tight loop until the token really expires. Short-lived tokens are recommended by the spec, which makes this the normal case near the end of a token's life.
- A `dispatch_timeout` larger than `write_timeout` does it to every connection, with no error at config time.

`setDispatchWriteDeadline` already tolerates the inverted case; the disconnection timer did not.

The fix keeps the margin when it is available and falls back to the write deadline itself otherwise, so the subscriber gets the time its token grants. A zero deadline still means no deadline and no timer is armed.

Full suite passes with `-race` in both tag configurations.