### PR TITLE
refactor: use static errors instead of suppressing err113

### DIFF
--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -764,6 +764,11 @@ func normalizeJWT(repl *caddy.Replacer, c *JWTConfig, jwksURL string) {
 	}
 }
 
+var (
+	ErrMissingPublisherVerifier  = errors.New("a JWT key or the URL of a JWK Set for publishers must be provided")
+	ErrMissingSubscriberVerifier = errors.New("a JWT key or the URL of a JWK Set for subscribers must be provided")
+)
+
 func (m *Mercure) populateJWTConfig() error {
 	repl := caddy.NewReplacer()
 
@@ -788,11 +793,11 @@ func (m *Mercure) populateJWTConfig() error {
 	}
 
 	if !hasPublisher && !AllowNoPublish {
-		return errors.New("a JWT key or the URL of a JWK Set for publishers must be provided") //nolint:err113
+		return ErrMissingPublisherVerifier
 	}
 
 	if !hasSubscriber && !m.Anonymous {
-		return errors.New("a JWT key or the URL of a JWK Set for subscribers must be provided") //nolint:err113
+		return ErrMissingSubscriberVerifier
 	}
 
 	return nil
@@ -882,6 +887,8 @@ func (m *Mercure) buildIssuers(ctx context.Context) ([]mercure.Issuer, error) {
 	return issuers, nil
 }
 
+var ErrInvalidJWKSetFileHost = errors.New(`file:// JWK Set URL host must be empty or "localhost"`)
+
 // newJWKSetKeyfunc builds a Keyfunc from a JWK Set URL.
 //
 // file:// URLs point to a local JSON file containing a JWK Set; the file is
@@ -898,7 +905,7 @@ func newJWKSetKeyfunc(ctx context.Context, rawURL string) (keyfunc.Keyfunc, erro
 
 	if u.Scheme == "file" {
 		if u.Host != "" && u.Host != "localhost" {
-			return nil, fmt.Errorf(`file:// JWK Set URL host must be empty or "localhost", got %q`, u.Host) //nolint:err113
+			return nil, fmt.Errorf("%w, got %q", ErrInvalidJWKSetFileHost, u.Host)
 		}
 
 		b, err := os.ReadFile(u.Path)

--- a/subscription.go
+++ b/subscription.go
@@ -2,7 +2,7 @@ package mercure
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -114,7 +114,7 @@ func filterFromVars(vars map[string]string) (subscriptionFilter, error) {
 	}{{paramTopic, &f.topic}, {paramMatch, &f.match}, {paramMatchType, &f.matchType}} {
 		v, err := url.PathUnescape(vars[seg.name])
 		if err != nil {
-			return subscriptionFilter{}, errors.New("invalid " + seg.name + " segment: " + err.Error()) //nolint:err113
+			return subscriptionFilter{}, fmt.Errorf("invalid %s segment: %w", seg.name, err)
 		}
 
 		*seg.dst = v


### PR DESCRIPTION
Four `//nolint:err113` suppressions in `main` become package-level sentinels, so these failures can be matched with `errors.Is` instead of by substring.

- `caddy/mercure.go`: `ErrMissingPublisherVerifier`, `ErrMissingSubscriberVerifier`. Messages are unchanged, so no configuration error text moves.
- `caddy/mercure.go`: `ErrInvalidJWKSetFileHost`, wrapped with the offending host.
- `subscription.go`: the filter error was concatenating `err.Error()` into a new string, discarding the `url.EscapeError`. It now wraps with `%w`, so callers keep access to the underlying error. This is the one behavior change: the message text is identical, the error chain is no longer severed.

Same treatment as https://github.com/dunglas/mercure/pull/1315 and https://github.com/dunglas/mercure/pull/1326, applied to the pre-existing sites.