### PR TITLE
feat(caddy)!: require compatibility mode to be opted into explicitly

### DIFF
--- a/caddy/caddy_deprecated_test.go
+++ b/caddy/caddy_deprecated_test.go
@@ -349,10 +349,9 @@ localhost:9080 {
 }
 
 // The deprecated top-level publisher_jwt directive maps to the implicit issuer,
-// which is rejected in modern mode. Without protocol_version_compatibility the
-// hub must auto-enable compatibility mode so a 0.x bare-claim token still
-// publishes, instead of failing to provision.
-func TestMercureDeprecatedAutoCompat(t *testing.T) {
+// which only compatibility mode accepts. With protocol_version_compatibility
+// stated explicitly, a 0.x bare-claim token still publishes.
+func TestMercureDeprecatedExplicitCompat(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`{
 	skip_install_trust
@@ -366,6 +365,7 @@ localhost:9080 {
 		mercure {
 			anonymous
 			publisher_jwt !ChangeMe!
+			protocol_version_compatibility 8
 			transport local
 		}
 

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -904,3 +904,51 @@ func TestUnmarshalCaddyfileAcceptsKnownDirectives(t *testing.T) {
 	assert.Equal(t, []string{"*"}, m.CORSOrigins)
 	assert.Len(t, m.Issuers, 1)
 }
+
+// Compatibility mode relaxes access-token validation, so a leftover deprecated
+// JWT directive must not switch it on by itself.
+func TestLegacyJWTDirectivesRequireExplicitCompatibility(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		mercure       Mercure
+		wantRejection bool
+	}{
+		{
+			name:          "legacy publisher key without compatibility mode",
+			mercure:       Mercure{PublisherJWT: JWTConfig{Key: "!ChangeMe!"}},
+			wantRejection: true,
+		},
+		{
+			name:          "legacy subscriber JWK Set without compatibility mode",
+			mercure:       Mercure{SubscriberJWKSURL: "https://example.com/jwks.json"},
+			wantRejection: true,
+		},
+		{
+			name:    "legacy publisher key with compatibility mode",
+			mercure: Mercure{PublisherJWT: JWTConfig{Key: "!ChangeMe!"}, ProtocolVersionCompatibility: 8},
+		},
+		{
+			name: "issuer block only",
+			mercure: Mercure{Issuers: []IssuerConfig{{
+				Identifier: "https://example.com",
+				Publisher:  VerifierConfig{JWT: JWTConfig{Key: "!ChangeMe!"}},
+			}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.mercure.checkLegacyVerifiers()
+			if !tc.wantRejection {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorContains(t, err, "work only in compatibility mode")
+			assert.ErrorContains(t, err, "protocol_version_compatibility 8")
+		})
+	}
+}

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -947,8 +947,7 @@ func TestLegacyJWTDirectivesRequireExplicitCompatibility(t *testing.T) {
 				return
 			}
 
-			require.ErrorContains(t, err, "work only in compatibility mode")
-			assert.ErrorContains(t, err, "protocol_version_compatibility 8")
+			require.ErrorIs(t, err, errLegacyVerifiersNeedCompatibility)
 		})
 	}
 }

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -41,6 +41,8 @@ var (
 
 	ErrCompatibility = errors.New("compatibility mode only supports protocol versions 7 and 8")
 
+	errLegacyVerifiersNeedCompatibility = errors.New(`the "publisher_jwt", "subscriber_jwt", "publisher_jwks_url" and "subscriber_jwks_url" directives work only in compatibility mode, which relaxes access-token validation: move them into an "issuer" block for modern mode, or set "protocol_version_compatibility 8" to opt in explicitly`)
+
 	// hubs is a list of registered Mercure hubs, the key is the top-most subroute.
 	hubs   = make(map[caddy.Module]*hubInfo) //nolint:gochecknoglobals
 	hubsMu sync.Mutex                        //nolint:gochecknoglobals
@@ -905,7 +907,7 @@ func (m *Mercure) checkLegacyVerifiers() error {
 		return nil
 	}
 
-	return errors.New(`the "publisher_jwt", "subscriber_jwt", "publisher_jwks_url" and "subscriber_jwks_url" directives work only in compatibility mode, which relaxes access-token validation: move them into an "issuer" block for modern mode, or set "protocol_version_compatibility 8" to opt in explicitly`) //nolint:err113
+	return errLegacyVerifiersNeedCompatibility
 }
 
 // buildIssuers assembles the hub's issuer bindings from the explicit issuer

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -257,14 +257,8 @@ func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,goc
 
 	m.logger = slog.New(mercure.NewSlogHandler(ctx.Slogger().Handler()))
 
-	// The deprecated top-level JWT directives map to an implicit issuer that is
-	// only usable in compatibility mode. Enable it automatically so these
-	// directives keep working instead of failing at provision, and warn to
-	// steer users toward an issuer block. Requires a binary built with the
-	// deprecated_claim tag to actually accept 0.x tokens.
-	if m.ProtocolVersionCompatibility == 0 && m.hasLegacyVerifiers() {
-		m.ProtocolVersionCompatibility = 8
-		m.logger.Warn("Deprecated top-level JWT directives detected; enabling protocol_version_compatibility 8. Migrate them into an issuer block to run in modern mode.")
+	if err := m.checkLegacyVerifiers(); err != nil {
+		return err
 	}
 
 	var transport mercure.Transport
@@ -897,6 +891,21 @@ func (m *Mercure) hasLegacyVerifiers() bool {
 	pub, sub := m.legacyVerifiers()
 
 	return pub.isSet() || sub.isSet()
+}
+
+// checkLegacyVerifiers refuses the deprecated top-level JWT directives unless
+// compatibility mode was asked for by name. They map to an implicit issuer with
+// no identifier, which only that mode accepts, and turning it on does more than
+// accept the legacy token format: it also drops the required exp, the audience
+// check, the at+jwt typ check and the verified-issuer check, and it re-accepts
+// the access token in the URL query string. Losing those should be a decision
+// the operator wrote down, not something a leftover directive switches on.
+func (m *Mercure) checkLegacyVerifiers() error {
+	if m.ProtocolVersionCompatibility != 0 || !m.hasLegacyVerifiers() {
+		return nil
+	}
+
+	return errors.New(`the "publisher_jwt", "subscriber_jwt", "publisher_jwks_url" and "subscriber_jwks_url" directives work only in compatibility mode, which relaxes access-token validation: move them into an "issuer" block for modern mode, or set "protocol_version_compatibility 8" to opt in explicitly`) //nolint:err113
 }
 
 // buildIssuers assembles the hub's issuer bindings from the explicit issuer

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -138,7 +138,7 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 
 - The hub derives its public URL, the OAuth 2.0 resource identifier (token `aud`) and the RFC 9728 metadata from each request, so a hub reachable through several public URLs works with no domain configuration. Set `resource_identifier` only to pin one canonical audience shared across every domain. On a catch-all site block (`:443`, no host matcher), add `public_urls <url...>` so a request whose origin is not listed is rejected with `421 Misdirected Request` instead of choosing the derived identity.
 - Declare your token issuer with an `issuer <id> { ... }` block binding the `iss` value your tokens carry to its `publisher`/`subscriber` verifier (`jwt` or `jwks_uri`); it's required when JWT auth is enabled in modern mode. Add `authorization_server` inside the block to advertise it (see [Discovery](concepts/discovery.md)). Repeat the block to trust several issuers with distinct keys.
-- The pre-1.0 top-level directives `publisher_jwt`, `subscriber_jwt`, `publisher_jwks_url` and `subscriber_jwks_url` still parse but map to a single implicit issuer usable only in compatibility mode. When one is set without `protocol_version_compatibility`, the hub enables `protocol_version_compatibility 8` automatically and logs a warning; migrate them into an `issuer` block for modern mode.
+- The pre-1.0 top-level directives `publisher_jwt`, `subscriber_jwt`, `publisher_jwks_url` and `subscriber_jwks_url` still parse but map to a single implicit issuer usable only in compatibility mode. Setting one without `protocol_version_compatibility` is now a configuration error, because that mode also drops the required `exp`, the audience check, the `at+jwt` check and the issuer check, and re-accepts the token in the URL query string. Migrate them into an `issuer` block for modern mode, or add `protocol_version_compatibility 8` to accept those trade-offs deliberately.
 - The official Caddyfile no longer redacts query parameters from logs or serves `/healthz`; both only mattered for 0.x clients. Restore them if you run [compatibility mode](#compatibility-mode).
 - `transport_url` (deprecated since 0.17) is removed; use `transport <name> { ... }`. The legacy non-Caddy server is removed.
 - An unrecognized directive inside the `mercure` block is now a configuration error instead of being ignored. A typo previously disabled whatever it was meant to configure, silently, so check your `MERCURE_EXTRA_DIRECTIVES` if the hub refuses to start after the upgrade.
@@ -148,7 +148,9 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 0.x behaviors are gated behind two build tags, honored only with `protocol_version_compatibility 8`:
 
 - `deprecated_topic`: URI Template selectors in `topic=`, bare-string JWT matcher claims, alternate topics, the `/subscriptions/{topic}` routes.
-- `deprecated_claim`: the legacy `mercure` claim (string and object forms), the `https://mercure.rocks/` namespaced claim, `mercure.payload`, the `authorization` query parameter, the `mercureAuthorization` cookie, and tokens without `typ: at+jwt` / `aud`.
+- `deprecated_claim`: the legacy `mercure` claim (string and object forms), the `https://mercure.rocks/` namespaced claim, `mercure.payload`, the `authorization` query parameter, the `mercureAuthorization` cookie, and tokens without `typ: at+jwt`, `aud`, `exp` or a matching `iss`.
+
+Enabling it therefore weakens access-token validation, which is why the hub never turns it on by itself.
 
 Official binaries and Docker images ship with both tags, so you can run `protocol_version_compatibility 8` during the migration. A hub built without a tag rejects the corresponding 0.x behavior outright. Custom builds must pass the tags to `go build`.
 


### PR DESCRIPTION
`Provision` set `protocol_version_compatibility` to 8 by itself whenever a deprecated top-level JWT directive was present, warning in the log:

```go
if m.ProtocolVersionCompatibility == 0 && m.hasLegacyVerifiers() {
	m.ProtocolVersionCompatibility = 8
	m.logger.Warn("Deprecated top-level JWT directives detected; enabling protocol_version_compatibility 8. …")
}
```

Release binaries are built with `deprecated_claim` (`.goreleaser.yml`), so `compatClaimsEnabled()` is live in the shipped hub. Any 0.x Caddyfile still using `publisher_jwt` / `subscriber_jwt` / `*_jwks_url` therefore ran with:

- **`exp` no longer required** — `jwtParserOptions` returns before `jwt.WithExpirationRequired()`, so a token with no `exp` never expires
- **no audience check** (same early return)
- **no `at+jwt` typ check** — `requireATJWT()` is false
- **no verified-issuer check**
- **the access token accepted in the `authorization` URL query parameter**, which RFC 9700 §4.3.2 forbids and 1.0 otherwise drops
- the legacy `mercureAuthorization` cookie name accepted

That is the default upgrade path for every existing deployment, reached by a log line rather than a decision. None of it is required to keep *reading* 0.x token formats.

Provisioning now fails with a message naming both ways forward. The check lives in `checkLegacyVerifiers` so it is unit-testable without a `caddy.Context`.

## Tests

- `TestLegacyJWTDirectivesRequireExplicitCompatibility` — table over legacy-key/legacy-JWKS/with-compat/issuer-block-only.
- `TestMercureDeprecatedAutoCompat` covered exactly the removed behaviour, so it becomes `TestMercureDeprecatedExplicitCompat`: same end-to-end 0.x publish flow, with `protocol_version_compatibility 8` stated in the Caddyfile.

Upgrade guide updated, including the `exp` and `iss` relaxations which the compatibility-mode section did not previously list.

Reverses 7389b66.