### PR TITLE
refactor!: drop configuration nothing reads

### DIFF
--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -201,14 +201,6 @@ type Mercure struct {
 	// URLs work without configuration; set it to force one canonical audience.
 	ResourceIdentifier string `json:"resource_identifier,omitempty"`
 
-	// OAuth 2.0 authorization server issuer identifiers advertised in the
-	// hub's protected resource metadata.
-	AuthorizationServers []string `json:"authorization_servers,omitempty"`
-
-	// Issuer identifiers accepted in the token iss claim in addition to the
-	// authorization servers, for self-issued tokens (RFC 9068).
-	TrustedIssuers []string `json:"trusted_issuers,omitempty"`
-
 	// The version of the Mercure protocol to be backward compatible with (versions 7 and 8 are supported)
 	ProtocolVersionCompatibility int `json:"protocol_version_compatibility,omitempty"`
 

--- a/handler.go
+++ b/handler.go
@@ -59,7 +59,6 @@ func (h *Hub) initHandler() {
 
 	secureMiddleware := secure.New(secure.Options{
 		IsDevelopment:         h.debug,
-		AllowedHosts:          h.allowedHosts,
 		FrameDeny:             true,
 		ContentTypeNosniff:    true,
 		BrowserXssFilter:      true,

--- a/hub.go
+++ b/hub.go
@@ -228,15 +228,6 @@ func WithIssuers(issuers []Issuer) Option {
 	}
 }
 
-// WithAllowedHosts sets the allowed hosts.
-func WithAllowedHosts(hosts []string) Option {
-	return func(o *opt) error {
-		o.allowedHosts = hosts
-
-		return nil
-	}
-}
-
 // WithPublicURLs restricts the hub to the given public URLs, pinning their
 // scheme as well as their host. A request whose derived origin (scheme + host)
 // is not one of them is rejected with 421 Misdirected Request, and the hub
@@ -416,7 +407,6 @@ type opt struct {
 	publisherConfigured          bool
 	subscriberConfigured         bool
 	metrics                      Metrics
-	allowedHosts                 []string
 	publishOriginsAll            bool
 	publishOrigins               []string
 	publishWOrigins              []wildcard


### PR DESCRIPTION
Three knobs are about to be frozen by 1.0 without ever having had an effect.

**`WithAllowedHosts`** (`hub.go`) and its `opt` field feed `secure.Options.AllowedHosts`, but grepping both modules finds no caller: no `allowed_hosts` Caddyfile directive, no test, no docs. The allowlist was always empty, so the host check never ran. `WithPublicURLs` supersedes it — it pins the scheme as well as the host and answers `421 Misdirected Request` — and the site address already constrains `Host`.

**`Mercure.AuthorizationServers` and `Mercure.TrustedIssuers`** (`caddy/mercure.go`) carry JSON tags, which makes them part of the module's JSON config API, yet nothing reads them and `UnmarshalCaddyfile` has no `case` for either. Both concepts already come from `issuer` blocks: the per-issuer `authorization_server` flag and the block identifier. A JSON-API user who set them got a hub that validated the config and then ignored it.

19 lines removed, one exported option and two config fields gone.

`WithAllowedHosts` is exported, so this is breaking for a library consumer that calls it — though calling it never did anything. 1.0-alpha1 is the moment to remove it rather than carry it through 1.x.

Both modules build, vet, test (both tag configurations) and lint clean.