### PR TITLE
docs: simplify quickstart, drop stale Regexp/CEL refs, fix Caddyfile examples

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -41,7 +41,7 @@ url.searchParams.append("match_urlpattern", "https://example.com/books/:id");
 
 - The exact-match parameter is `match` (explicit spelling: `match_exact`); the templated one is `match_urlpattern`, using [URL Pattern](https://urlpattern.spec.whatwg.org) syntax (`:id`, not `{id}`).
 - Parameter names are **case-sensitive**. Any other name under the `match` prefix is rejected with `400`, so typos fail loudly.
-- The `Regexp`, `CEL`, and `URI Template` matcher types are gone. Rewrite `Regexp`/CEL filters as URL Patterns or exact topics. URI Templates survive only on a hub built with `deprecated_topic` running `protocol_version_compatibility 8`.
+- The `URI Template` matcher type is gone; it survives only on a hub built with `deprecated_topic` running `protocol_version_compatibility 8`. Rewrite templated topics as URL Patterns and string topics as exact topics.
 
 ### Migrate your tokens
 
@@ -122,7 +122,6 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 
 - `?topic=` / `&topic=` in subscriber URLs -> `match=` (or `match_urlpattern=` if templated)
 - URI Template syntax in subscribe URLs (`{id}`) -> URL Pattern syntax (`:id`)
-- `Regexp` / CEL subscribe filters -> URL Patterns or exact topics
 - `"mercure": { "publish": [...] }` in issuer code -> `authorization_details` with `actions: ["publish"]`
 - `"mercure": { "subscribe": [...] }` -> `authorization_details` with `actions: ["subscribe"]`
 - `mercureAuthorization` cookie -> `mercure_access_token`; `authorization=` query param -> `Authorization` header or cookie (no query parameter)

--- a/docs/concepts/authorization.md
+++ b/docs/concepts/authorization.md
@@ -273,8 +273,12 @@ When an identity provider or authorization server (Keycloak, Cognito, Auth0) iss
 mercure {
   issuer https://idp.example.com {
     authorization_server
-    publisher  { jwks_uri https://idp.example.com/.well-known/jwks.json }
-    subscriber { jwks_uri https://idp.example.com/.well-known/jwks.json }
+    publisher {
+      jwks_uri https://idp.example.com/.well-known/jwks.json
+    }
+    subscriber {
+      jwks_uri https://idp.example.com/.well-known/jwks.json
+    }
   }
 }
 ```
@@ -289,8 +293,12 @@ The default algorithm is HS256 (symmetric HMAC). For asymmetric verification (th
 # Verifying tokens with RSA and ECDSA keys
 mercure {
   issuer https://example.com {
-    publisher  { jwt {env.PUBLISHER_PUBLIC_KEY} RS256 }
-    subscriber { jwt {env.SUBSCRIBER_PUBLIC_KEY} RS256 }
+    publisher {
+      jwt {env.PUBLISHER_PUBLIC_KEY} RS256
+    }
+    subscriber {
+      jwt {env.SUBSCRIBER_PUBLIC_KEY} RS256
+    }
   }
 }
 ```

--- a/docs/concepts/authorization.md
+++ b/docs/concepts/authorization.md
@@ -231,7 +231,7 @@ Set the cookie during discovery, when the user fetches the page or the API resou
 
 ```http
 # Cookies in detail
-HTTP/1.1 200 OK
+200 OK
 Set-Cookie: __Secure-mercure_access_token=<JWT>; Domain=example.com; Path=/.well-known/mercure; Secure; HttpOnly; SameSite=Strict
 Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"
 ```

--- a/docs/concepts/encryption.md
+++ b/docs/concepts/encryption.md
@@ -34,7 +34,7 @@ The publisher and the subscriber need a shared key. Two patterns work:
 
 ```http
 # Distributing the JWE Key Between Publisher and Subscriber
-GET /books/1 HTTP/1.1
+GET /books/1
 Host: example.com
 Authorization: Bearer <session token>
 

--- a/docs/concepts/publishing.md
+++ b/docs/concepts/publishing.md
@@ -9,7 +9,7 @@ A publication is an HTTP `POST` to the hub with a form-encoded body:
 
 ```http
 # Publishing
-POST /.well-known/mercure HTTP/1.1
+POST /.well-known/mercure
 Host: hub.example.com
 Authorization: Bearer <access token>
 Content-Type: application/x-www-form-urlencoded

--- a/docs/concepts/reconnection-and-history.md
+++ b/docs/concepts/reconnection-and-history.md
@@ -31,7 +31,7 @@ The publisher closes that gap by attaching a `last-event-id` attribute to its `L
 
 ```http
 # Bootstrapping after page load
-GET /books/1 HTTP/1.1
+GET /books/1
 Host: example.com
 
 200 OK

--- a/docs/concepts/subscribing.md
+++ b/docs/concepts/subscribing.md
@@ -176,7 +176,7 @@ The publisher of a resource can advertise its hub via a `Link` header so clients
 
 ```http
 # Discovering the Mercure Hub via Link Header
-GET /books/1 HTTP/1.1
+GET /books/1
 Host: example.com
 
 200 OK

--- a/docs/concepts/topics-and-matchers.md
+++ b/docs/concepts/topics-and-matchers.md
@@ -7,7 +7,7 @@ description: "How subscribers select topics in Mercure with the two matcher type
 
 A **topic** is the address of an update. A **matcher** is the rule a subscriber uses to say which topics it cares about. Mercure defines two matcher types, `exact` and `urlpattern`; every hub supports both. Pick the one that fits the shape of your data.
 
-> **Upgrading from 0.x?** The subscriber query parameter changed from `topic=` to `match=` (exact) or `match_urlpattern=` (templated), and URI Templates are replaced by [URL Patterns](https://urlpattern.spec.whatwg.org). The Regexp, CEL, and URI Template matcher types are gone. Authorization claims are now `authorization_details` objects, not bare strings. Full details: [Upgrade guide](../UPGRADE.md#10-from-0x).
+> **Upgrading from 0.x?** The subscriber query parameter changed from `topic=` to `match=` (exact) or `match_urlpattern=` (templated), and URI Templates are replaced by [URL Patterns](https://urlpattern.spec.whatwg.org). The URI Template matcher type is gone. Authorization claims are now `authorization_details` objects, not bare strings. Full details: [Upgrade guide](../UPGRADE.md#10-from-0x).
 
 ## Topics
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -95,8 +95,12 @@ issuer https://issuer-a.example {
 }
 
 issuer https://issuer-b.example {
-  publisher  { jwks_uri https://issuer-b.example/jwks }
-  subscriber { jwks_uri https://issuer-b.example/jwks }
+  publisher {
+    jwks_uri https://issuer-b.example/jwks
+  }
+  subscriber {
+    jwks_uri https://issuer-b.example/jwks
+  }
 }
 ```
 
@@ -196,8 +200,12 @@ When tokens are minted by an external IdP (Keycloak, Cognito, Auth0):
 mercure {
   issuer https://idp.example.com {
     authorization_server
-    publisher  { jwks_uri https://idp.example.com/.well-known/jwks.json }
-    subscriber { jwks_uri https://idp.example.com/.well-known/jwks.json }
+    publisher {
+      jwks_uri https://idp.example.com/.well-known/jwks.json
+    }
+    subscriber {
+      jwks_uri https://idp.example.com/.well-known/jwks.json
+    }
   }
 }
 ```
@@ -216,8 +224,12 @@ mercure {
   resource_identifier https://hub.example.com/.well-known/mercure
   issuer https://auth.example.com {
     authorization_server
-    publisher  { jwks_uri https://auth.example.com/jwks }
-    subscriber { jwks_uri https://auth.example.com/jwks }
+    publisher {
+      jwks_uri https://auth.example.com/jwks
+    }
+    subscriber {
+      jwks_uri https://auth.example.com/jwks
+    }
   }
 }
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -13,28 +13,20 @@ If you already have a hub running, jump to [Subscribe](#subscribe-to-a-mercure-t
 
 ```console
 # Run the Mercure Hub Locally with Docker
-docker run -p 8080:80 \
-  -e SERVER_NAME=':80' \
+docker run -p 80:80 -p 443:443 \
   -e MERCURE_PUBLISHER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
   -e MERCURE_SUBSCRIBER_JWT_KEY='!ChangeThisMercureHubJWTSecretKey!' \
-  -e MERCURE_TRUSTED_ISSUERS='https://localhost' \
-  -e MERCURE_EXTRA_DIRECTIVES='anonymous
-cors_origins *
-resource_identifier https://localhost/.well-known/mercure
-demo' \
-  dunglas/mercure
+  dunglas/mercure caddy run --config /etc/caddy/dev.Caddyfile
 ```
 
-The hub is now serving on `http://localhost:8080`.
+The hub is now serving on `https://localhost`.
 
 What that command does:
 
 - `MERCURE_*_JWT_KEY`: the secret used to verify access tokens. Don't ship this value to production; the [installation guide](installation.md) covers proper key management.
-- `MERCURE_TRUSTED_ISSUERS`: the issuer tokens must carry in their `iss` claim. The demo token below uses this exact value.
-- `anonymous`: lets clients subscribe to public topics without a token (handy in dev, off by default in prod).
-- `cors_origins *`: allow any origin to connect (you'll want to restrict this).
-- `resource_identifier`: the OAuth 2.0 audience tokens must carry in their `aud` claim, and the value the demo token below uses. The hub derives this from the request by default; `SERVER_NAME=':80'` here is a catch-all address, so it is pinned to a stable value.
-- `demo`: turns on the in-browser debugger at <http://localhost:8080/.well-known/mercure/ui/>.
+- `caddy run --config /etc/caddy/dev.Caddyfile`: swaps in the image's bundled development config, which turns on anonymous subscriptions, permissive CORS, and the in-browser debugger at <https://localhost/.well-known/mercure/ui/>. Drop this flag for production; the [installation guide](installation.md) covers the default config.
+
+Because `SERVER_NAME` defaults to `localhost`, Caddy serves real HTTPS on it: an internal, self-signed certificate, since `localhost` can't get a publicly trusted one. Open <https://localhost/.well-known/mercure/ui/> in your browser and accept the certificate warning once; that's expected for local dev, and it doubles as a check that the hub is up. This also means the hub's default trusted issuer (`https://localhost`) and its derived resource identifier (`https://localhost/.well-known/mercure`) already match the demo token below, so nothing needs pinning.
 
 > **Pro tip.** Don't want to manage a hub? [Mercure Cloud](https://mercure.rocks/pricing) has a free tier sized for prototyping. Same protocol, no infrastructure to run.
 
@@ -48,7 +40,7 @@ Save this as `index.html` and open it in your browser:
 <title>Mercure quickstart</title>
 <ul id="log"></ul>
 <script>
-  const url = new URL("http://localhost:8080/.well-known/mercure");
+  const url = new URL("https://localhost/.well-known/mercure");
   url.searchParams.append("match", "https://example.com/books/1");
 
   const es = new EventSource(url);
@@ -75,11 +67,13 @@ In another terminal:
 
 ```console
 # Publish a Mercure Update with curl
-curl -X POST http://localhost:8080/.well-known/mercure \
+curl --insecure -X POST https://localhost/.well-known/mercure \
   -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJhdWQiOiJodHRwczovL2xvY2FsaG9zdC8ud2VsbC1rbm93bi9tZXJjdXJlIiwiYXV0aG9yaXphdGlvbl9kZXRhaWxzIjpbeyJhY3Rpb25zIjpbInB1Ymxpc2giXSwidG9waWNzIjpbeyJtYXRjaCI6IioifV0sInR5cGUiOiJodHRwczovL21lcmN1cmUucm9ja3MvYXV0aG9yaXphdGlvbi1kZXRhaWwifSx7ImFjdGlvbnMiOlsic3Vic2NyaWJlIl0sInRvcGljcyI6W3sibWF0Y2giOiIqIn1dLCJ0eXBlIjoiaHR0cHM6Ly9tZXJjdXJlLnJvY2tzL2F1dGhvcml6YXRpb24tZGV0YWlsIn1dLCJleHAiOjQxMDI0NDQ4MDAsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0In0.VO0-PRjJ2MGOrMk2HxlrBv217pB7hyLxLIQUGgSfyXs' \
   -d 'topic=https://example.com/books/1' \
   -d 'data={"status": "checked out"}'
 ```
+
+`--insecure` skips certificate verification, needed here only because the dev hub's certificate is self-signed. Drop it once you point `curl` at a hub with a real certificate.
 
 Reload the browser tab. The new message appears at the top of the list.
 
@@ -106,7 +100,7 @@ The bearer token is an OAuth 2.0 access token signed with the dev key above (hea
 }
 ```
 
-The `iss` matches one of the hub's trusted issuers (an `issuer` block), the `aud` matches its `resource_identifier`, the `typ` header is `at+jwt`, and the `publish` grant covers every topic. Generate your own at [jwt.io](https://jwt.io). Details in [Authorization](../concepts/authorization.md).
+The `iss` matches the hub's default trusted issuer, the `aud` matches its derived resource identifier, the `typ` header is `at+jwt`, and the `publish` grant covers every topic. Generate your own at [jwt.io](https://jwt.io). Details in [Authorization](../concepts/authorization.md).
 
 ## Closing the Mercure EventSource connection
 


### PR DESCRIPTION
## Summary
- Quickstart now boots with `caddy run --config /etc/caddy/dev.Caddyfile` (real HTTPS on `https://localhost`, anonymous/CORS/demo already baked in), so `MERCURE_TRUSTED_ISSUERS` and `MERCURE_EXTRA_DIRECTIVES` are no longer needed — the demo token's `iss`/`aud` already match the hub's defaults.
- Removed doc references to `Regexp`/`CEL` matcher types being "removed in 1.0" — they were never merged into a tagged release.
- Fixed `publisher { jwks_uri ... }` / `subscriber { jwt ... }` single-line blocks in Caddyfile examples: an opening brace must be the last token on its line, not followed by more tokens and a closing brace on the same line.
- Dropped the `HTTP/1.1` version token from raw request/response examples across the docs.