### PR TITLE
build: set CustomBinaryName so help/completion say mercure

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
     ldflags:
       - -X 'github.com/caddyserver/caddy/v2/modules/caddyhttp.ServerHeader=Mercure.rocks Caddy'
       - -X 'github.com/caddyserver/caddy/v2.CustomVersion=Mercure.rocks {{ .Version }} Caddy'
+      - -X 'github.com/caddyserver/caddy/v2.CustomBinaryName=mercure'
     tags:
       - deprecated_transport
       - deprecated_topic


### PR DESCRIPTION
## Summary
- Set `github.com/caddyserver/caddy/v2.CustomBinaryName=mercure` via ldflags in `.goreleaser.yml`
- Caddy's root cobra command falls back to "caddy" for `--help` text, usage lines, and shell completion unless this var is set; confirmed via local build that release binaries currently say "caddy run"/"caddy start" even though the binary is `mercure`

## Test plan
- [x] Built locally with the release ldflags/tags and confirmed `--help` and `completion bash` output now say "mercure"