### PR TITLE
ci: lint the build tags the release is built with

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,15 @@ jobs:
           args: --timeout=30m --config ../.golangci.yml
           working-directory: caddy
 
+      # The config pins the tags the release is built with, so the build-tag
+      # variants selected by !deprecated_topic / !deprecated_claim would never
+      # be linted. Mirror the reduced-tag test run below.
+      - name: golangci-lint (without the deprecated_topic and deprecated_claim tags)
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: latest
+          args: --timeout=30m --build-tags deprecated_transport,nobadger,nomysql,nopgx
+
       # infertypeargs is a gopls-only analyzer, unavailable in golangci-lint.
       - name: gopls infertypeargs
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,12 @@
 version: "2"
 run:
   tests: true
+  # Match the tags the released binaries are built with (see .goreleaser.yml),
+  # so the code that ships is the code that gets linted.
   build-tags:
     - deprecated_transport
+    - deprecated_topic
+    - deprecated_claim
     - nobadger
     - nomysql
     - nopgx
@@ -59,6 +63,11 @@ linters:
           - godox
           - noctx
           - wrapcheck
+          # A deprecated test variant deliberately mirrors its modern
+          # counterpart, so that the two protocol versions are covered by the
+          # same scenario. Same reasoning as the disabled jscpd check in
+          # .github/workflows/lint.yml.
+          - dupl
         path: _test\.go
     paths:
       - third_party$


### PR DESCRIPTION
`run.build-tags` omitted `deprecated_topic` and `deprecated_claim`, while `.goreleaser.yml` builds official binaries with both. With `linters.default: all`, the linter only ever saw the `!deprecated_*` variants, leaving nine non-test files unchecked:

`authorization_deprecated.go`, `authorizationclaims_deprecated.go`, `update_deprecated.go`, `topicmatcher_deprecated.go`, `matcher_deprecated.go`, `handlertopic_deprecated.go`, `claimrequirestopic_deprecated.go`, `publishtopic_deprecated.go`, `matcherclaim.go`

So the code that ships was the code that was never linted.

Pinning the release tags on its own would just move the blind spot to the `!deprecated_*` variants, so this also adds a second pass with the reduced tag set, mirroring the dual `go test` runs already in this workflow.

Verified locally, all three configurations report `0 issues`:

- root module with the release tags
- root module with the reduced tags
- caddy module with the release tags

`dupl` joins the existing test-file exclusion list: `caddy_deprecated_test.go` deliberately mirrors `caddy_test.go` so the same scenario covers both protocol versions. That is the intentional duplication already documented as the reason `VALIDATE_JSCPD` is off in `lint.yml`.