### PR TITLE
fix: hide empty payload block in debugger's active subscriptions

### DIFF
--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -1073,6 +1073,7 @@ func (m *Mercure) playgroundTokenFunc() func(string) (string, error) {
 			alg:       sub.Alg,
 			exp:       devExp,
 			subscribe: []string{"*"},
+			payload:   `{"playground":true}`,
 		}
 		if pub {
 			p.publish = []string{"*"}

--- a/public/app.js
+++ b/public/app.js
@@ -283,7 +283,15 @@ const addSubscription = (s) => {
     : "topic";
   node.querySelector(".match").textContent = modern ? s.match : s.topic;
   node.querySelector(".subscriber").textContent = s.subscriber;
-  node.querySelector("pre").textContent = JSON.stringify(s.payload, null, 2);
+
+  const pre = node.querySelector("pre");
+  if (s.payload === undefined) {
+    node.querySelector(".payload-label").remove();
+    pre.remove();
+  } else {
+    pre.textContent = JSON.stringify(s.payload, null, 2);
+  }
+
   $subscriptions.appendChild(node);
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -297,6 +297,7 @@ https://example.com/books/1</textarea
                 <dd class="match"></dd>
                 <dt>Subscriber</dt>
                 <dd class="subscriber"></dd>
+                <dt class="payload-label">Payload</dt>
                 <pre></pre>
               </dl>
             </div>


### PR DESCRIPTION
## Summary

- Subscription payload (subscription.go:84) stays nil unless the JWT carries a per-subscribe payload claim, which is the common case. The debugger's "Active subscriptions" card always rendered an empty `pre` box regardless.
- Hide the payload label and `pre` when no payload is present instead of showing an empty box.
- Give the insecure playground token an example payload (`{"playground":true}`) so the feature is visible out of the box.