### PR TITLE
docs: clarify 1.0 upgrade guide and intro pitch

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -133,12 +133,23 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 
 ### Hub configuration changes
 
+#### New in 1.0 (nothing to migrate)
+
+`resource_identifier`, `public_urls`, and RFC 9728 discovery have no 0.x equivalent. There's no prior config to translate here, only something new to configure if you want it.
+
 - The hub derives its public URL, the OAuth 2.0 resource identifier (token `aud`) and the RFC 9728 metadata from each request, so a hub reachable through several public URLs works with no domain configuration. Set `resource_identifier` only to pin one canonical audience shared across every domain. On a catch-all site block (`:443`, no host matcher), add `public_urls <url...>` so a request whose origin is not listed is rejected with `421 Misdirected Request` instead of choosing the derived identity.
+
+#### Changed configuration
+
 - Declare your token issuer with an `issuer <id> { ... }` block binding the `iss` value your tokens carry to its `publisher`/`subscriber` verifier (`jwt` or `jwks_uri`); it's required when JWT auth is enabled in modern mode. Add `authorization_server` inside the block to advertise it (see [Discovery](concepts/discovery.md)). Repeat the block to trust several issuers with distinct keys.
 - The pre-1.0 top-level directives `publisher_jwt`, `subscriber_jwt`, `publisher_jwks_url` and `subscriber_jwks_url` still parse but map to a single implicit issuer usable only in compatibility mode. Setting one without `protocol_version_compatibility` is now a configuration error, because that mode also drops the required `exp`, the audience check, the `at+jwt` check and the issuer check, and re-accepts the token in the URL query string. Migrate them into an `issuer` block for modern mode, or add `protocol_version_compatibility 8` to accept those trade-offs deliberately.
 - The official Caddyfile no longer redacts query parameters from logs or serves `/healthz`; both only mattered for 0.x clients. Restore them if you run [compatibility mode](#compatibility-mode).
-- `transport_url` (deprecated since 0.17) is removed; use `transport <name> { ... }`. The legacy non-Caddy server is removed.
+- `transport_url` (deprecated since 0.17) is removed; use `transport <name> { ... }`.
 - An unrecognized directive inside the `mercure` block is now a configuration error instead of being ignored. A typo previously disabled whatever it was meant to configure, silently, so check your `MERCURE_EXTRA_DIRECTIVES` if the hub refuses to start after the upgrade.
+
+#### Legacy non-Caddy server removed
+
+The standalone non-Caddy binary is gone. It's been deprecated since Mercure 0.11, when the Caddy module became the primary hub, so this shouldn't affect anyone still on a supported setup. If you're still running it: switch to the Caddy-based binary or Docker image everyone else already uses (see [Installation](getting-started/installation.md)). There's no flag-for-flag migration to give, because this isn't a config change, it's a different binary. [Compatibility mode](#compatibility-mode) restores 0.x _protocol_ behaviors on the Caddy-based hub only; it doesn't bring the removed binary back.
 
 ### Compatibility mode
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -16,6 +16,7 @@ If you've ever wired up a WebSocket server just to push notifications, sync a UI
 - **Native browser support.** No SDK. The `EventSource` API ships in every modern browser; on the server, any HTTP client can publish.
 - **HTTP/2+ multiplexing.** One TCP connection carries every subscription a client opens, plus the rest of your app traffic.
 - **Built-in reconnection and replay.** Clients reconnect automatically and resume from the last event they saw. The hub's history buffer fills the gap.
+- **Presence.** The hub publishes an event every time someone subscribes or unsubscribes, so "who's online" and "who's viewing this document" work without a separate service. ([Details](concepts/active-subscriptions.md))
 - **JWT authorization.** Sign tokens with the matchers a publisher or subscriber is allowed to use. The hub enforces them.
 - **Hypermedia-friendly.** Topics are URLs. The protocol works with REST, GraphQL, JSON-LD, and HTML over the wire (Hotwire, htmx).
 - **Encryption support.** Updates can be JWE-encrypted end-to-end, so even the hub operator cannot read them.
@@ -33,7 +34,7 @@ If you've ever wired up a WebSocket server just to push notifications, sync a UI
 
 **vs. WebSockets.** WebSocket is a low-level transport; you still need to design framing, authorization, reconnection, replay, and presence. Mercure gives you all of that on top of HTTP/2, which most infrastructure already understands. For request/response inside the same connection, just use a regular `POST`: HTTP/2 already multiplexes it.
 
-**vs. Pusher / Ably / Firebase / Supabase Realtime.** These are SaaS-only. Mercure is a protocol with an open-source reference hub: you own the data and the connections, and you can run it on your own infrastructure if compliance demands it. The free Mercure.rocks Hub has **unlimited connections and an unlimited history buffer**, bound only by the hardware you give it.
+**vs. Pusher / Ably / Firebase / Supabase Realtime.** These are SaaS-only. Mercure is a protocol, not a vendor: run the open-source hub yourself, or use [Mercure Cloud](https://mercure.rocks/pricing) if you'd rather not manage infrastructure. Either way the wire format is the same, so you're not locked into a proprietary SDK, and switching between self-hosted and Cloud is a config change, not a rewrite. The free self-hosted Hub has **unlimited connections and an unlimited history buffer**, bound only by the hardware you give it. See the [pricing comparison](production/high-availability.md#mercure-vs-pusher-and-ably-pricing-comparison) for the numbers.
 
 **vs. WebSub.** WebSub is server-to-server only. Mercure does server-to-server, server-to-client, and client-to-client over the same primitive.
 


### PR DESCRIPTION
## Summary
- Split UPGRADE.md's hub-config section into new-in-1.0 (resource_identifier, public_urls, RFC 9728 discovery — no 0.x equivalent) vs actual migrations (issuer blocks, removed directives), plus a dedicated callout for the removed legacy non-Caddy server.
- Added presence to the intro feature list and reframed the SaaS comparison around Mercure Cloud being the same protocol, not a separate product.