### PR TITLE
docs: correct the deprecated build tag names

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -191,14 +191,12 @@ The entries below describe earlier upgrades. They are kept for users migrating a
 
 When Mercure is compiled manually or used as a Go library, deprecated features are no longer included by default.
 
-To re-enable deprecated transports, pass the `deprecated_transports` build tag when compiling Mercure:
+To re-enable deprecated transports, pass the `deprecated_transport` build tag when compiling Mercure:
 
 ```console
 # Mercure 0.21 Upgrade Notes
 go build -tags deprecated_transport
 ```
-
-To re-enable the legacy HTTP server, pass the `deprecated_server` build tag.
 
 Official binaries and Docker images still include deprecated features.
 


### PR DESCRIPTION
Two build tags in the 0.21 upgrade notes do not exist.

`deprecated_transports` (plural) — the guard is `//go:build deprecated_transport`, and the fenced example directly below the sentence already used the singular form, contradicting it. Go accepts an unknown build tag silently, so anyone following the prose got a build with the deprecated transports still stripped and no error to explain why.

`deprecated_server` — a repo-wide grep of `//go:build` lines finds no such tag, and the legacy HTTP server itself is gone, which the 1.0 section already records under hub configuration changes. Removed rather than corrected.

After this, every `deprecated_*` tag named anywhere in `docs/`, `README.md` and `CONTRIBUTING.md` matches a real guard: `deprecated_claim`, `deprecated_topic`, `deprecated_transport`.