### PR TITLE
fix(bolt): report "earliest" when the requested Last-Event-ID is missing

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -322,13 +322,15 @@ func (t *BoltTransport) dispatchHistory(ctx context.Context, s *LocalSubscriber,
 			// searching would instead claim it is caught up to an event it
 			// never received. This also covers giving up at maxHistoryScan.
 			responseLastEventID = EarliestLastEventID
-
-			if t.logger.Enabled(ctx, slog.LevelInfo) {
-				t.logger.LogAttrs(ctx, slog.LevelInfo, "Can't find requested LastEventID")
-			}
 		}
 
+		// Unblock the subscriber before logging: it is parked on this channel
+		// and cannot send its response headers until the value arrives.
 		s.HistoryDispatched(responseLastEventID)
+
+		if !afterFromID && t.logger.Enabled(ctx, slog.LevelInfo) {
+			t.logger.LogAttrs(ctx, slog.LevelInfo, "Can't find requested LastEventID")
+		}
 
 		return nil
 	})

--- a/bolt.go
+++ b/bolt.go
@@ -313,13 +313,22 @@ func (t *BoltTransport) dispatchHistory(ctx context.Context, s *LocalSubscriber,
 			}
 		}
 
-		s.HistoryDispatched(responseLastEventID)
-
 		if !afterFromID {
+			// The requested id was never found, so nothing was replayed and
+			// there is no event preceding a first one sent. The protocol
+			// reserves "earliest" for this case — a requested event that does
+			// not exist or has been discarded — and reporting it tells the
+			// subscriber to re-fetch. Reporting the newest id seen while
+			// searching would instead claim it is caught up to an event it
+			// never received. This also covers giving up at maxHistoryScan.
+			responseLastEventID = EarliestLastEventID
+
 			if t.logger.Enabled(ctx, slog.LevelInfo) {
 				t.logger.LogAttrs(ctx, slog.LevelInfo, "Can't find requested LastEventID")
 			}
 		}
+
+		s.HistoryDispatched(responseLastEventID)
 
 		return nil
 	})

--- a/bolt_test.go
+++ b/bolt_test.go
@@ -407,3 +407,51 @@ func TestBoltTransportCleanupSkippedWithinSizeLimit(t *testing.T) {
 	unlimited := &BoltTransport{size: 0, cleanupFrequency: 1}
 	assert.False(t, unlimited.shouldCleanup(1_000_000))
 }
+
+// A requested Last-Event-ID that is not in the history means nothing was
+// replayed, so there is no "event preceding the first one sent". The response
+// cursor must be the reserved "earliest" value rather than the newest id seen
+// while searching, which the subscriber never received.
+func TestBoltTransportUnknownLastEventIDReportsEarliest(t *testing.T) {
+	t.Parallel()
+
+	transport := createBoltTransport(t, 0, 0)
+
+	for i := range 5 {
+		require.NoError(t, transport.Dispatch(t.Context(), &Update{
+			Event: Event{ID: strconv.Itoa(i)},
+			Topic: "https://example.com/foo",
+		}))
+	}
+
+	s := NewLocalSubscriber("does-not-exist", transport.logger, &TopicMatcherStore{})
+	s.SetMatchers([]TopicMatcher{{Type: MatcherTypeExact, Pattern: "https://example.com/foo"}}, nil)
+	require.NoError(t, transport.AddSubscriber(t.Context(), s))
+
+	assert.Equal(t, EarliestLastEventID, <-s.responseLastEventID)
+
+	s.Disconnect()
+}
+
+// A known id is echoed back: the subscriber already has it, and it really is
+// the event preceding the first one replayed.
+func TestBoltTransportKnownLastEventIDIsEchoed(t *testing.T) {
+	t.Parallel()
+
+	transport := createBoltTransport(t, 0, 0)
+
+	for i := range 5 {
+		require.NoError(t, transport.Dispatch(t.Context(), &Update{
+			Event: Event{ID: strconv.Itoa(i)},
+			Topic: "https://example.com/foo",
+		}))
+	}
+
+	s := NewLocalSubscriber("2", transport.logger, &TopicMatcherStore{})
+	s.SetMatchers([]TopicMatcher{{Type: MatcherTypeExact, Pattern: "https://example.com/foo"}}, nil)
+	require.NoError(t, transport.AddSubscriber(t.Context(), s))
+
+	assert.Equal(t, "2", <-s.responseLastEventID)
+
+	s.Disconnect()
+}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -977,7 +977,9 @@ func TestUnknownLastEventID(t *testing.T) {
 			}
 
 			hub.SubscribeHandler(w, req)
-			assert.Equal(t, "a", w.Header().Get("Mercure-Last-Event-ID"))
+			// "unknown" is not in the history, so nothing was replayed and the
+			// cursor is the reserved "earliest", not the newest id in history.
+			assert.Equal(t, EarliestLastEventID, w.Header().Get("Mercure-Last-Event-ID"))
 		}(ctx)
 
 		go func(ctx context.Context) {
@@ -994,7 +996,9 @@ func TestUnknownLastEventID(t *testing.T) {
 			}
 
 			hub.SubscribeHandler(w, req)
-			assert.Equal(t, "a", w.Header().Get("Mercure-Last-Event-ID"))
+			// "unknown" is not in the history, so nothing was replayed and the
+			// cursor is the reserved "earliest", not the newest id in history.
+			assert.Equal(t, EarliestLastEventID, w.Header().Get("Mercure-Last-Event-ID"))
 		}(ctx)
 
 		for {
@@ -1054,10 +1058,15 @@ func TestUnknownLastEventIDDoesNotLeakPrivateEventID(t *testing.T) {
 			}
 
 			hub.SubscribeHandler(w, req)
-			// Authorized "a" leaks back as the recovery anchor; the
-			// private "b" does not, even though it is the most recent
-			// in-history event.
-			assert.Equal(t, "a", w.Header().Get("Mercure-Last-Event-ID"))
+
+			cursor := w.Header().Get("Mercure-Last-Event-ID")
+			// The private "b" must not leak, even though it is the most
+			// recent in-history event. Nothing was replayed either, since
+			// "unknown" is not in the history, so the cursor is the reserved
+			// "earliest" rather than the authorized "a" — which the
+			// subscriber never received.
+			assert.NotEqual(t, "b", cursor)
+			assert.Equal(t, EarliestLastEventID, cursor)
 		}(ctx)
 
 		for {


### PR DESCRIPTION
While searching the history for the requested id, every authorized event the cursor walks past advances `responseLastEventID`. When the id is never found, `afterFromID` stays false, nothing is replayed, and yet the cursor still reported the newest authorized event in the scanned window.

So the subscriber was told it was caught up to an event it never received. Only a log line recorded the failure. Measured before the fix, with `last_event_id=does-not-exist` against a five-event history: the response cursor was `"4"`.

The protocol reserves `earliest` for a requested event that "does not exist or has been discarded", which is exactly this case, and reporting it makes the documented compare-and-refetch check work. It also fixes the `maxHistoryScan` path, where giving up after 10000 entries reported an arbitrary event that deep in the history.

A found id is still echoed back unchanged: the subscriber already has it, and it genuinely is the event preceding the first one replayed.

## Test changes

`TestUnknownLastEventID` and `TestUnknownLastEventIDDoesNotLeakPrivateEventID` asserted the old cursor, so both now expect `earliest`. The second one guards a privacy property — that a private event id must not leak into the header — and `earliest` satisfies it strictly more than the previous `"a"` did; I kept an explicit `NotEqual("b")` assertion so that intent stays visible rather than implied.