### PR TITLE
fix: disable wsl_v5 alongside the deprecated wsl linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
     - testpackage
     - varnamelen
     - wsl
+    - wsl_v5
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
## Summary

- golangci-lint replaced `wsl` with `wsl_v5` as a distinct linter (the old one still exists, deprecated). `linters.default: all` enables both independently, so disabling only `wsl` left `wsl_v5` silently active and enforcing blank-line/cuddling rules the codebase was never held to.
- Adds `wsl_v5` to the disable list alongside `wsl`.

## Test plan

- [x] `golangci-lint run` on the root module: 0 issues (previously would flag 14 pre-existing `wsl_v5` violations once `wsl_v5` is left enabled)
- [x] `golangci-lint run --config ../.golangci.yml` on the `caddy` submodule: 0 issues (previously 4)
- [x] No deprecation warnings printed by golangci-lint after the fix