### PR TITLE
fix: don't sort the update's own topic slice while dispatching

### DIFF
--- a/subscriberlist.go
+++ b/subscriberlist.go
@@ -1,7 +1,7 @@
 package mercure
 
 import (
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/dunglas/skipfilter"
@@ -38,8 +38,6 @@ func NewSubscriberList(cacheSize int) *SubscriberList {
 }
 
 func encode(topics []string, private bool) string {
-	sort.Strings(topics)
-
 	parts := make([]string, len(topics)+1)
 	if private {
 		parts[0] = "1"
@@ -50,6 +48,13 @@ func encode(topics []string, private bool) string {
 	for i, t := range topics {
 		parts[i+1] = replacer.Replace(t)
 	}
+
+	// Sort the escaped copies, never the caller's slice: Update.topics() can
+	// return the Update's own backing array, and reordering it would change
+	// what MarshalJSON, LogValue and SpanAttributes report, and race with any
+	// concurrent reader. The key only has to be one canonical string per topic
+	// set, which sorting the escaped forms gives just as well.
+	slices.Sort(parts[1:])
 
 	return strings.Join(parts, string(delim))
 }

--- a/subscriberlist_test.go
+++ b/subscriberlist_test.go
@@ -3,6 +3,7 @@ package mercure
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,5 +43,51 @@ func BenchmarkSubscriberList(b *testing.B) {
 		assert.NotEmpty(b, l.MatchAny(&Update{Topic: "https://example.org/foo"}))
 		assert.Empty(b, l.MatchAny(&Update{Topic: "https://example.org/baz"}))
 		assert.NotEmpty(b, l.MatchAny(&Update{Topic: "https://example.com/8", Private: false}))
+	}
+}
+
+// encode must not reorder the slice it is given: Update.topics() can return the
+// Update's own backing array, so sorting in place would mutate the update being
+// dispatched and race with concurrent readers of it.
+func TestEncodeDoesNotMutateItsInput(t *testing.T) {
+	t.Parallel()
+
+	topics := []string{"https://example.com/z", "https://example.com/a", "https://example.com/m"}
+	want := slices.Clone(topics)
+
+	encode(topics, false)
+
+	assert.Equal(t, want, topics)
+}
+
+// The cache key must still be one canonical value per topic set, whatever order
+// the topics arrive in.
+func TestEncodeIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	a := encode([]string{"https://example.com/a", "https://example.com/z"}, false)
+	b := encode([]string{"https://example.com/z", "https://example.com/a"}, false)
+
+	assert.Equal(t, a, b)
+	assert.NotEqual(t, a, encode([]string{"https://example.com/a", "https://example.com/z"}, true))
+	assert.NotEqual(t, a, encode([]string{"https://example.com/a"}, false))
+}
+
+// A round-trip still recovers the topic set and the private flag, including
+// topics containing the escape and delimiter bytes.
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range [][]string{
+		{"https://example.com/a"},
+		{"https://example.com/z", "https://example.com/a"},
+		{"with\x00escape", "with\x01delim"},
+	} {
+		for _, private := range []bool{false, true} {
+			topics, gotPrivate := decode(encode(slices.Clone(tc), private))
+
+			assert.Equal(t, private, gotPrivate)
+			assert.ElementsMatch(t, tc, topics)
+		}
 	}
 }


### PR DESCRIPTION
`encode` started with `sort.Strings(topics)`, mutating the slice it was handed, and `SubscriberList.MatchAny` hands it `Update.topics()`.

In the default build `topics()` returns a fresh `[]string{u.Topic}`, so this was harmless. Under the `deprecated_topic` tag the first branch returns `u.Topics` directly — the update's own backing array:

```go
func (u *Update) topics() []string {
	if u.Topic == "" && len(u.Topics) > 0 {
		return u.Topics
	}
	...
```

So dispatching reordered the update's alternate topics in place. That is observable: `MarshalJSON`, `LogValue` and `SpanAttributes` all call `topics()` and would report the reordered list, persisted history entries included. Because the same `*Update` pointer travels across dispatch paths, the sort also raced with any concurrent reader of it.

Sorting the escaped copies is equivalent for the purpose: the key only has to be one canonical string per topic set. `sort.Strings` becomes `slices.Sort` on the copy, so the `sort` import goes away.

Three tests added: no mutation of the input, order-independence of the key, and an encode/decode round-trip covering topics that contain the escape and delimiter bytes. The first fails against the old in-place sort. Full suite passes with `-race` in both tag configurations.