### PR TITLE
fix: announce a subscription only once it exists

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -297,11 +297,9 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	addCtx := context.WithoutCancel(ctx)
-	h.dispatchSubscriptionUpdate(addCtx, s, true)
 
 	if err := h.transport.AddSubscriber(addCtx, s); err != nil {
 		http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
-		h.dispatchSubscriptionUpdate(addCtx, s, false)
 
 		if h.logger.Enabled(ctx, slog.LevelError) {
 			h.logger.LogAttrs(ctx, slog.LevelError, "Unable to add subscriber", slog.Any("error", err))
@@ -311,6 +309,12 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 
 		return nil, nil
 	}
+
+	// Announce the subscription only once it exists, so a failed registration
+	// cannot publish an active:true for a subscriber that never connected and
+	// then have to take it back. shutdown() already announces termination in
+	// this order: remove first, then dispatch active:false.
+	h.dispatchSubscriptionUpdate(addCtx, s, true)
 
 	h.sendHeaders(ctx, w, s)
 	rc := h.newResponseController(w, s)

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1398,3 +1398,74 @@ func TestNewResponseControllerNoDeadline(t *testing.T) {
 	assert.True(t, rc.writeDeadline.IsZero())
 	assert.True(t, rc.disconnectionTime.IsZero())
 }
+
+// refusingTransport records dispatched updates and refuses to register
+// subscribers, to exercise the registration-failure path.
+type refusingTransport struct {
+	dispatched []*Update
+}
+
+func (t *refusingTransport) Dispatch(_ context.Context, u *Update) error {
+	t.dispatched = append(t.dispatched, u)
+
+	return nil
+}
+
+func (t *refusingTransport) AddSubscriber(context.Context, *LocalSubscriber) error {
+	return ErrClosedTransport
+}
+
+func (t *refusingTransport) RemoveSubscriber(context.Context, *LocalSubscriber) error { return nil }
+
+func (t *refusingTransport) Close(context.Context) error { return nil }
+
+// A registration that fails must not announce a subscription that never
+// existed, nor take it back with a compensating active:false.
+func TestNoSubscriptionEventWhenRegistrationFails(t *testing.T) {
+	t.Parallel()
+
+	transport := &refusingTransport{}
+	hub := createAnonymousDummy(t, WithSubscriptions(), WithTransport(transport))
+
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match=https://example.com/foo", nil)
+	w := httptest.NewRecorder()
+
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Empty(t, transport.dispatched)
+}
+
+// The subscription is announced once it exists, so a subscriber authorized for
+// the subscriptions namespace sees its own arrival and needs no reconciliation
+// against the snapshot it fetched from the subscription API.
+func TestSubscriptionEventReachesTheSubscriberItDescribes(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t, WithSubscriptions())
+
+	req := httptest.NewRequest(http.MethodGet,
+		defaultHubURL+"?match_urlpattern=/.well-known/mercure/subscriptions/:mt/:m/:s", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  defaultCookieName,
+		Value: createDummyAuthorizedJWT(roleSubscriber, []string{"*"}),
+	})
+
+	w := newSubscribeRecorder()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	hub.SubscribeHandler(w, req.WithContext(ctx))
+
+	body := w.Body.String()
+	assert.Contains(t, body, "event: mercure")
+	assert.Contains(t, body, `"active": true`)
+	assert.Contains(t, body, `"match": "/.well-known/mercure/subscriptions/:mt/:m/:s"`)
+}


### PR DESCRIPTION
`dispatchSubscriptionUpdate(active: true)` ran **before** `transport.AddSubscriber`, so a failed registration published an arrival for a subscriber that never connected, then took it back with a compensating `active:false`. Observers of the subscriptions namespace saw a subscriber appear and vanish, while `metrics.SubscriberConnected` and `shutdown` never ran for it.

Registering first also makes the pair symmetric with `shutdown()`, which already removes the subscriber before announcing `active:false`.

## Behaviour change to review

A subscriber authorized for the subscriptions namespace now receives **its own** `active:true`, because it is in the subscriber list by the time the event is dispatched. Verified by probe — before this change its own body was empty, after it contains its own subscription document.

I think this is an improvement: `docs/concepts/active-subscriptions.md` describes fetching a snapshot from the subscription API and then following events to keep it current, and previously a subscriber's own subscription could appear in neither (missing from the snapshot if it raced, and never announced). But it is a visible change rather than a pure bug fix, so flagging it explicitly — say the word and I can keep the old behaviour by excluding the new subscriber from that one dispatch instead.

Anonymous subscribers are unaffected either way: subscription events are private, so they never matched.

## Tests

- `TestNoSubscriptionEventWhenRegistrationFails` — a transport that refuses `AddSubscriber` must produce no subscription update at all. Fails against the old order with the phantom event.
- `TestSubscriptionEventReachesTheSubscriberItDescribes` — pins the self-notification above so it stays deliberate. Fails against the old order with an empty body.

Full suite passes with `-race` in both tag configurations; lint clean.