### PR TITLE
Events Query Modular Implementation

### DIFF
--- a/bolt_test.go
+++ b/bolt_test.go
@@ -27,8 +27,8 @@ func createBoltTransport(t *testing.T, size uint64, cleanupFrequency float64) *B
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, os.Remove(path))
 		require.NoError(t, transport.Close(t.Context()))
+		require.NoError(t, os.Remove(path))
 	})
 
 	return transport

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -1176,4 +1176,6 @@ func TestEventsQuery(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, resp.Body.Close())
 	})
+
+	assert.Equal(t, "application/x-www-form-urlencoded", resp.Header.Get("Accept-Query"))
 }

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -1178,7 +1178,8 @@ func TestEventsQuery(t *testing.T) {
 		require.NoError(t, resp.Body.Close())
 	})
 
-	assert.Equal(t, "application/x-www-form-urlencoded", resp.Header.Get("Accept-Query"))
+	assert.Equal(t, "application/events+json, application/x-www-form-urlencoded",
+		resp.Header.Get("Accept-Query"))
 	assert.Equal(t, "?1", resp.Header.Get("Incremental"))
 	// The bound the subscription asked for, read from the request and served
 	// back: a hub ignoring it would advertise its own write timeout instead.

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -1178,4 +1178,5 @@ func TestEventsQuery(t *testing.T) {
 	})
 
 	assert.Equal(t, "application/x-www-form-urlencoded", resp.Header.Get("Accept-Query"))
+	assert.Equal(t, "?1", resp.Header.Get("Incremental"))
 }

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -1170,6 +1170,7 @@ func TestEventsQuery(t *testing.T) {
 	req, err := http.NewRequest("QUERY", "http://localhost:9080/.well-known/mercure", strings.NewReader(body.Encode()))
 	require.NoError(t, err)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Events", "duration=1")
 
 	resp := tester.AssertResponseCode(req, http.StatusOK)
 
@@ -1179,4 +1180,7 @@ func TestEventsQuery(t *testing.T) {
 
 	assert.Equal(t, "application/x-www-form-urlencoded", resp.Header.Get("Accept-Query"))
 	assert.Equal(t, "?1", resp.Header.Get("Incremental"))
+	// The bound the subscription asked for, read from the request and served
+	// back: a hub ignoring it would advertise its own write timeout instead.
+	assert.Equal(t, "duration=1", resp.Header.Get("Events"))
 }

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -1137,3 +1137,43 @@ func TestLegacyJWTDirectivesRequireExplicitCompatibility(t *testing.T) {
 		})
 	}
 }
+
+func TestEventsQuery(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		skip_install_trust
+		admin localhost:2999
+		http_port     9080
+		https_port    9443
+	}
+
+	localhost:9080 {
+		route {
+			mercure {
+				anonymous
+				events_query
+				issuer https://example.com {
+					publisher {
+						jwt !ChangeMe!
+					}
+				}
+				resource_identifier https://example.com/.well-known/mercure
+			}
+
+			respond 404
+		}
+	}
+	`, "caddyfile")
+
+	body := url.Values{"match": {"https://example.com/foo/1"}, "events": {""}}
+	req, err := http.NewRequest("QUERY", "http://localhost:9080/.well-known/mercure", strings.NewReader(body.Encode()))
+	require.NoError(t, err)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp := tester.AssertResponseCode(req, http.StatusOK)
+
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
+}

--- a/caddy/go.mod
+++ b/caddy/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da // indirect
 	github.com/dlclark/regexp2/v2 v2.1.1 // indirect
 	github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526 // indirect
+	github.com/dunglas/httpsfv v1.1.1 // indirect
 	github.com/dunglas/skipfilter v1.0.0 // indirect
 	github.com/elnormous/contenttype v1.0.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/caddy/go.mod
+++ b/caddy/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/dlclark/regexp2/v2 v2.1.1 // indirect
 	github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526 // indirect
 	github.com/dunglas/skipfilter v1.0.0 // indirect
+	github.com/elnormous/contenttype v1.0.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
 	github.com/go-chi/chi/v5 v5.3.0 // indirect

--- a/caddy/go.sum
+++ b/caddy/go.sum
@@ -156,6 +156,8 @@ github.com/dunglas/skipfilter v1.0.0/go.mod h1:ryhr8j7CAHSjzeN7wI6YEuwoArQ3OQmRq
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/elnormous/contenttype v1.0.4 h1:FjmVNkvQOGqSX70yvocph7keC8DtmJaLzTTq6ZOQCI8=
+github.com/elnormous/contenttype v1.0.4/go.mod h1:5KTOW8m1kdX1dLMiUJeN9szzR2xkngiv2K+RVZwWBbI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/caddy/go.sum
+++ b/caddy/go.sum
@@ -151,6 +151,8 @@ github.com/dlclark/regexp2/v2 v2.1.1 h1:LCUGyd9Wf+r+VVOl8Ny38JTpWJcAsdVnCIuhhtth
 github.com/dlclark/regexp2/v2 v2.1.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526 h1:biCci7wlx/ChMqOkoUw6FPrhEZYRpulBZ+fO4Geo5Xs=
 github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526/go.mod h1:9qyjDljBPOWyWCGz7vo3Ek7cdnoG/DVk0Ucle7gWVS8=
+github.com/dunglas/httpsfv v1.1.1 h1:HoSs101zIE9I23DlqlmljJ/OIi7ILwrH347pXhRZdxI=
+github.com/dunglas/httpsfv v1.1.1/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
 github.com/dunglas/skipfilter v1.0.0 h1:JG9SgGg4n6BlFwuTYzb9RIqjH7PfwszvWehanrYWPF4=
 github.com/dunglas/skipfilter v1.0.0/go.mod h1:ryhr8j7CAHSjzeN7wI6YEuwoArQ3OQmRqWWVCEAfb9w=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -133,6 +133,9 @@ type Mercure struct {
 	// Dispatch updates when subscriptions are created or terminated
 	Subscriptions bool `json:"subscriptions,omitempty"`
 
+	// Serve subscriptions expressed as an Events Query
+	EventsQuery bool `json:"events_query,omitempty"`
+
 	// Enable the prod-safe debugger UI at /.well-known/mercure/debug/.
 	Debugger bool `json:"debugger,omitempty"`
 
@@ -335,6 +338,10 @@ func (m *Mercure) Provision(ctx caddy.Context) (err error) { //nolint:funlen,goc
 		opts = append(opts, mercure.WithSubscriptions())
 	}
 
+	if m.EventsQuery {
+		opts = append(opts, mercure.WithEventsQuery())
+	}
+
 	if d := m.WriteTimeout; d != nil {
 		opts = append(opts, mercure.WithWriteTimeout(time.Duration(*d)))
 	}
@@ -496,6 +503,9 @@ func (m *Mercure) UnmarshalCaddyfile(d *caddyfile.Dispenser) (err error) { //nol
 
 			case "subscriptions":
 				m.Subscriptions = true
+
+			case "events_query":
+				m.EventsQuery = true
 
 			case "write_timeout":
 				if m.WriteTimeout, err = parseDurationParameter(d); err != nil {

--- a/contenttype_test.go
+++ b/contenttype_test.go
@@ -1,0 +1,120 @@
+package mercure
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateValidateContentType(t *testing.T) {
+	t.Parallel()
+
+	base := Update{Topics: []string{"https://example.com/books/1"}}
+
+	valid := base
+	valid.ContentType = "application/ld+json; charset=utf-8"
+	require.NoError(t, valid.Validate())
+
+	for _, ct := range []string{"not a media type", "text/plain\r\nX-Injected: 1", "/missing-type"} {
+		invalid := base
+		invalid.ContentType = ct
+		require.ErrorIs(t, invalid.Validate(), ErrInvalidMediaType, ct)
+	}
+}
+
+// History entries persisted before the ContentType field existed must still
+// decode, and the field must survive a marshal/unmarshal round trip.
+func TestUpdateContentTypeJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	u := &Update{
+		Topics:      []string{"https://example.com/books/1"},
+		ContentType: "application/ld+json",
+		Event:       Event{Data: "d", ID: "i"},
+	}
+
+	serialized, err := json.Marshal(u)
+	require.NoError(t, err)
+
+	var decoded Update
+
+	require.NoError(t, json.Unmarshal(serialized, &decoded))
+	assert.Equal(t, *u, decoded)
+
+	var legacy Update
+
+	require.NoError(t, json.Unmarshal([]byte(`{"Topics":["https://example.com/books/1"],"Data":"d","ID":"i"}`), &legacy))
+	assert.Empty(t, legacy.ContentType)
+}
+
+func TestPublishHandlerContentType(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t)
+
+	// The subscriber is registered before the publication, so by the time
+	// PublishHandler returns the update sits in its buffered channel.
+	s := NewLocalSubscriber("", hub.logger, hub.topicMatcherStore)
+	s.SetMatchers([]TopicMatcher{{Type: MatcherTypeExact, Pattern: "https://example.com/books/1"}}, nil)
+	require.NoError(t, hub.transport.AddSubscriber(t.Context(), s))
+
+	form := url.Values{}
+	form.Add("topic", "https://example.com/books/1")
+	form.Add("data", "Hello World")
+	form.Add("content_type", "application/ld+json")
+
+	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
+
+	w := httptest.NewRecorder()
+	hub.PublishHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case dispatched := <-s.Receive():
+		assert.Equal(t, "application/ld+json", dispatched.ContentType)
+	case <-time.After(5 * time.Second):
+		t.Fatal("update not received")
+	}
+}
+
+func TestPublishHandlerInvalidContentType(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t)
+
+	form := url.Values{}
+	form.Add("topic", "https://example.com/books/1")
+	form.Add("data", "Hello World")
+	form.Add("content_type", "not a media type")
+
+	req := httptest.NewRequest(http.MethodPost, defaultHubURL, strings.NewReader(form.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
+
+	w := httptest.NewRecorder()
+	hub.PublishHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,21 @@
+package mercure
+
+// streamEncoder frames updates onto a subscription response stream.
+//
+// A subscription response is a sequence of framed messages: a preamble
+// written with the headers, one message per update, and keep-alives in
+// between.
+type streamEncoder interface {
+	// contentType is the response Content-Type field value.
+	contentType() []string
+
+	// preamble is written immediately after the headers and before any
+	// update. Writing it is also what forces the headers onto the wire.
+	preamble() string
+
+	// encode returns the wire form of a single update.
+	encode(u *Update) string
+
+	// heartbeat returns the keep-alive payload.
+	heartbeat() string
+}

--- a/encoder.go
+++ b/encoder.go
@@ -6,13 +6,14 @@ package mercure
 // subscription expressing no preference gets.
 //
 //nolint:gochecknoglobals
-var carrierContentTypes = []string{eventStreamContentType}
+var carrierContentTypes = []string{multipartDigestContentType, eventStreamContentType}
 
 // responseEncoders provides the framing for each media type
 //
 //nolint:gochecknoglobals
-var responseEncoders = map[string]streamEncoder{
-	eventStreamContentType: eventStreamEncoder{},
+var responseEncoders = map[string]func() streamEncoder{
+	multipartDigestContentType: newMultipartDigestEncoder,
+	eventStreamContentType:     newEventStreamEncoder,
 }
 
 // Mercure ordinarily (without Events Query) serves only Event Stream
@@ -38,4 +39,9 @@ type streamEncoder interface {
 
 	// heartbeat returns the keep-alive payload.
 	heartbeat() string
+
+	// trailer closes the stream, or "" when the framing needs no terminator.
+	// It is written only when the response ends cleanly, never once the
+	// client has gone away.
+	trailer() string
 }

--- a/encoder.go
+++ b/encoder.go
@@ -1,5 +1,25 @@
 package mercure
 
+// carrierContentTypes are the media types a stream of notifications can be
+// served as, most preferred first. An Events Query names what it will read in
+// Accept; this list decides what there is to choose from, and what a
+// subscription expressing no preference gets.
+//
+//nolint:gochecknoglobals
+var carrierContentTypes = []string{eventStreamContentType}
+
+// responseEncoders provides the framing for each media type
+//
+//nolint:gochecknoglobals
+var responseEncoders = map[string]streamEncoder{
+	eventStreamContentType: eventStreamEncoder{},
+}
+
+// Mercure ordinarily (without Events Query) serves only Event Stream
+//
+//nolint:gochecknoglobals
+var mercureCarrierContentType = []string{eventStreamContentType}
+
 // streamEncoder frames updates onto a subscription response stream.
 //
 // A subscription response is a sequence of framed messages: a preamble

--- a/encoder_eventstream.go
+++ b/encoder_eventstream.go
@@ -8,6 +8,8 @@ const eventStreamContentType = "text/event-stream"
 // the protocol's first version.
 type eventStreamEncoder struct{}
 
+func newEventStreamEncoder() streamEncoder { return eventStreamEncoder{} }
+
 func (eventStreamEncoder) contentType() []string { return []string{eventStreamContentType} }
 
 // A bare SSE comment. Go currently provides no better way to flush the
@@ -18,3 +20,5 @@ func (eventStreamEncoder) encode(u *Update) string { return u.String() }
 
 // An SSE comment, to prevent issues with some proxies and old browsers.
 func (eventStreamEncoder) heartbeat() string { return ":\n" }
+
+func (eventStreamEncoder) trailer() string { return "" }

--- a/encoder_eventstream.go
+++ b/encoder_eventstream.go
@@ -1,0 +1,20 @@
+package mercure
+
+// The media type a Server-Sent Events stream is served as.
+const eventStreamContentType = "text/event-stream"
+
+// eventStreamEncoder frames updates as Server-Sent Events
+// (text/event-stream), the framing every Mercure subscriber has used since
+// the protocol's first version.
+type eventStreamEncoder struct{}
+
+func (eventStreamEncoder) contentType() []string { return []string{eventStreamContentType} }
+
+// A bare SSE comment. Go currently provides no better way to flush the
+// headers, so writing it is what sends them.
+func (eventStreamEncoder) preamble() string { return ":\n" }
+
+func (eventStreamEncoder) encode(u *Update) string { return u.String() }
+
+// An SSE comment, to prevent issues with some proxies and old browsers.
+func (eventStreamEncoder) heartbeat() string { return ":\n" }

--- a/encoder_eventstream_test.go
+++ b/encoder_eventstream_test.go
@@ -1,0 +1,107 @@
+package mercure
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventStreamEncoderContentType(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"text/event-stream"}, eventStreamEncoder{}.contentType())
+}
+
+// The preamble is a bare comment, written only to force the headers onto the
+// wire, so it must carry no fields a subscriber could mistake for an update.
+func TestEventStreamEncoderPreamble(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, ":\n", eventStreamEncoder{}.preamble())
+}
+
+func TestEventStreamEncoderEncode(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		u    *Update
+		want string
+	}{
+		{
+			"id and data",
+			&Update{Event: Event{ID: "a", Data: "hi"}},
+			"id: a\ndata: hi\n\n",
+		},
+		{
+			// type and retry precede the id, and are omitted when unset.
+			"every field",
+			&Update{Event: Event{ID: "a", Data: "hi", Type: "update", Retry: 5}},
+			"event: update\nretry: 5\nid: a\ndata: hi\n\n",
+		},
+		{
+			// A data field carries one line each, per the event stream format.
+			"data spanning several lines",
+			&Update{Event: Event{ID: "a", Data: "one\ntwo"}},
+			"id: a\ndata: one\ndata: two\n\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, eventStreamEncoder{}.encode(tc.u))
+		})
+	}
+}
+
+// The framing is Event.String(); encoding must not diverge from it.
+func TestEventStreamEncoderEncodeMatchesEventString(t *testing.T) {
+	t.Parallel()
+
+	u := &Update{Event: Event{ID: "a", Data: "hi", Type: "update", Retry: 5}}
+
+	assert.Equal(t, u.String(), eventStreamEncoder{}.encode(u))
+}
+
+// Topics are not part of an event, and never reach a subscriber. This pins
+// that they stay that way.
+func TestEventStreamEncoderOmitsTopics(t *testing.T) {
+	t.Parallel()
+
+	encoded := eventStreamEncoder{}.encode(&Update{
+		Topics:  []string{"https://example.com/books/1", "https://example.com/users/42/books/1"},
+		Private: true,
+		Event:   Event{ID: "a", Data: "hi"},
+	})
+
+	assert.NotContains(t, encoded, "users/42")
+	assert.NotContains(t, encoded, "topic")
+	assert.NotContains(t, encoded, "private")
+}
+
+// A comment, which a subscriber ignores, keeping proxies and old browsers
+// from closing an idle connection.
+func TestEventStreamEncoderHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, ":\n", eventStreamEncoder{}.heartbeat())
+}
+
+// The assembled stream is what a subscriber actually reads: a comment, then
+// one event per update, each ending in a blank line.
+func TestEventStreamEncoderStream(t *testing.T) {
+	t.Parallel()
+
+	e := eventStreamEncoder{}
+
+	stream := e.preamble() +
+		e.encode(&Update{Event: Event{ID: "a", Data: "first"}}) +
+		e.heartbeat() +
+		e.encode(&Update{Event: Event{ID: "b", Data: "second"}})
+
+	assert.Equal(t, ":\nid: a\ndata: first\n\n:\nid: b\ndata: second\n\n", stream)
+
+	// Every event is terminated, so a subscriber never waits on a partial one.
+	assert.True(t, strings.HasSuffix(stream, "\n\n"))
+}

--- a/encoder_multipartdigest.go
+++ b/encoder_multipartdigest.go
@@ -1,0 +1,88 @@
+package mercure
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+// Content type for the Events Query response
+const multipartDigestContentType = "multipart/digest"
+
+// Default media type of the update data sent to/from the hub.
+const updateDataContentType = "text/plain; charset=utf-8"
+
+// Opens every boundary, as many browsers and HTTP libraries write it.
+const boundaryPrefix = "----------------"
+
+// multipartDigestEncoder frames updates as a multipart/digest stream. A part
+// defaults to message/rfc822 (RFC 2046 §5.1.5), so a notification is a message:
+// the event's fields as header fields, its data as the body.
+type multipartDigestEncoder struct {
+	boundary string
+}
+
+// newMultipartDigestEncoder returns an encoder with a fresh random boundary.
+func newMultipartDigestEncoder() streamEncoder {
+	var b [8]byte
+	rand.Read(b[:])
+
+	return &multipartDigestEncoder{boundary: boundaryPrefix + hex.EncodeToString(b[:])}
+}
+
+func (e *multipartDigestEncoder) contentType() []string {
+	return []string{multipartDigestContentType + `; boundary="` + e.boundary + `"`}
+}
+
+// The delimiter opening the first part. The CRLF that terminates it belongs
+// to the part itself, so that every part including the terminal is written the
+// same way.
+func (e *multipartDigestEncoder) preamble() string { return "--" + e.boundary }
+
+// encode writes the notification as a message/rfc822 body wrapped in a
+// multipart framing.
+func (e *multipartDigestEncoder) encode(u *Update) string {
+	var m strings.Builder
+
+	m.WriteString("Event-ID: ")
+	m.WriteString(u.ID)
+	m.WriteString("\r\n")
+
+	// Mirrors Event.String(): the optional fields are omitted when unset
+	// rather than sent empty.
+	if u.Type != "" {
+		m.WriteString("Event-Type: ")
+		m.WriteString(u.Type)
+		m.WriteString("\r\n")
+	}
+
+	// Milliseconds, as the SSE field this re-emits.
+	if u.Retry != 0 {
+		m.WriteString("Retry: ")
+		m.WriteString(strconv.FormatUint(u.Retry, 10))
+		m.WriteString("\r\n")
+	}
+
+	m.WriteString("Content-Type: ")
+	m.WriteString(updateDataContentType)
+	m.WriteString("\r\nContent-Length: ")
+	m.WriteString(strconv.Itoa(len(u.Data)))
+	m.WriteString("\r\n\r\n")
+	m.WriteString(u.Data)
+
+	return e.notification("", m.String())
+}
+
+// An empty part is sent for the heartbeat. An internet linebreak is the
+// smallest rfc822 message.
+func (e *multipartDigestEncoder) heartbeat() string { return e.notification("", "\r\n") }
+
+// Promotes the delimiter written by the last part into the close-delimiter.
+func (e *multipartDigestEncoder) trailer() string { return "--\r\n" }
+
+// Assembles the notification, closing it with the boundary delimiter.
+// Thus, a receiver knows that the message is complete.
+func (e *multipartDigestEncoder) notification(headers string, body string) string {
+	return "\r\n" + headers + "\r\n" + body + "\r\n--" + e.boundary
+}

--- a/encoder_multipartdigest.go
+++ b/encoder_multipartdigest.go
@@ -64,8 +64,13 @@ func (e *multipartDigestEncoder) encode(u *Update) string {
 		m.WriteString("\r\n")
 	}
 
+	contentType := u.ContentType
+	if contentType == "" {
+		contentType = updateDataContentType
+	}
+
 	m.WriteString("Content-Type: ")
-	m.WriteString(updateDataContentType)
+	m.WriteString(contentType)
 	m.WriteString("\r\nContent-Length: ")
 	m.WriteString(strconv.Itoa(len(u.Data)))
 	m.WriteString("\r\n\r\n")

--- a/encoder_multipartdigest.go
+++ b/encoder_multipartdigest.go
@@ -13,9 +13,6 @@ const multipartDigestContentType = "multipart/digest"
 // Default media type of the update data sent to/from the hub.
 const updateDataContentType = "text/plain; charset=utf-8"
 
-// Opens every boundary, as many browsers and HTTP libraries write it.
-const boundaryPrefix = "----------------"
-
 // multipartDigestEncoder frames updates as a multipart/digest stream. A part
 // defaults to message/rfc822 (RFC 2046 §5.1.5), so a notification is a message:
 // the event's fields as header fields, its data as the body.
@@ -24,11 +21,15 @@ type multipartDigestEncoder struct {
 }
 
 // newMultipartDigestEncoder returns an encoder with a fresh random boundary.
+// Length-aware receivers read each body by its Content-Length, but standard
+// multipart parsers locate parts by scanning for the delimiter, so the
+// boundary carries enough entropy (240 bits, the same as mime/multipart's
+// writer) that a payload can never be crafted to contain it.
 func newMultipartDigestEncoder() streamEncoder {
-	var b [8]byte
+	var b [30]byte
 	rand.Read(b[:])
 
-	return &multipartDigestEncoder{boundary: boundaryPrefix + hex.EncodeToString(b[:])}
+	return &multipartDigestEncoder{boundary: hex.EncodeToString(b[:])}
 }
 
 func (e *multipartDigestEncoder) contentType() []string {

--- a/encoder_multipartdigest_test.go
+++ b/encoder_multipartdigest_test.go
@@ -1,0 +1,248 @@
+package mercure
+
+import (
+	"bufio"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultipartDigestEncoderContentType(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	ct := e.contentType()
+	require.Len(t, ct, 1)
+
+	mediaType, params, err := mime.ParseMediaType(ct[0])
+	require.NoError(t, err)
+	assert.Equal(t, "multipart/digest", mediaType)
+	assert.Equal(t, e.boundary, params["boundary"])
+}
+
+// Two encoders must not share a boundary: a payload that happened to contain
+// one would otherwise confuse every connection alike.
+func TestMultipartDigestEncoderBoundaryIsRandom(t *testing.T) {
+	t.Parallel()
+
+	a := newDigestEncoder(t)
+
+	b := newDigestEncoder(t)
+
+	assert.NotEqual(t, a.boundary, b.boundary)
+}
+
+// 16 hyphens and 16 random hex characters, the shape many browsers and HTTP
+// libraries write.
+func TestMultipartDigestEncoderBoundaryShape(t *testing.T) {
+	t.Parallel()
+
+	boundary := newDigestEncoder(t).boundary
+
+	assert.Len(t, boundary, 32)
+	assert.Equal(t, strings.Repeat("-", 16), boundary[:16])
+	assert.Regexp(t, "^[0-9a-f]{16}$", boundary[16:])
+}
+
+func TestMultipartDigestEncoderEncode(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	assert.Equal(t,
+		"\r\n\r\n"+
+			"Event-ID: urn:1\r\n"+
+			"Content-Type: text/plain; charset=utf-8\r\n"+
+			"Content-Length: 2\r\n"+
+			"\r\n"+
+			"hi"+
+			"\r\n--"+e.boundary,
+		e.encode(&Update{Event: Event{ID: "urn:1", Data: "hi"}}),
+	)
+}
+
+// type and retry are omitted when unset, as Event.String() omits the
+// corresponding SSE fields.
+func TestMultipartDigestEncoderOmitsUnsetFields(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	header, _ := encodedNotification(t, e, e.encode(&Update{Event: Event{ID: "a", Data: "d"}}))
+	assert.Equal(t, "a", header.Get("Event-ID"))
+	assert.Empty(t, header.Get("Event-Type"))
+	assert.Empty(t, header.Get("Retry"))
+
+	header, _ = encodedNotification(t, e,
+		e.encode(&Update{Event: Event{ID: "a", Data: "d", Type: "t", Retry: 5}}))
+	assert.Equal(t, "t", header.Get("Event-Type"))
+	assert.Equal(t, "5", header.Get("Retry"))
+}
+
+// Topics never reach subscribers over Event Stream; an alternate topic can
+// name another subscriber's namespace, so it must not leak here either.
+func TestMultipartDigestEncoderOmitsTopics(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	part := e.encode(&Update{
+		Topics:  []string{"https://example.com/books/1", "https://example.com/users/42/books/1"},
+		Private: true,
+		Event:   Event{ID: "a", Data: "d"},
+	})
+
+	assert.NotContains(t, part, "users/42")
+	assert.NotContains(t, part, "Topic")
+	assert.NotContains(t, part, "Private")
+}
+
+// Data may hold any valid UTF-8, including the control characters that
+// Update.Validate permits. The message body is delimited by its length, so
+// they travel as they were published.
+func TestMultipartDigestEncoderCarriesDataVerbatim(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	const data = "line\r\nnext\x00null&amp=x"
+
+	_, body := encodedNotification(t, e, e.encode(&Update{Event: Event{ID: "a", Data: data}}))
+	assert.Equal(t, data, body)
+}
+
+// A payload containing the boundary must not terminate the part early. Every
+// part declares a Content-Length, so a conforming parser reads the body by
+// length rather than scanning for the delimiter.
+func TestMultipartDigestEncoderBoundaryInPayload(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	data := "--" + e.boundary + "--"
+
+	_, body := encodedNotification(t, e, e.encode(&Update{Event: Event{ID: "a", Data: data}}))
+	assert.Equal(t, data, body)
+}
+
+// The keep-alive is a part carrying the smallest message there is: no fields
+// and no body, one linebreak in all.
+func TestMultipartDigestEncoderHeartbeatIsEmptyPart(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	assert.Equal(t, "\r\n\r\n\r\n\r\n--"+e.boundary, e.heartbeat())
+}
+
+// The whole stream must parse as a multipart body: preamble, parts, trailer.
+func TestMultipartDigestEncoderStreamIsWellFormed(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	stream := e.preamble() +
+		e.encode(&Update{Event: Event{ID: "a", Data: "first"}}) +
+		e.heartbeat() +
+		e.encode(&Update{Event: Event{ID: "b", Data: "second", Type: "update"}}) +
+		e.trailer()
+
+	r := multipart.NewReader(strings.NewReader(stream), e.boundary)
+
+	type part struct {
+		contentType string
+		body        string
+	}
+
+	var parts []part
+
+	for {
+		p, err := r.NextPart()
+		if err != nil {
+			break
+		}
+
+		body, err := io.ReadAll(p)
+		require.NoError(t, err)
+
+		parts = append(parts, part{p.Header.Get("Content-Type"), string(body)})
+	}
+
+	require.Len(t, parts, 3, "expected two notifications and one keep-alive")
+
+	assert.Empty(t, parts[0].contentType, "a notification takes the carrier's default")
+	assert.Equal(t,
+		"Event-ID: a\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 5\r\n\r\nfirst",
+		parts[0].body,
+	)
+
+	assert.Empty(t, parts[1].contentType, "the keep-alive is a message too")
+	assert.Equal(t, "\r\n", parts[1].body)
+
+	assert.Equal(t,
+		"Event-ID: b\r\nEvent-Type: update\r\n"+
+			"Content-Type: text/plain; charset=utf-8\r\nContent-Length: 6\r\n\r\nsecond",
+		parts[2].body,
+	)
+}
+
+// encodedNotification reads back one encoded part as the notification it
+// carries, by the length the message declares rather than the delimiter,
+// which a payload may contain.
+func encodedNotification(t *testing.T, e *multipartDigestEncoder, part string) (textproto.MIMEHeader, string) {
+	t.Helper()
+
+	message, found := strings.CutPrefix(part, "\r\n\r\n")
+	require.True(t, found, "a notification part carries no header of its own")
+
+	r := bufio.NewReader(strings.NewReader(message))
+
+	header, data := readNotification(t, r)
+
+	rest, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "\r\n--"+e.boundary, string(rest),
+		"Content-Length disagrees with the delimiter closing the part")
+
+	return header, data
+}
+
+// readNotification parses a notification: the message's header fields, then
+// the data its Content-Length delimits.
+func readNotification(t *testing.T, r *bufio.Reader) (textproto.MIMEHeader, string) {
+	t.Helper()
+
+	m := textproto.NewReader(r)
+
+	header, err := m.ReadMIMEHeader()
+	require.NoError(t, err)
+
+	length, err := strconv.Atoi(header.Get("Content-Length"))
+	require.NoError(t, err)
+
+	data := make([]byte, length)
+	_, err = io.ReadFull(m.R, data)
+	require.NoError(t, err)
+
+	return header, string(data)
+}
+
+// newDigestEncoder builds an encoder through its constructor, as the response
+// side does, and hands back the concrete type whose boundary the assertions
+// read.
+func newDigestEncoder(t *testing.T) *multipartDigestEncoder {
+	t.Helper()
+
+	e, ok := newMultipartDigestEncoder().(*multipartDigestEncoder)
+	require.True(t, ok)
+
+	return e
+}

--- a/encoder_multipartdigest_test.go
+++ b/encoder_multipartdigest_test.go
@@ -40,16 +40,14 @@ func TestMultipartDigestEncoderBoundaryIsRandom(t *testing.T) {
 	assert.NotEqual(t, a.boundary, b.boundary)
 }
 
-// 16 hyphens and 16 random hex characters, the shape many browsers and HTTP
-// libraries write.
+// 60 random hex characters: RFC 2046 caps a boundary at 70, and delimiter
+// scanning is only safe when a payload cannot be crafted to contain it.
 func TestMultipartDigestEncoderBoundaryShape(t *testing.T) {
 	t.Parallel()
 
 	boundary := newDigestEncoder(t).boundary
 
-	assert.Len(t, boundary, 32)
-	assert.Equal(t, strings.Repeat("-", 16), boundary[:16])
-	assert.Regexp(t, "^[0-9a-f]{16}$", boundary[16:])
+	assert.Regexp(t, "^[0-9a-f]{60}$", boundary)
 }
 
 func TestMultipartDigestEncoderEncode(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ retract (
 
 require (
 	github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526
+	github.com/dunglas/httpsfv v1.1.1
 	github.com/dunglas/skipfilter v1.0.0
 	github.com/elnormous/contenttype v1.0.4
 	github.com/gofrs/uuid/v5 v5.4.0

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ retract (
 require (
 	github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526
 	github.com/dunglas/skipfilter v1.0.0
+	github.com/elnormous/contenttype v1.0.4
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526 h1:biCci7wlx
 github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526/go.mod h1:9qyjDljBPOWyWCGz7vo3Ek7cdnoG/DVk0Ucle7gWVS8=
 github.com/dunglas/skipfilter v1.0.0 h1:JG9SgGg4n6BlFwuTYzb9RIqjH7PfwszvWehanrYWPF4=
 github.com/dunglas/skipfilter v1.0.0/go.mod h1:ryhr8j7CAHSjzeN7wI6YEuwoArQ3OQmRqWWVCEAfb9w=
+github.com/elnormous/contenttype v1.0.4 h1:FjmVNkvQOGqSX70yvocph7keC8DtmJaLzTTq6ZOQCI8=
+github.com/elnormous/contenttype v1.0.4/go.mod h1:5KTOW8m1kdX1dLMiUJeN9szzR2xkngiv2K+RVZwWBbI=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526 h1:biCci7wlx/ChMqOkoUw6FPrhEZYRpulBZ+fO4Geo5Xs=
 github.com/dunglas/go-urlpattern v0.0.0-20260716093037-fb05c4998526/go.mod h1:9qyjDljBPOWyWCGz7vo3Ek7cdnoG/DVk0Ucle7gWVS8=
+github.com/dunglas/httpsfv v1.1.1 h1:HoSs101zIE9I23DlqlmljJ/OIi7ILwrH347pXhRZdxI=
+github.com/dunglas/httpsfv v1.1.1/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
 github.com/dunglas/skipfilter v1.0.0 h1:JG9SgGg4n6BlFwuTYzb9RIqjH7PfwszvWehanrYWPF4=
 github.com/dunglas/skipfilter v1.0.0/go.mod h1:ryhr8j7CAHSjzeN7wI6YEuwoArQ3OQmRqWWVCEAfb9w=
 github.com/elnormous/contenttype v1.0.4 h1:FjmVNkvQOGqSX70yvocph7keC8DtmJaLzTTq6ZOQCI8=

--- a/handler.go
+++ b/handler.go
@@ -107,10 +107,11 @@ func (h *Hub) corsHandler(router http.Handler) http.Handler {
 		AllowedHeaders:   []string{authorizationHeader, "cache-control", "last-event-id"},
 		// Exposed so cross-origin subscribers can read the subscription API's
 		// rel="mercure" Link header, the Mercure-Last-Event-Id field a
-		// subscription answers with, and the Accept-Query field naming what a
-		// QUERY body may be expressed in. A fetch-based subscriber cannot read
+		// subscription answers with, the Accept-Query field naming what a
+		// QUERY body may be expressed in, and the Incremental field asking for
+		// the response as it is produced. A fetch-based subscriber cannot read
 		// any of them unless they are listed here.
-		ExposedHeaders: []string{"Link", "Mercure-Last-Event-Id", "Accept-Query"},
+		ExposedHeaders: []string{"Link", "Mercure-Last-Event-Id", "Accept-Query", "Incremental"},
 		Debug:          h.debug,
 	}).Handler(router)
 }

--- a/handler.go
+++ b/handler.go
@@ -104,14 +104,15 @@ func (h *Hub) corsHandler(router http.Handler) http.Handler {
 		AllowedOrigins:   h.corsOrigins,
 		AllowCredentials: allowCredentials,
 		AllowedMethods:   []string{http.MethodGet, http.MethodHead, http.MethodPost, methodQuery},
-		AllowedHeaders:   []string{authorizationHeader, "cache-control", "last-event-id"},
+		AllowedHeaders:   []string{authorizationHeader, "cache-control", "last-event-id", "events"},
 		// Exposed so cross-origin subscribers can read the subscription API's
 		// rel="mercure" Link header, the Mercure-Last-Event-Id field a
 		// subscription answers with, the Accept-Query field naming what a
 		// QUERY body may be expressed in, and the Incremental field asking for
-		// the response as it is produced. A fetch-based subscriber cannot read
-		// any of them unless they are listed here.
-		ExposedHeaders: []string{"Link", "Mercure-Last-Event-Id", "Accept-Query", "Incremental"},
+		// the response as it is produced, and the Events field stating how long it
+		// will be served for. A fetch-based subscriber cannot read any of them
+		// unless they are listed here.
+		ExposedHeaders: []string{"Link", "Mercure-Last-Event-Id", "Accept-Query", "Incremental", "Events"},
 		Debug:          h.debug,
 	}).Handler(router)
 }

--- a/handler.go
+++ b/handler.go
@@ -106,10 +106,11 @@ func (h *Hub) corsHandler(router http.Handler) http.Handler {
 		AllowedMethods:   []string{http.MethodGet, http.MethodHead, http.MethodPost, methodQuery},
 		AllowedHeaders:   []string{authorizationHeader, "cache-control", "last-event-id"},
 		// Exposed so cross-origin subscribers can read the subscription API's
-		// rel="mercure" Link header, and the Mercure-Last-Event-Id field a
-		// subscription answers with. A fetch-based subscriber cannot read
-		// either unless they are listed here.
-		ExposedHeaders: []string{"Link", "Mercure-Last-Event-Id"},
+		// rel="mercure" Link header, the Mercure-Last-Event-Id field a
+		// subscription answers with, and the Accept-Query field naming what a
+		// QUERY body may be expressed in. A fetch-based subscriber cannot read
+		// any of them unless they are listed here.
+		ExposedHeaders: []string{"Link", "Mercure-Last-Event-Id", "Accept-Query"},
 		Debug:          h.debug,
 	}).Handler(router)
 }

--- a/handler.go
+++ b/handler.go
@@ -106,8 +106,10 @@ func (h *Hub) corsHandler(router http.Handler) http.Handler {
 		AllowedMethods:   []string{http.MethodGet, http.MethodHead, http.MethodPost, methodQuery},
 		AllowedHeaders:   []string{authorizationHeader, "cache-control", "last-event-id"},
 		// Exposed so cross-origin subscribers can read the subscription API's
-		// rel="mercure" Link header, which carries the last-event-id cursor.
-		ExposedHeaders: []string{"Link"},
+		// rel="mercure" Link header, and the Mercure-Last-Event-Id field a
+		// subscription answers with. A fetch-based subscriber cannot read
+		// either unless they are listed here.
+		ExposedHeaders: []string{"Link", "Mercure-Last-Event-Id"},
 		Debug:          h.debug,
 	}).Handler(router)
 }

--- a/hub.go
+++ b/hub.go
@@ -425,12 +425,15 @@ func WithResourceIdentifier(resourceIdentifier string) Option {
 //
 // If you change this, also update the Caddy module and the documentation.
 type opt struct {
-	transport                    Transport
-	topicMatcherStore            *TopicMatcherStore
-	anonymous                    bool
-	debug                        bool
-	subscriptions                bool
-	eventsQuery                  bool
+	transport         Transport
+	topicMatcherStore *TopicMatcherStore
+	anonymous         bool
+	debug             bool
+	subscriptions     bool
+	eventsQuery       bool
+	// acceptQuery is the Accept-Query field value, resolved once from the
+	// media types this hub reads a subscription in.
+	acceptQuery                  []string
 	debugger                     bool
 	playground                   bool
 	playgroundTokenFunc          func(resourceIdentifier string) (string, error)
@@ -556,6 +559,14 @@ func NewHub(ctx context.Context, options ...Option) (*Hub, error) {
 
 	if opt.logger == nil {
 		opt.logger = slog.New(mercureHandler{slog.Default().Handler()})
+	}
+
+	// A hub not serving Events Query reads a subscription only as form-encoded
+	// parameters, whatever else a parser file registers.
+	if opt.eventsQuery {
+		opt.acceptQuery = []string{strings.Join(subscriptionMediaTypes, ", ")}
+	} else {
+		opt.acceptQuery = []string{urlEncodedMediaType}
 	}
 
 	if opt.topicMatcherStore == nil {

--- a/hub.go
+++ b/hub.go
@@ -142,6 +142,20 @@ func WithSubscriptions() Option {
 	}
 }
 
+// WithEventsQuery serves subscriptions expressed as an Events Query
+// (draft-gupta-httpapi-events-query), a QUERY request whose body realizes the
+// subscription data model.
+//
+// EXPERIMENTAL: the draft is an individual Internet-Draft and this behavior is
+// not covered by the backward compatibility promise.
+func WithEventsQuery() Option {
+	return func(o *opt) error {
+		o.eventsQuery = true
+
+		return nil
+	}
+}
+
 // WithLogger sets the logger to use.
 func WithLogger(logger *slog.Logger) Option {
 	return func(o *opt) error {
@@ -416,6 +430,7 @@ type opt struct {
 	anonymous                    bool
 	debug                        bool
 	subscriptions                bool
+	eventsQuery                  bool
 	debugger                     bool
 	playground                   bool
 	playgroundTokenFunc          func(resourceIdentifier string) (string, error)

--- a/hub_test.go
+++ b/hub_test.go
@@ -692,3 +692,25 @@ func TestCORSExposesAcceptQuery(t *testing.T) {
 
 	assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "Accept-Query")
 }
+
+// Incremental asks for the response as it is produced rather than buffered,
+// which a user agent is as free to do as an intermediary.
+func TestCORSExposesIncremental(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithCORSOrigins([]string{"https://example.com"}))
+
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL, nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	w := httptest.NewRecorder()
+	hub.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "Incremental")
+}

--- a/hub_test.go
+++ b/hub_test.go
@@ -714,3 +714,49 @@ func TestCORSExposesIncremental(t *testing.T) {
 
 	assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "Incremental")
 }
+
+// A subscription answers with the period it will be served for. A
+// fetch-based subscriber cannot read the field unless CORS exposes it.
+func TestCORSExposesTheEventsDuration(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery(), WithCORSOrigins([]string{"https://example.com"}))
+
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL, nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	w := httptest.NewRecorder()
+	hub.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "Events")
+}
+
+// And a subscription may ask for a shorter one, which a browser can only send
+// if the preflight allows the field.
+func TestCORSAllowsTheEventsRequestField(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery(), WithCORSOrigins([]string{"https://example.com"}))
+
+	req := httptest.NewRequest(http.MethodOptions, defaultHubURL, nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	req.Header.Set("Access-Control-Request-Headers", "events")
+
+	w := httptest.NewRecorder()
+	hub.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Headers"), "events")
+}

--- a/hub_test.go
+++ b/hub_test.go
@@ -648,3 +648,25 @@ func createDummyNoneSignedJWT() string {
 
 	return tokenString
 }
+
+// A subscription answers with Mercure-Last-Event-Id, the cursor to resume
+// from. A fetch-based subscriber cannot read it unless CORS exposes it.
+func TestCORSExposesTheLastEventIDCursor(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithCORSOrigins([]string{"https://example.com"}))
+
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL, nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	w := httptest.NewRecorder()
+	hub.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "Mercure-Last-Event-Id")
+}

--- a/hub_test.go
+++ b/hub_test.go
@@ -670,3 +670,25 @@ func TestCORSExposesTheLastEventIDCursor(t *testing.T) {
 
 	assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "Mercure-Last-Event-Id")
 }
+
+// Accept-Query tells a subscriber what a QUERY body may be expressed in, which
+// is of no use to a fetch-based one unless CORS exposes it.
+func TestCORSExposesAcceptQuery(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithCORSOrigins([]string{"https://example.com"}))
+
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL, nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	w := httptest.NewRecorder()
+	hub.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "Accept-Query")
+}

--- a/parser.go
+++ b/parser.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"mime"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/dunglas/httpsfv"
 	"github.com/elnormous/contenttype"
 )
 
@@ -58,7 +61,7 @@ var subscriptionParsers = map[string]func(body []byte) (url.Values, error){
 //
 //nolint:gochecknoglobals
 var (
-	parsedCarriers = parseMediaTypes(carrierContentTypes)
+	parsedCarriers       = parseMediaTypes(carrierContentTypes)
 	parsedMercureCarrier = parseMediaTypes(mercureCarrierContentType)
 )
 
@@ -77,6 +80,11 @@ type subscribeRequest struct {
 	// The framing is built from it on the response side, a per-connection
 	// framing belonging there rather than to a request.
 	contentType string
+
+	// duration is the bound the client asked the hub to apply. Zero is no
+	// bound: the smallest duration a client can express is a millisecond,
+	// Structured Fields Decimals carrying three fractional digits.
+	duration time.Duration
 }
 
 // parseError is a subscription request the hub will not serve, carrying the
@@ -135,11 +143,14 @@ func (h *Hub) parseSubscribeRequest(ctx context.Context, r *http.Request) (*subs
 			lastEventID, lastEventIDSet = id, lastEventIDSet || exists
 		}
 
+		duration := parseEventsDuration(r.Header.Values("Events"))
+
 		return &subscribeRequest{
 			values:         values,
 			lastEventID:    lastEventID,
 			lastEventIDSet: lastEventIDSet,
 			contentType:    contentType,
+			duration:       duration,
 		}, nil
 	}
 
@@ -310,4 +321,77 @@ func getValueAndExistence(source []string) (string, bool) {
 	}
 
 	return source[0], true
+}
+
+// parseEventsDuration reads from the Events request field the upper bound a
+// client asks the hub to apply to the response. The property is an Integer
+// or Decimal number of seconds, of which only non-negative values are valid.
+//
+// A zero duration means the client supplied no bound the hub can apply,
+// which is the case when the property is
+//
+//   - absent, or 0, which the specification defines as no preference;
+//   - malformed, or not a number, since a preference the hub may overrule
+//     anyway should not fail a subscription;
+//   - larger than a time.Duration holds, roughly 292 years, which no
+//     response could ever reach.
+//
+// The hub is then left to its own deadline, which may itself be absent. A
+// bound and a zero cannot be confused: the smallest a client can express is
+// a millisecond, Structured Fields Decimals carrying three fractional
+// digits.
+func parseEventsDuration(values []string) time.Duration {
+	if len(values) == 0 {
+		return 0
+	}
+
+	dict, err := httpsfv.UnmarshalDictionary(values)
+	if err != nil {
+		return 0
+	}
+
+	member, found := dict.Get("duration")
+	if !found {
+		return 0
+	}
+
+	// An Inner List is not a number; the property is defined as an Item.
+	item, isItem := member.(httpsfv.Item)
+	if !isItem {
+		return 0
+	}
+
+	var seconds float64
+
+	switch v := item.Value.(type) {
+	case int64:
+		seconds = float64(v)
+	case float64:
+		seconds = v
+	default:
+		return 0
+	}
+
+	// Zero is "no preference", which is the same outcome as an absent
+	// property, and negatives are invalid.
+	if seconds <= 0 {
+		return 0
+	}
+
+	// A Structured Field Integer reaches 999999999999999, some five orders
+	// of magnitude beyond the ~292 years a time.Duration holds, so a large
+	// but perfectly legal value would wrap to a negative duration and pull
+	// the deadline into the past, closing the connection the instant it
+	// opened.
+	//
+	// No response could run that long, so there is no bound here for the hub
+	// to apply. Against a hub with its own deadline this changes nothing —
+	// a request may only shorten, and this shortens nothing. Against a hub
+	// with no deadline the connection stays open indefinitely, which is what
+	// was asked for.
+	if seconds >= float64(math.MaxInt64)/float64(time.Second) {
+		return 0
+	}
+
+	return time.Duration(seconds * float64(time.Second))
 }

--- a/parser.go
+++ b/parser.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"net/url"
 )
@@ -17,6 +18,10 @@ const (
 	deprecatedLastEventIDNotice  = "Deprecated: the 'Last-Event-ID' query parameter is deprecated since the version 8 of the protocol, use 'last_event_id' instead."
 	unsupportedLastEventIDNotice = `Unsupported: the "Last-Event-ID" query parameter is not supported anymore, use "last_event_id" instead or enable backward compatibility with version 7 of the protocol.`
 )
+
+// errUnreadableSubscription rejects a subscription in a media type the hub
+// cannot read.
+var errUnreadableSubscription = errors.New("unsupported subscription media type")
 
 // subscribeRequest describes the resolved values that the hub needs to process
 // the subscription request.
@@ -51,6 +56,22 @@ func (h *Hub) parseSubscribeRequest(ctx context.Context, r *http.Request) (*subs
 		body, readErr := readSubscribeBody(r)
 		if readErr != nil {
 			return nil, readErr
+		}
+
+		// A request naming no media type is incorrect by definition, and one
+		// naming a media type the hub cannot read as a subscription is
+		// unsupported (RFC 10008, Section 2.3). Neither is read as a form:
+		// a server does not infer a media type from the content it carries.
+		mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, &parseError{status: http.StatusBadRequest, cause: err}
+		}
+
+		if mediaType != urlEncodedMediaType {
+			return nil, &parseError{
+				status: http.StatusUnsupportedMediaType,
+				cause:  fmt.Errorf("%w: %q", errUnreadableSubscription, mediaType),
+			}
 		}
 
 		bodyValues, err := parseURLEncoded(body)

--- a/parser.go
+++ b/parser.go
@@ -9,6 +9,9 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"strings"
+
+	"github.com/elnormous/contenttype"
 )
 
 // Notices about the "Last-Event-ID" query parameter, deprecated since version
@@ -23,6 +26,10 @@ var (
 	// errUnreadableSubscription rejects a subscription in a media type the hub
 	// cannot read.
 	errUnreadableSubscription = errors.New("unsupported subscription media type")
+
+	// errUnacceptableSubscription rejects a subscription refusing every media
+	// type the hub can stream notifications in, leaving nothing to send it.
+	errUnacceptableSubscription = errors.New("unacceptable response media type")
 
 	// errNoEvents rejects a subscription expressing no interest in a stream of
 	// notifications. That request is the single notification of the
@@ -46,6 +53,15 @@ var subscriptionParsers = map[string]func(body []byte) (url.Values, error){
 	urlEncodedMediaType: parseURLEncoded,
 }
 
+// The media types a stream of notifications is negotiated from, parsed once
+// from the lists the encoders are registered under.
+//
+//nolint:gochecknoglobals
+var (
+	parsedCarriers = parseMediaTypes(carrierContentTypes)
+	parsedMercureCarrier = parseMediaTypes(mercureCarrierContentType)
+)
+
 // subscribeRequest describes the resolved values that the hub needs to process
 // the subscription request.
 type subscribeRequest struct {
@@ -56,6 +72,11 @@ type subscribeRequest struct {
 	lastEventID string
 	// lastEventIDSet records that a cursor was supplied even when empty.
 	lastEventIDSet bool
+
+	// contentType is the media type the notifications stream is served as.
+	// The framing is built from it on the response side, a per-connection
+	// framing belonging there rather than to a request.
+	contentType string
 }
 
 // parseError is a subscription request the hub will not serve, carrying the
@@ -101,6 +122,12 @@ func (h *Hub) parseSubscribeRequest(ctx context.Context, r *http.Request) (*subs
 			return nil, &parseError{status: http.StatusUnprocessableEntity, cause: errNoEvents}
 		}
 
+		// Content Negotiation for the response
+		contentType := negotiate(r, parsedCarriers)
+		if contentType == "" {
+			return nil, &parseError{status: http.StatusNotAcceptable, cause: errUnacceptableSubscription}
+		}
+
 		lastEventID, lastEventIDSet := getValueAndExistence(r.Header.Values("Last-Event-ID"))
 
 		if lastEventID == "" {
@@ -112,6 +139,7 @@ func (h *Hub) parseSubscribeRequest(ctx context.Context, r *http.Request) (*subs
 			values:         values,
 			lastEventID:    lastEventID,
 			lastEventIDSet: lastEventIDSet,
+			contentType:    contentType,
 		}, nil
 	}
 
@@ -155,6 +183,11 @@ func (h *Hub) parseSubscribeRequest(ctx context.Context, r *http.Request) (*subs
 		}
 	}
 
+	// A client refusing text/event-stream leaves nothing for the hub to send.
+	if negotiate(r, parsedMercureCarrier) == "" {
+		return nil, &parseError{status: http.StatusNotAcceptable, cause: errUnacceptableSubscription}
+	}
+
 	// The following block extracts the Last-Event-ID from possible sources that
 	// have the following precedence: the header field, the parameter, then the
 	// version 7 spelling of the parameter. It also reports whether Last-Event-ID
@@ -185,7 +218,48 @@ func (h *Hub) parseSubscribeRequest(ctx context.Context, r *http.Request) (*subs
 		values:         values,
 		lastEventID:    lastEventID,
 		lastEventIDSet: lastEventIDSet,
+		contentType:    eventStreamContentType,
 	}, nil
+}
+
+// negotiate picks the media type a subscription is answered in.
+//
+// A subscription naming none of them is not refusing them, so it gets the
+// first; one naming several gets whichever it weighted highest. Only a
+// subscription that refuses every one of them is answered with an error,
+// there being nothing left to send it.
+func negotiate(r *http.Request, available []contenttype.MediaType) string {
+	// Accept is a list, so field lines repeating it are one list split in two
+	// (RFC 9110, Section 5.3). Only the first is read, so a subscription that
+	// split its list is negotiated from a request carrying them joined.
+	request := r
+	if accept := r.Header.Values("Accept"); len(accept) > 1 {
+		request = &http.Request{Header: http.Header{"Accept": {strings.Join(accept, ", ")}}}
+	}
+
+	best, _, err := contenttype.GetAcceptableMediaType(request, available)
+
+	switch {
+	case errors.Is(err, contenttype.ErrNoAcceptableTypeFound):
+		return ""
+	case err != nil:
+		// An Accept the hub cannot read states no preference.
+		return available[0].MIME()
+	default:
+		return best.MIME()
+	}
+}
+
+// parseMediaTypes is the form negotiation compares against, parsed from the
+// media types a list offers. The lists themselves stay strings: that is what
+// a reader adds a media type to, and what the encoders are registered under.
+func parseMediaTypes(available []string) []contenttype.MediaType {
+	parsed := make([]contenttype.MediaType, 0, len(available))
+	for _, a := range available {
+		parsed = append(parsed, contenttype.NewMediaType(a))
+	}
+
+	return parsed
 }
 
 // readSubscribeBody reads the request body. Its size is bounded by

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,127 @@
+package mercure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+)
+
+// Notices about the "Last-Event-ID" query parameter, deprecated since version
+// 8 of the protocol. Whether the hub still honours it decides which of the two
+// gets logged.
+const (
+	deprecatedLastEventIDNotice  = "Deprecated: the 'Last-Event-ID' query parameter is deprecated since the version 8 of the protocol, use 'last_event_id' instead."
+	unsupportedLastEventIDNotice = `Unsupported: the "Last-Event-ID" query parameter is not supported anymore, use "last_event_id" instead or enable backward compatibility with version 7 of the protocol.`
+)
+
+// subscribeRequest describes the resolved values that the hub needs to process
+// the subscription request.
+type subscribeRequest struct {
+	// values holds the topic matcher parameters in the shape parseMatchers
+	// consumes.
+	values url.Values
+
+	lastEventID string
+	// lastEventIDSet records that a cursor was supplied even when empty.
+	lastEventIDSet bool
+}
+
+// parseError is a subscription request the hub will not serve, carrying the
+// status it is answered with.
+type parseError struct {
+	status int
+	// cause is recorded on the request span. It is not disclosed to the
+	// client, which is answered with the status text.
+	cause error
+}
+
+// parseSubscribeRequest returns the subscription parameters that a hub needs
+// to serve notifications, or refuses with the appropriate HTTP status.
+func (h *Hub) parseSubscribeRequest(ctx context.Context, r *http.Request) (*subscribeRequest, *parseError) {
+	// For GET and HEAD the subscription parameters come from the URL query.
+	values := r.URL.Query()
+
+	// For QUERY the application/x-www-form-urlencoded request body is parsed and
+	// merged on top, so a subscriber can pass topics either way.
+	if r.Method == methodQuery {
+		body, readErr := readSubscribeBody(r)
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		bodyValues, err := parseURLEncoded(body)
+		if err != nil {
+			return nil, &parseError{
+				status: http.StatusBadRequest,
+				cause:  fmt.Errorf("invalid %s request body: %w", urlEncodedMediaType, err),
+			}
+		}
+
+		for k, vs := range bodyValues {
+			values[k] = append(values[k], vs...)
+		}
+	}
+
+	// The following block extracts the Last-Event-ID from possible sources that
+	// have the following precedence: the header field, the parameter, then the
+	// version 7 spelling of the parameter. It also reports whether Last-Event-ID
+	// was present at all, even with an empty value: the protocol requires
+	// answering with a Mercure-Last-Event-ID response field whenever one was.
+	lastEventID, lastEventIDSet := getValueAndExistence(r.Header.Values("Last-Event-ID"))
+
+	if lastEventID == "" {
+		id, exists := getValueAndExistence(values["last_event_id"])
+		lastEventID, lastEventIDSet = id, lastEventIDSet || exists
+	}
+
+	if lastEventID == "" {
+		id, exists := getValueAndExistence(values["Last-Event-ID"])
+		notice := unsupportedLastEventIDNotice
+
+		if h.isBackwardCompatiblyEnabledWith(7) {
+			notice = deprecatedLastEventIDNotice
+			lastEventID, lastEventIDSet = id, lastEventIDSet || exists
+		}
+
+		if exists && h.logger.Enabled(ctx, slog.LevelInfo) {
+			h.logger.LogAttrs(ctx, slog.LevelInfo, notice)
+		}
+	}
+
+	return &subscribeRequest{
+		values:         values,
+		lastEventID:    lastEventID,
+		lastEventIDSet: lastEventIDSet,
+	}, nil
+}
+
+// readSubscribeBody reads the request body. Its size is bounded by
+// limitRequestBody, as for the publish endpoint.
+func readSubscribeBody(r *http.Request) ([]byte, *parseError) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		status := http.StatusBadRequest
+
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			status = http.StatusRequestEntityTooLarge
+		}
+
+		return nil, &parseError{status: status, cause: fmt.Errorf("reading QUERY request body: %w", err)}
+	}
+
+	return body, nil
+}
+
+// getValueAndExistence returns the source string and if it was specified at all.
+func getValueAndExistence(source []string) (string, bool) {
+	if len(source) == 0 {
+		return "", false
+	}
+
+	return source[0], true
+}

--- a/parser.go
+++ b/parser.go
@@ -46,7 +46,7 @@ var (
 // them are offered, and in what order.
 //
 //nolint:gochecknoglobals
-var subscriptionMediaTypes = []string{urlEncodedMediaType}
+var subscriptionMediaTypes = []string{eventsJSONMediaType, urlEncodedMediaType}
 
 // subscriptionParsers is the reader each media type is read by, one per parser
 // file.
@@ -54,6 +54,7 @@ var subscriptionMediaTypes = []string{urlEncodedMediaType}
 //nolint:gochecknoglobals
 var subscriptionParsers = map[string]func(body []byte) (url.Values, error){
 	urlEncodedMediaType: parseURLEncoded,
+	eventsJSONMediaType: parseEventsJSON,
 }
 
 // The media types a stream of notifications is negotiated from, parsed once

--- a/parser.go
+++ b/parser.go
@@ -19,9 +19,32 @@ const (
 	unsupportedLastEventIDNotice = `Unsupported: the "Last-Event-ID" query parameter is not supported anymore, use "last_event_id" instead or enable backward compatibility with version 7 of the protocol.`
 )
 
-// errUnreadableSubscription rejects a subscription in a media type the hub
-// cannot read.
-var errUnreadableSubscription = errors.New("unsupported subscription media type")
+var (
+	// errUnreadableSubscription rejects a subscription in a media type the hub
+	// cannot read.
+	errUnreadableSubscription = errors.New("unsupported subscription media type")
+
+	// errNoEvents rejects a subscription expressing no interest in a stream of
+	// notifications. That request is the single notification of the
+	// specification's section 8, which this hub does not serve.
+	errNoEvents = errors.New(`missing "events": a stream of notifications is the only mode this hub serves`)
+)
+
+// subscriptionMediaTypes are the media types a subscription can be expressed
+// in, most preferred first. A parser file registers its reader in
+// subscriptionParsers under the same media type; this list decides which of
+// them are offered, and in what order.
+//
+//nolint:gochecknoglobals
+var subscriptionMediaTypes = []string{urlEncodedMediaType}
+
+// subscriptionParsers is the reader each media type is read by, one per parser
+// file.
+//
+//nolint:gochecknoglobals
+var subscriptionParsers = map[string]func(body []byte) (url.Values, error){
+	urlEncodedMediaType: parseURLEncoded,
+}
 
 // subscribeRequest describes the resolved values that the hub needs to process
 // the subscription request.
@@ -47,6 +70,51 @@ type parseError struct {
 // parseSubscribeRequest returns the subscription parameters that a hub needs
 // to serve notifications, or refuses with the appropriate HTTP status.
 func (h *Hub) parseSubscribeRequest(ctx context.Context, r *http.Request) (*subscribeRequest, *parseError) {
+
+	// An Events Query carries the subscription in the request body, in one of
+	// the media types realizing the subscription data model. Nothing comes
+	// from the URL: the request carries a subscription rather than naming one.
+	if h.eventsQuery && r.Method == methodQuery {
+		body, readErr := readSubscribeBody(r)
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		// A request naming no media type, or naming one that is not a media
+		// type at all, is incorrect by definition and answered 400; one
+		// naming a media type no parser reads is unsupported and answered
+		// 415, below (RFC 10008, Section 2.3).
+		mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, &parseError{status: http.StatusBadRequest, cause: err}
+		}
+
+		values, parseErr := parseSubscriptionBody(mediaType, body)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+
+		// The hub reads and understands the subscription, but serves only a
+		// stream of notifications, so one asking for no events is
+		// unprocessable.
+		if _, asked := values["events"]; !asked {
+			return nil, &parseError{status: http.StatusUnprocessableEntity, cause: errNoEvents}
+		}
+
+		lastEventID, lastEventIDSet := getValueAndExistence(r.Header.Values("Last-Event-ID"))
+
+		if lastEventID == "" {
+			id, exists := getValueAndExistence(values["last_event_id"])
+			lastEventID, lastEventIDSet = id, lastEventIDSet || exists
+		}
+
+		return &subscribeRequest{
+			values:         values,
+			lastEventID:    lastEventID,
+			lastEventIDSet: lastEventIDSet,
+		}, nil
+	}
+
 	// For GET and HEAD the subscription parameters come from the URL query.
 	values := r.URL.Query()
 
@@ -136,6 +204,29 @@ func readSubscribeBody(r *http.Request) ([]byte, *parseError) {
 	}
 
 	return body, nil
+}
+
+// parseSubscriptionBody reads a body in the media type it declares, or refuses a
+// media type no parser reads (RFC 10008, Section 2.3).
+func parseSubscriptionBody(mediaType string, body []byte) (url.Values, *parseError) {
+	for _, offered := range subscriptionMediaTypes {
+		if offered == mediaType {
+			values, err := subscriptionParsers[mediaType](body)
+			if err != nil {
+				return nil, &parseError{
+					status: http.StatusBadRequest,
+					cause:  fmt.Errorf("invalid %s request body: %w", mediaType, err),
+				}
+			}
+
+			return values, nil
+		}
+	}
+
+	return nil, &parseError{
+		status: http.StatusUnsupportedMediaType,
+		cause:  fmt.Errorf("%w: %q", errUnreadableSubscription, mediaType),
+	}
 }
 
 // getValueAndExistence returns the source string and if it was specified at all.

--- a/parser_eventsjson.go
+++ b/parser_eventsjson.go
@@ -1,0 +1,137 @@
+package mercure
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// Media Type for Events Query in JSON
+const eventsJSONMediaType = "application/events+json"
+
+// parseEventsJSON reads a JSON Events Query into the values a form-encoded
+// subscription would have carried, so that one implementation validates both.
+// A property that may be absent is decoded into a pointer and becomes a key
+// only when it was supplied, which is the presence a form body expresses by
+// carrying the parameter at all.
+//
+// The "state" property is ignored: Mercure hubs serve notifications only and
+// a hub has no representation to deliver alongside them.
+func parseEventsJSON(body []byte) (url.Values, error) {
+	var subscription eventsQuerySubscription
+
+	// The decoder's own errors name the offending property and its offset, so
+	// they are returned as they are — parseSubscriptionBody names the media
+	// type once, for every parser.
+	if err := json.Unmarshal(body, &subscription); err != nil {
+		return nil, err
+	}
+
+	values := subscription.URL.values()
+
+	if subscription.Events != nil {
+		values["events"] = []string{""}
+	}
+
+	// An empty cursor is still a cursor: the protocol answers with a
+	// Mercure-Last-Event-Id field whenever one was supplied at all, which is
+	// why presence rather than value decides.
+	if subscription.LastEventID != nil {
+		values["last_event_id"] = []string{*subscription.LastEventID}
+	}
+
+	return values, nil
+}
+
+// eventsQuerySubscription is the JSON realization of the subscription data
+// model. A pointer distinguishes a property that was absent or null from one
+// that was supplied, which is what the "events" property turns on.
+//
+// The "state" property has no field: it asks for a representation, of which a
+// hub has none, and properties without a field are ignored.
+type eventsQuerySubscription struct {
+	URL         *eventsQueryURL    `json:"url"`
+	Events      *eventsQueryEvents `json:"events"`
+	LastEventID *string            `json:"last_event_id"`
+}
+
+// eventsQueryEvents describes the notifications asked for. Its presence
+// is the interest in a stream; its sub-properties will describe the form
+// they take.
+type eventsQueryEvents struct{}
+
+// eventsQueryURL is the "url" property of Mercure: an object naming a topic
+// matcher type per key, or an array of topics as shorthand for the default
+// matcher type, so that
+//
+//	"url": ["https://example.com/books/1"]
+//
+// means the same as
+//
+//	"url": {"match": ["https://example.com/books/1"]}
+//
+// Matcher parameter names are kept as they arrive, including ones outside
+// the matcher namespace. Which names are meaningful, which are reserved and
+// which are rejected is decided once, where the matchers are parsed, so the
+// JSON and the query component cannot drift apart.
+type eventsQueryURL map[string]eventsQueryTopics
+
+func (u *eventsQueryURL) UnmarshalJSON(data []byte) error {
+	if data[0] == '[' {
+		var topics []string
+		if err := json.Unmarshal(data, &topics); err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		*u = eventsQueryURL{paramMatch: topics}
+
+		return nil
+	}
+
+	var named map[string]eventsQueryTopics
+	if err := json.Unmarshal(data, &named); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	*u = named
+
+	return nil
+}
+
+// values converts the property into the name/value pairs the subscription
+// URL's query component would have carried. A nil property carried none.
+func (u *eventsQueryURL) values() url.Values {
+	if u == nil {
+		return url.Values{}
+	}
+
+	values := make(url.Values, len(*u))
+	for name, topics := range *u {
+		values[name] = topics
+	}
+
+	return values
+}
+
+// eventsQueryTopics is one topic or an array of them.
+type eventsQueryTopics []string
+
+func (t *eventsQueryTopics) UnmarshalJSON(data []byte) error {
+	// A null value reaches an Unmarshaler too, and would otherwise decode
+	// down the scalar branch as a single empty topic.
+	if string(data) == "null" {
+		return nil
+	}
+
+	if data[0] == '[' {
+		return json.Unmarshal(data, (*[]string)(t)) //nolint:wrapcheck
+	}
+
+	var one string
+	if err := json.Unmarshal(data, &one); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	*t = eventsQueryTopics{one}
+
+	return nil
+}

--- a/parser_eventsjson_test.go
+++ b/parser_eventsjson_test.go
@@ -1,0 +1,196 @@
+package mercure
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The "url" member reaches parseMatchers in the shape the query component
+// would have produced, so that one matcher implementation serves both forms.
+func TestParseEventsJSONURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want url.Values
+	}{
+		{
+			"an array is shorthand for the default matcher",
+			`{"url": ["https://example.com/books/1"], "events": {}}`,
+			url.Values{"match": {"https://example.com/books/1"}, "events": {""}},
+		},
+		{
+			"an object names the matcher parameter",
+			`{"url": {"match_urlpattern": ["https://example.com/books/:id"]}, "events": {}}`,
+			url.Values{"match_urlpattern": {"https://example.com/books/:id"}, "events": {""}},
+		},
+		{
+			"a scalar topic is one topic",
+			`{"url": {"match": "https://example.com/books/1"}, "events": {}}`,
+			url.Values{"match": {"https://example.com/books/1"}, "events": {""}},
+		},
+		{
+			"several matchers together",
+			`{"url": {"match": ["a"], "match_urlpattern": ["b", "c"]}, "events": {}}`,
+			url.Values{"match": {"a"}, "match_urlpattern": {"b", "c"}, "events": {""}},
+		},
+		{
+			"a null topic list carries no topic",
+			`{"url": {"match": null}, "events": {}}`,
+			url.Values{"match": nil, "events": {""}},
+		},
+		{
+			"an absent url member carries none",
+			`{"events": {}}`,
+			url.Values{"events": {""}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			values, err := parseEventsJSON([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, values)
+		})
+	}
+}
+
+// Member names arrive unchanged: parseMatchers owns which are meaningful, so
+// the two request forms cannot drift apart.
+func TestParseEventsJSONPassesNamesThrough(t *testing.T) {
+	t.Parallel()
+
+	values, err := parseEventsJSON([]byte(`{"url": {"nonsense": ["a"]}, "events": {}}`))
+	require.NoError(t, err)
+	assert.Equal(t, url.Values{"nonsense": {"a"}, "events": {""}}, values)
+}
+
+// The "state" member asks for a representation, which a hub has none of.
+func TestParseEventsJSONIgnoresState(t *testing.T) {
+	t.Parallel()
+
+	values, err := parseEventsJSON([]byte(`{"state": {"accept": "text/html"}, "url": ["a"], "events": {}}`))
+	require.NoError(t, err)
+	assert.Equal(t, url.Values{"match": {"a"}, "events": {""}}, values)
+}
+
+func TestParseEventsJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"not JSON at all", `nonsense`},
+		{"an array, not an object", `["https://example.com/books/1"]`},
+		{"url is a number", `{"url": 42, "events": {}}`},
+		{"a topic is a number", `{"url": {"match": 42}, "events": {}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseEventsJSON([]byte(tc.body))
+			require.Error(t, err)
+		})
+	}
+}
+
+// A request expresses its interest in a stream of notifications with the
+// "events" member; whether it is there is all the hub reads from it.
+func TestParseEventsJSONEventsMember(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"an events member asks for notifications", `{"url": ["a"], "events": {}}`, []string{""}},
+		{"no events member", `{"url": ["a"]}`, nil},
+		{"a null events member", `{"url": ["a"], "events": null}`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			values, err := parseEventsJSON([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, values["events"])
+		})
+	}
+}
+
+// The cursor to resume from travels in "last_event_id", as it does in a query
+// component. An empty cursor is still a cursor: the protocol answers with
+// Mercure-Last-Event-Id whenever a subscription supplied one at all.
+func TestParseEventsJSONLastEventID(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"a cursor", `{"url": ["a"], "events": {}, "last_event_id": "b"}`, []string{"b"}},
+		{"an empty cursor", `{"url": ["a"], "events": {}, "last_event_id": ""}`, []string{""}},
+		{"no cursor", `{"url": ["a"], "events": {}}`, nil},
+		{"a null cursor", `{"url": ["a"], "events": {}, "last_event_id": null}`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			values, err := parseEventsJSON([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, values["last_event_id"])
+		})
+	}
+}
+
+// A request the hub reads but cannot act on is unprocessable: this one asks
+// for no events, the single notification of the specification's section 8.
+func TestEventsQuerySubscribeJSONWithoutEvents(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL,
+		strings.NewReader(`{"url": ["https://example.com/books/1"]}`))
+	req.Header.Set("Content-Type", eventsJSONMediaType)
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}
+
+// A hub not serving Events Query reads none of its requests: the media type
+// is then one like any other the hub cannot parse, whatever parsers are
+// registered.
+func TestQuerySubscribeEventsJSONRejectedWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL,
+		strings.NewReader(`{"url": ["https://example.com/books/1"], "events": {}}`))
+	req.Header.Set("Content-Type", eventsJSONMediaType)
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -5,8 +5,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A subscription refusing every media type the hub answers with leaves
@@ -291,4 +293,125 @@ func TestEventsQuerySubscribeWithoutEvents(t *testing.T) {
 	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
 
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}
+
+func TestParseEventsDuration(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		values []string
+		want   time.Duration
+	}{
+		{"integer", []string{"duration=30"}, 30 * time.Second},
+		{"decimal", []string{"duration=1.5"}, 1500 * time.Millisecond},
+		{"among other keys", []string{"foo=1, duration=30, bar=?1"}, 30 * time.Second},
+		{"split over several field lines", []string{"foo=1", "duration=30"}, 30 * time.Second},
+		{"with parameters", []string{"duration=30;precise"}, 30 * time.Second},
+
+		// Beyond what a time.Duration holds — a shade over 9223372036
+		// seconds — there is no bound the hub can apply, and never a
+		// negative duration.
+		{"just past time.Duration", []string{"duration=9223372037"}, 0},
+		{"the largest Integer the field can carry", []string{"duration=999999999999999"}, 0},
+
+		// "no preference" and invalid values both degrade to no preference.
+		{"zero is no preference", []string{"duration=0"}, 0},
+		{"negative is invalid", []string{"duration=-5"}, 0},
+		{"absent", []string{"foo=1"}, 0},
+		{"no field at all", nil, 0},
+		{"empty field", []string{""}, 0},
+
+		// A malformed field must not fail the subscription.
+		{"unparsable", []string{"duration=="}, 0},
+		{"not a number", []string{`duration="600"`}, 0},
+		{"token not a number", []string{"duration=abc"}, 0},
+		{"inner list", []string{"duration=(1 2)"}, 0},
+
+		// Decimals carry three fractional digits, so a millisecond is the
+		// smallest bound a client can express; a fourth digit is not a
+		// Structured Field at all.
+		{"a millisecond", []string{"duration=0.001"}, time.Millisecond},
+		{"finer than a millisecond", []string{"duration=0.0001"}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, parseEventsDuration(tc.values))
+		})
+	}
+}
+
+// The Events request field bounds the response an Events Query asked for.
+func TestEventsQuerySubscribeReadsEventsDuration(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	r := eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events=")
+	r.Header.Set("Events", "duration=30")
+
+	req, parseErr := hub.parseSubscribeRequest(t.Context(), r)
+	require.Nil(t, parseErr)
+	assert.Equal(t, 30*time.Second, req.duration)
+}
+
+// No field is no bound.
+func TestEventsQuerySubscribeWithoutEventsDuration(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	req, parseErr := hub.parseSubscribeRequest(t.Context(),
+		eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events="))
+	require.Nil(t, parseErr)
+	assert.Zero(t, req.duration)
+}
+
+// An ordinary subscription is not an Events Query, so the field does not
+// bound it even on a hub serving that protocol.
+func TestSubscribeIgnoresEventsDuration(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	r := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match=https://example.com/books/1", nil)
+	r.Header.Set("Events", "duration=30")
+
+	req, parseErr := hub.parseSubscribeRequest(t.Context(), r)
+	require.Nil(t, parseErr)
+	assert.Zero(t, req.duration)
+}
+
+// A hub not serving Events Query reads none of its fields: a subscriber
+// sending one keeps the connection it would have had.
+func TestQuerySubscribeIgnoresEventsDurationWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	r := httptest.NewRequest(methodQuery, defaultHubURL,
+		strings.NewReader("match=https://example.com/books/1"))
+	r.Header.Set("Content-Type", urlEncodedMediaType)
+	r.Header.Set("Events", "duration=30")
+
+	req, parseErr := hub.parseSubscribeRequest(t.Context(), r)
+	require.Nil(t, parseErr)
+	assert.Zero(t, req.duration)
+}
+
+// Events is a Structured Fields Dictionary, so field lines repeating it are
+// one dictionary split in two (RFC 9110, Section 5.3).
+func TestEventsQuerySubscribeReadsEventsDurationSplitOverFieldLines(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	r := eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events=")
+	r.Header.Add("Events", "foo=1")
+	r.Header.Add("Events", "duration=30")
+
+	req, parseErr := hub.parseSubscribeRequest(t.Context(), r)
+	require.Nil(t, parseErr)
+	assert.Equal(t, 30*time.Second, req.duration)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -31,3 +31,44 @@ func TestQuerySubscribeMalformedBodyRejectedWith400(t *testing.T) {
 	// refused before any matcher is looked for.
 	assert.Equal(t, http.StatusText(http.StatusBadRequest)+"\n", w.Body.String())
 }
+
+// A QUERY naming a media type the hub cannot read as a subscription is
+// unsupported: its content is not read as a form (RFC 10008, Section 2.3).
+func TestQuerySubscribeUnsupportedMediaTypeRejectedWith415(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL,
+		strings.NewReader(`{"url": ["https://example.com/books/1"]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
+}
+
+// A QUERY naming no media type at all is incorrect by definition, so it is a
+// bad request rather than an unsupported one (RFC 10008, Section 2.3).
+func TestQuerySubscribeWithoutMediaTypeRejectedWith400(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL,
+		strings.NewReader("match=https://example.com/books/1"))
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -9,6 +9,146 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// A subscription refusing every media type the hub answers with leaves
+// nothing to send it.
+func TestEventsQuerySubscribeRefusedResponseMediaType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	req := eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events=")
+	req.Header.Set("Accept", eventStreamContentType+";q=0")
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusNotAcceptable, resp.StatusCode)
+}
+
+// A subscription that named no media type it will read is not refusing any,
+// and one that named several is served whichever it weighted highest. Only a
+// subscription refusing all of them leaves nothing to send.
+func TestNegotiate(t *testing.T) {
+	t.Parallel()
+
+	const ndjson = "application/x-ndjson"
+
+	offered := parseMediaTypes([]string{eventStreamContentType, ndjson})
+
+	for name, tc := range map[string]struct {
+		accept []string
+		want   string
+	}{
+		"absent":     {nil, eventStreamContentType},
+		"wildcard":   {[]string{"*/*"}, eventStreamContentType},
+		"named":      {[]string{ndjson}, ndjson},
+		"weighted":   {[]string{eventStreamContentType + ";q=0.3, " + ndjson + ";q=0.8"}, ndjson},
+		"split":      {[]string{eventStreamContentType + ";q=0.3", ndjson + ";q=0.8"}, ndjson},
+		"unnamed":    {[]string{"application/json"}, ""},
+		"refused":    {[]string{eventStreamContentType + ";q=0", ndjson + ";q=0"}, ""},
+		"unreadable": {[]string{"text/"}, eventStreamContentType},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, defaultHubURL, nil)
+			for _, accept := range tc.accept {
+				req.Header.Add("Accept", accept)
+			}
+
+			assert.Equal(t, tc.want, negotiate(req, offered))
+		})
+	}
+}
+
+// A subscription refusing the only media type an ordinary subscription is
+// served in leaves nothing to send it, whether it asked with GET or QUERY.
+func TestSubscribeRefusedResponseMediaType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	req := httptest.NewRequest(http.MethodGet,
+		defaultHubURL+"?match=https://example.com/books/1", nil)
+	req.Header.Set("Accept", eventStreamContentType+";q=0")
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusNotAcceptable, resp.StatusCode)
+}
+
+func TestQuerySubscribeRefusedResponseMediaType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL,
+		strings.NewReader("match=https://example.com/books/1"))
+	req.Header.Set("Content-Type", urlEncodedMediaType)
+	req.Header.Set("Accept", eventStreamContentType+";q=0")
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusNotAcceptable, resp.StatusCode)
+}
+
+// What the hub would send is settled only once it knows the request can be
+// served at all, so a body it cannot read is refused before the response is
+// negotiated.
+func TestQuerySubscribeUnsupportedMediaTypeBeforeRefusedResponseMediaType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL,
+		strings.NewReader(`{"url": ["https://example.com/books/1"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", eventStreamContentType+";q=0")
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
+}
+
+// The same order inside the Events Query dispatch: a subscription asking for
+// no events is unprocessable however it would have been answered.
+func TestEventsQuerySubscribeWithoutEventsBeforeRefusedResponseMediaType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	req := eventsQueryRequest(t.Context(), "match=https://example.com/books/1")
+	req.Header.Set("Accept", eventStreamContentType+";q=0")
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}
+
 // A QUERY body the hub cannot parse is a bad request. Only a body can be
 // malformed this way: the query component of a GET is parsed leniently.
 func TestQuerySubscribeMalformedBodyRejectedWith400(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -72,3 +72,83 @@ func TestQuerySubscribeWithoutMediaTypeRejectedWith400(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
+
+// The same two rules apply inside the Events Query dispatch, which reads the
+// media type to choose a parser.
+func TestEventsQuerySubscribeUnsupportedMediaType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL, strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
+}
+
+func TestEventsQuerySubscribeWithoutMediaType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL, strings.NewReader(`{}`))
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// A QUERY served as an Events Query carries its subscription in the body, so
+// a matcher in the query component is not one.
+func TestEventsQuerySubscribeIgnoresURLParameters(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	req := httptest.NewRequest(methodQuery,
+		defaultHubURL+"?match=https://example.com/books/1", strings.NewReader("events="))
+	req.Header.Set("Content-Type", urlEncodedMediaType)
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "missing \"match\" subscription parameter\n", w.Body.String())
+}
+
+// A QUERY the hub reads and understands but that asks for no events is
+// unprocessable: a stream of notifications is the only mode it serves.
+func TestEventsQuerySubscribeWithoutEvents(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL,
+		strings.NewReader("match=https://example.com/books/1"))
+	req.Header.Set("Content-Type", urlEncodedMediaType)
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -18,7 +18,7 @@ func TestEventsQuerySubscribeRefusedResponseMediaType(t *testing.T) {
 
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
-	req := eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events=")
+	req := eventsQueryRequest(t.Context(), `{"url": ["https://example.com/books/1"], "events": {}}`)
 	req.Header.Set("Accept", eventStreamContentType+";q=0")
 
 	w := httptest.NewRecorder()
@@ -138,7 +138,7 @@ func TestEventsQuerySubscribeWithoutEventsBeforeRefusedResponseMediaType(t *test
 
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
-	req := eventsQueryRequest(t.Context(), "match=https://example.com/books/1")
+	req := eventsQueryRequest(t.Context(), `{"url": ["https://example.com/books/1"]}`)
 	req.Header.Set("Accept", eventStreamContentType+";q=0")
 
 	w := httptest.NewRecorder()
@@ -348,7 +348,7 @@ func TestEventsQuerySubscribeReadsEventsDuration(t *testing.T) {
 
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
-	r := eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events=")
+	r := eventsQueryRequest(t.Context(), `{"url": ["https://example.com/books/1"], "events": {}}`)
 	r.Header.Set("Events", "duration=30")
 
 	req, parseErr := hub.parseSubscribeRequest(t.Context(), r)
@@ -363,7 +363,7 @@ func TestEventsQuerySubscribeWithoutEventsDuration(t *testing.T) {
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
 	req, parseErr := hub.parseSubscribeRequest(t.Context(),
-		eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events="))
+		eventsQueryRequest(t.Context(), `{"url": ["https://example.com/books/1"], "events": {}}`))
 	require.Nil(t, parseErr)
 	assert.Zero(t, req.duration)
 }
@@ -407,7 +407,7 @@ func TestEventsQuerySubscribeReadsEventsDurationSplitOverFieldLines(t *testing.T
 
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
-	r := eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events=")
+	r := eventsQueryRequest(t.Context(), `{"url": ["https://example.com/books/1"], "events": {}}`)
 	r.Header.Add("Events", "foo=1")
 	r.Header.Add("Events", "duration=30")
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,33 @@
+package mercure
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A QUERY body the hub cannot parse is a bad request. Only a body can be
+// malformed this way: the query component of a GET is parsed leniently.
+func TestQuerySubscribeMalformedBodyRejectedWith400(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	req := httptest.NewRequest(methodQuery, defaultHubURL, strings.NewReader("match=%zz"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	// The status text, not the matcher error: a body that will not parse is
+	// refused before any matcher is looked for.
+	assert.Equal(t, http.StatusText(http.StatusBadRequest)+"\n", w.Body.String())
+}

--- a/parser_urlencoded.go
+++ b/parser_urlencoded.go
@@ -1,0 +1,15 @@
+package mercure
+
+import (
+	"net/url"
+)
+
+// Media type of a subscription expressed as form-encoded parameters, the
+// shape a query component carries.
+const urlEncodedMediaType = "application/x-www-form-urlencoded"
+
+// parseURLEncoded parses a form-encoded (application/x-www-form-urlencoded)
+// representation.
+func parseURLEncoded(body []byte) (url.Values, error) {
+	return url.ParseQuery(string(body))
+}

--- a/publish.go
+++ b/publish.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -39,6 +40,7 @@ var (
 	ErrInvalidEventType  = errors.New(`"type" field contains a forbidden control character or invalid UTF-8`)
 	ErrReservedEventType = errors.New(`"type" field uses the reserved value "mercure"`)
 	ErrInvalidTopic      = errors.New("topic contains a forbidden control character or invalid UTF-8")
+	ErrInvalidMediaType  = errors.New(`"content_type" field is not a valid media type`)
 	ErrTooManyTopics     = errors.New("too many topics in update")
 	ErrMissingTopic      = errors.New("update carries no topic")
 	ErrInvalidData       = errors.New(`"data" field is not valid UTF-8`)
@@ -110,6 +112,15 @@ func (u *Update) Validate() error {
 	// enforce it, so reject invalid data rather than dispatch it.
 	if !utf8.ValidString(u.Data) {
 		return ErrInvalidData
+	}
+
+	// The content type ends up on the wire as a header of negotiated response
+	// encodings, so a malformed value could inject fields there (CWE-93);
+	// ParseMediaType rejects everything but valid media type syntax.
+	if u.ContentType != "" {
+		if _, _, err := mime.ParseMediaType(u.ContentType); err != nil {
+			return fmt.Errorf("%q: %w", u.ContentType, ErrInvalidMediaType)
+		}
 	}
 
 	return nil
@@ -275,10 +286,11 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	u = &Update{
-		Topics:  topics,
-		Private: private,
-		Debug:   h.debug,
-		Event:   Event{r.PostForm.Get("data"), r.PostForm.Get("id"), r.PostForm.Get("type"), retry},
+		Topics:      topics,
+		Private:     private,
+		Debug:       h.debug,
+		ContentType: r.PostForm.Get("content_type"),
+		Event:       Event{r.PostForm.Get("data"), r.PostForm.Get("id"), r.PostForm.Get("type"), retry},
 	}
 
 	dispatchCtx := context.WithoutCancel(ctx)
@@ -290,7 +302,8 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 			errors.Is(err, ErrInvalidEventID), errors.Is(err, ErrInvalidEventType),
 			errors.Is(err, ErrReservedEventType),
 			errors.Is(err, ErrInvalidTopic), errors.Is(err, ErrTooManyTopics),
-			errors.Is(err, ErrMissingTopic), errors.Is(err, ErrInvalidData):
+			errors.Is(err, ErrMissingTopic), errors.Is(err, ErrInvalidData),
+			errors.Is(err, ErrInvalidMediaType):
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		default:
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/resourcemetadata.go
+++ b/resourcemetadata.go
@@ -35,6 +35,9 @@ type protectedResourceMetadata struct {
 	// MercureSubscriptions advertises the active subscriptions feature (a
 	// Mercure extension to RFC 9728) when the hub implements it.
 	MercureSubscriptions bool `json:"mercure_subscriptions,omitempty"`
+	// MercureEventsQuery advertises subscriptions expressed as an Events
+	// Query (a Mercure extension to RFC 9728) when the hub serves them.
+	MercureEventsQuery bool `json:"mercure_events_query,omitempty"`
 }
 
 // bearerMethodsSupported lists the RFC 6750 token presentation methods the hub
@@ -62,6 +65,7 @@ func (h *Hub) ProtectedResourceMetadataHandler(w http.ResponseWriter, r *http.Re
 		// advertise the configured cookie name.
 		MercureCookie:        h.cookieName,
 		MercureSubscriptions: h.subscriptions,
+		MercureEventsQuery:   h.eventsQuery,
 	}
 
 	if err := json.NewEncoder(w).Encode(metadata); err != nil && h.logger.Enabled(r.Context(), slog.LevelInfo) {

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -76,6 +76,9 @@ paths:
                 data:
                   description: The content of the new version of this topic.
                   type: string
+                content_type:
+                  description: The media type of the data value, conveyed to subscribers when the negotiated response media type can carry per-event metadata.
+                  type: string
                 private:
                   description: To mark an update as private. If not provided, this update will be public.
                   type: boolean

--- a/subscribe.go
+++ b/subscribe.go
@@ -235,6 +235,10 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 
 	h.limitRequestBody(w, r)
 
+	// Advertised on every answer, a refusal included: a client told 415 needs
+	// to know what it should have sent (RFC 10008, Section 3).
+	w.Header()["Accept-Query"] = h.acceptQuery
+
 	req, parseErr := h.parseSubscribeRequest(ctx, r)
 	if parseErr != nil {
 		http.Error(w, http.StatusText(parseErr.status), parseErr.status)

--- a/subscribe.go
+++ b/subscribe.go
@@ -339,6 +339,11 @@ var (
 	headerExpire       = []string{"0"}
 
 	headerXAccelBuffering = []string{"no"}
+
+	// Incremental (draft-ietf-httpbis-incremental) asks an intermediary to
+	// forward each chunk as it arrives rather than buffer the response, the
+	// standardized counterpart of X-Accel-Buffering above.
+	headerIncremental = []string{"?1"}
 )
 
 // sendHeaders sends correct HTTP headers to create a keep-alive connection.
@@ -359,6 +364,7 @@ func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSu
 
 	// NGINX support https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering
 	header["X-Accel-Buffering"] = headerXAccelBuffering
+	header["Incremental"] = headerIncremental
 
 	if s.RequestLastEventIDSet {
 		header["Mercure-Last-Event-Id"] = []string{<-s.responseLastEventID}

--- a/subscribe.go
+++ b/subscribe.go
@@ -129,6 +129,12 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The response begins here, once the subscriber is registered. Registering
+	// one and answering it are separate concerns, and only the second belongs
+	// to a handler that then keeps the connection.
+	h.sendHeaders(ctx, w, s)
+	rc.flush(ctx)
+
 	ctx = context.WithValue(ctx, SubscriberContextKey, &s.Subscriber)
 
 	defer h.shutdown(ctx, s)
@@ -316,9 +322,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 	// this order: remove first, then dispatch active:false.
 	h.dispatchSubscriptionUpdate(addCtx, s, true)
 
-	h.sendHeaders(ctx, w, s)
 	rc := h.newResponseController(w, s)
-	rc.flush(ctx)
 
 	if h.logger.Enabled(ctx, slog.LevelInfo) {
 		if claims != nil && h.logger.Enabled(ctx, slog.LevelDebug) {

--- a/subscribe.go
+++ b/subscribe.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"math"
 	"math/rand/v2"
 	"net/http"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -74,7 +76,7 @@ func (rc *responseController) flush(ctx context.Context) bool {
 	return true
 }
 
-func (h *Hub) newResponseController(w http.ResponseWriter, s *LocalSubscriber) *responseController {
+func (h *Hub) newResponseController(w http.ResponseWriter, s *LocalSubscriber, duration time.Duration) *responseController {
 	wd := h.getWriteDeadline(s)
 
 	// Disconnect one dispatch before the write deadline so the client sees a
@@ -89,6 +91,15 @@ func (h *Hub) newResponseController(w http.ResponseWriter, s *LocalSubscriber) *
 	if !wd.IsZero() {
 		if d := wd.Add(-h.dispatchTimeout); d.After(time.Now()) {
 			dt = d
+		}
+	}
+
+	// A subscription may ask the hub to stop sooner, and only sooner. The
+	// dispatch of margin belongs to the connection's write deadline, not to what
+	// was asked for, so it is added back rather than taken out.
+	if duration > 0 {
+		if capped := time.Now().Add(duration); dt.IsZero() || capped.Before(dt) {
+			dt = capped
 		}
 	}
 
@@ -129,7 +140,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 	// The response begins here, once the subscriber is registered. Registering
 	// one and answering it are separate concerns, and only the second belongs
 	// to a handler that then keeps the connection.
-	h.sendHeaders(ctx, w, s, enc.contentType(), enc.preamble())
+	h.sendHeaders(ctx, w, s, enc.contentType(), enc.preamble(), rc.disconnectionTime)
 	rc.flush(ctx)
 
 	ctx = context.WithValue(ctx, SubscriberContextKey, &s.Subscriber)
@@ -159,7 +170,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 	// connection no later than exp, so relying on a failed write against a past
 	// deadline would otherwise leave an authenticated connection open up to a
 	// heartbeat interval past exp, or indefinitely with heartbeat off.
-	if !rc.writeDeadline.IsZero() {
+	if !rc.disconnectionTime.IsZero() {
 		disconnectionTimer := time.NewTimer(time.Until(rc.disconnectionTime))
 		defer disconnectionTimer.Stop()
 
@@ -315,7 +326,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 	// this order: remove first, then dispatch active:false.
 	h.dispatchSubscriptionUpdate(addCtx, s, true)
 
-	rc := h.newResponseController(w, s)
+	rc := h.newResponseController(w, s, req.duration)
 	enc := responseEncoders[req.contentType]
 
 	if h.logger.Enabled(ctx, slog.LevelInfo) {
@@ -348,7 +359,7 @@ var (
 
 // sendHeaders sends correct HTTP headers to create a keep-alive connection.
 func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSubscriber,
-	contentType []string, preamble string,
+	contentType []string, preamble string, disconnectionTime time.Time,
 ) {
 	header := w.Header()
 
@@ -365,6 +376,11 @@ func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSu
 	// NGINX support https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering
 	header["X-Accel-Buffering"] = headerXAccelBuffering
 	header["Incremental"] = headerIncremental
+
+	if h.eventsQuery && !disconnectionTime.IsZero() {
+		seconds := max(int64(math.Ceil(time.Until(disconnectionTime).Seconds())), 0)
+		header["Events"] = []string{"duration=" + strconv.FormatInt(seconds, 10)}
+	}
 
 	if s.RequestLastEventIDSet {
 		header["Mercure-Last-Event-Id"] = []string{<-s.responseLastEventID}

--- a/subscribe.go
+++ b/subscribe.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
-	"net/url"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -238,25 +235,16 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 
 	h.limitRequestBody(w, r)
 
-	values, err := h.subscribeValues(r)
-	if err != nil {
-		status := http.StatusBadRequest
-
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
-			status = http.StatusRequestEntityTooLarge
-		}
-
-		http.Error(w, http.StatusText(status), status)
-		recordSpanError(span, err)
+	req, parseErr := h.parseSubscribeRequest(ctx, r)
+	if parseErr != nil {
+		http.Error(w, http.StatusText(parseErr.status), parseErr.status)
+		recordSpanError(span, parseErr.cause)
 
 		return nil, nil, nil
 	}
 
-	lastEventID, lastEventIDSet := h.retrieveLastEventID(ctx, r, values)
-
-	s := NewLocalSubscriber(lastEventID, h.logger, h.topicMatcherStore)
-	s.RequestLastEventIDSet = lastEventIDSet
+	s := NewLocalSubscriber(req.lastEventID, h.logger, h.topicMatcherStore)
+	s.RequestLastEventIDSet = req.lastEventIDSet
 
 	var claims *claims
 
@@ -281,7 +269,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 
 	deprecated := h.isBackwardCompatiblyEnabledWith(8)
 
-	matchers, err := h.parseMatchers(values, deprecated)
+	matchers, err := h.parseMatchers(req.values, deprecated)
 	if err != nil {
 		h.writeMatcherParamError(ctx, w, err)
 		recordSpanError(span, err)
@@ -377,70 +365,6 @@ func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSu
 	if _, err := w.Write([]byte(preamble)); err != nil && h.logger.Enabled(ctx, slog.LevelInfo) {
 		h.logger.LogAttrs(ctx, slog.LevelInfo, "Failed to write preamble", slog.Any("error", err))
 	}
-}
-
-// subscribeValues returns the subscription parameters. For GET and HEAD they
-// come from the URL query; for QUERY the application/x-www-form-urlencoded
-// request body is parsed and merged on top, so a subscriber can pass topics
-// either way. Body size is bounded by limitRequestBody, as for the publish
-// endpoint.
-func (h *Hub) subscribeValues(r *http.Request) (url.Values, error) {
-	values := r.URL.Query()
-	if r.Method != methodQuery {
-		return values, nil
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading QUERY request body: %w", err)
-	}
-
-	bodyValues, err := url.ParseQuery(string(body))
-	if err != nil {
-		return nil, fmt.Errorf("parsing QUERY request body: %w", err)
-	}
-
-	for k, vs := range bodyValues {
-		values[k] = append(values[k], vs...)
-	}
-
-	return values, nil
-}
-
-// retrieveLastEventID extracts the Last-Event-ID from the corresponding HTTP
-// header with a fallback on the query parameter. The second return value
-// reports whether either was present at all, even with an empty value: the
-// protocol requires answering with a Mercure-Last-Event-ID response field
-// whenever one was.
-func (h *Hub) retrieveLastEventID(ctx context.Context, r *http.Request, query url.Values) (string, bool) {
-	if id := r.Header.Get("Last-Event-ID"); id != "" {
-		return id, true
-	}
-
-	_, headerPresent := r.Header["Last-Event-Id"]
-
-	if id := query.Get("last_event_id"); id != "" {
-		return id, true
-	}
-
-	_, queryPresent := query["last_event_id"]
-
-	if legacyEventIDValues, present := query["Last-Event-ID"]; present { //nolint:nestif
-		infoLevel := h.logger.Enabled(ctx, slog.LevelInfo)
-		if h.isBackwardCompatiblyEnabledWith(7) {
-			if infoLevel {
-				h.logger.LogAttrs(ctx, slog.LevelInfo, "Deprecated: the 'Last-Event-ID' query parameter is deprecated since the version 8 of the protocol, use 'last_event_id' instead.")
-			}
-
-			if len(legacyEventIDValues) != 0 {
-				return legacyEventIDValues[0], true
-			}
-		} else if infoLevel {
-			h.logger.LogAttrs(ctx, slog.LevelInfo, `Unsupported: the "Last-Event-ID" query parameter is not supported anymore, use "last_event_id" instead or enable backward compatibility with version 7 of the protocol.`)
-		}
-	}
-
-	return "", headerPresent || queryPresent
 }
 
 // Write sends the given string to the client.

--- a/subscribe.go
+++ b/subscribe.go
@@ -203,6 +203,8 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 				rc.hub.logger.LogAttrs(ctx, slog.LevelDebug, "Hub is shutting down, closing connection")
 			}
 
+			h.sendTrailer(ctx, rc, enc.trailer())
+
 			return
 		case <-ctx.Done():
 			if debugLevel {
@@ -219,6 +221,8 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 			heartbeatTimer.Reset(h.heartbeat)
 		case <-disconnectionTimerC:
 			// Cleanly close the HTTP connection before the write deadline to prevent client-side errors
+			h.sendTrailer(ctx, rc, enc.trailer())
+
 			return
 		case update, ok := <-s.Receive():
 			if !ok || !h.write(ctx, rc, enc.encode(update)) {
@@ -327,7 +331,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 	h.dispatchSubscriptionUpdate(addCtx, s, true)
 
 	rc := h.newResponseController(w, s, req.duration)
-	enc := responseEncoders[req.contentType]
+	enc := responseEncoders[req.contentType]()
 
 	if h.logger.Enabled(ctx, slog.LevelInfo) {
 		if claims != nil && h.logger.Enabled(ctx, slog.LevelDebug) {
@@ -391,6 +395,36 @@ func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSu
 	if _, err := w.Write([]byte(preamble)); err != nil && h.logger.Enabled(ctx, slog.LevelInfo) {
 		h.logger.LogAttrs(ctx, slog.LevelInfo, "Failed to write preamble", slog.Any("error", err))
 	}
+}
+
+// sendTrailer closes the stream for framings that need a terminator. It is
+// called only on the clean exit paths, never once the client has gone away.
+//
+// The terminator gets a write deadline of its own rather than the
+// connection's. The response ends because its deadline arrived, so that
+// deadline has just expired: writing through it would fail, and the client
+// would receive a body that reads as truncated rather than finished. This is
+// the last write on the connection, and it is one buffered line long.
+func (h *Hub) sendTrailer(ctx context.Context, rc *responseController, trailer string) {
+	if trailer == "" {
+		return
+	}
+
+	if err := rc.SetWriteDeadline(time.Now().Add(h.dispatchTimeout)); err != nil {
+		h.handleWriterError(ctx, err, "Error while setting the trailer write deadline")
+
+		return
+	}
+
+	if _, err := rc.rw.Write([]byte(trailer)); err != nil {
+		if h.logger.Enabled(ctx, slog.LevelDebug) {
+			h.logger.LogAttrs(ctx, slog.LevelDebug, "Failed to write trailer", slog.Any("error", err))
+		}
+
+		return
+	}
+
+	rc.flush(ctx)
 }
 
 // Write sends the given string to the client.

--- a/subscribe.go
+++ b/subscribe.go
@@ -124,7 +124,7 @@ func (h *Hub) getWriteDeadline(s *LocalSubscriber) (deadline time.Time) {
 func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	s, rc := h.registerSubscriber(ctx, w, r)
+	s, rc, enc := h.registerSubscriber(ctx, w, r)
 	if s == nil {
 		return
 	}
@@ -132,7 +132,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 	// The response begins here, once the subscriber is registered. Registering
 	// one and answering it are separate concerns, and only the second belongs
 	// to a handler that then keeps the connection.
-	h.sendHeaders(ctx, w, s)
+	h.sendHeaders(ctx, w, s, enc.contentType(), enc.preamble())
 	rc.flush(ctx)
 
 	ctx = context.WithValue(ctx, SubscriberContextKey, &s.Subscriber)
@@ -147,7 +147,8 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 		disconnectionTimerC <-chan time.Time
 	)
 
-	if h.heartbeat != 0 {
+	heartbeat := enc.heartbeat()
+	if h.heartbeat != 0 && heartbeat != "" {
 		heartbeatTimer = time.NewTimer(h.heartbeat)
 		defer heartbeatTimer.Stop()
 
@@ -202,8 +203,8 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 
 			return
 		case <-heartbeatTimerC:
-			// Send an SSE comment as a heartbeat, to prevent issues with some proxies and old browsers
-			if !h.write(ctx, rc, ":\n") {
+			// Keep the connection alive, to prevent issues with some proxies and old browsers
+			if !h.write(ctx, rc, enc.heartbeat()) {
 				return
 			}
 
@@ -212,7 +213,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 			// Cleanly close the HTTP connection before the write deadline to prevent client-side errors
 			return
 		case update, ok := <-s.Receive():
-			if !ok || !h.write(ctx, rc, newSerializedUpdate(update).event) {
+			if !ok || !h.write(ctx, rc, enc.encode(update)) {
 				return
 			}
 
@@ -231,7 +232,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // registerSubscriber initializes the connection.
-func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *http.Request) (*LocalSubscriber, *responseController) { //nolint:funlen
+func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *http.Request) (*LocalSubscriber, *responseController, streamEncoder) { //nolint:funlen
 	ctx, span := startSpan(ctx, "mercure.subscribe", trace.WithSpanKind(trace.SpanKindConsumer))
 	defer span.End()
 
@@ -249,7 +250,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 		http.Error(w, http.StatusText(status), status)
 		recordSpanError(span, err)
 
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	lastEventID, lastEventIDSet := h.retrieveLastEventID(ctx, r, values)
@@ -274,7 +275,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 				recordSpanError(span, err)
 			}
 
-			return nil, nil
+			return nil, nil, nil
 		}
 	}
 
@@ -285,7 +286,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 		h.writeMatcherParamError(ctx, w, err)
 		recordSpanError(span, err)
 
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	var privateTopicMatchers []TopicMatcher
@@ -313,7 +314,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 
 		recordSpanError(span, err)
 
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Announce the subscription only once it exists, so a failed registration
@@ -323,6 +324,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 	h.dispatchSubscriptionUpdate(addCtx, s, true)
 
 	rc := h.newResponseController(w, s)
+	enc := eventStreamEncoder{}
 
 	if h.logger.Enabled(ctx, slog.LevelInfo) {
 		if claims != nil && h.logger.Enabled(ctx, slog.LevelDebug) {
@@ -334,13 +336,12 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 
 	h.metrics.SubscriberConnected(s)
 
-	return s, rc
+	return s, rc, enc
 }
 
 //nolint:gochecknoglobals
 var (
 	headerConnection   = []string{"keep-alive"}
-	headerContentType  = []string{"text/event-stream"}
 	headerCacheControl = []string{"private, no-cache, no-store, must-revalidate, max-age=0"}
 	headerPragma       = []string{"no-cache"}
 	headerExpire       = []string{"0"}
@@ -349,13 +350,15 @@ var (
 )
 
 // sendHeaders sends correct HTTP headers to create a keep-alive connection.
-func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSubscriber) {
+func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSubscriber,
+	contentType []string, preamble string,
+) {
 	header := w.Header()
 
 	// Keep alive, useful only for HTTP 1 clients https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive
 	header["Connection"] = headerConnection
 
-	header["Content-Type"] = headerContentType
+	header["Content-Type"] = contentType
 
 	// Disable cache, even for old browsers and proxies
 	header["Cache-Control"] = headerCacheControl
@@ -369,10 +372,10 @@ func (h *Hub) sendHeaders(ctx context.Context, w http.ResponseWriter, s *LocalSu
 		header["Mercure-Last-Event-Id"] = []string{<-s.responseLastEventID}
 	}
 
-	// Write a comment in the body
+	// Write the framing's preamble in the body
 	// Go currently doesn't provide a better way to flush the headers
-	if _, err := w.Write([]byte{':', '\n'}); err != nil && h.logger.Enabled(ctx, slog.LevelInfo) {
-		h.logger.LogAttrs(ctx, slog.LevelInfo, "Failed to write comment", slog.Any("error", err))
+	if _, err := w.Write([]byte(preamble)); err != nil && h.logger.Enabled(ctx, slog.LevelInfo) {
+		h.logger.LogAttrs(ctx, slog.LevelInfo, "Failed to write preamble", slog.Any("error", err))
 	}
 }
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -316,7 +316,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 	h.dispatchSubscriptionUpdate(addCtx, s, true)
 
 	rc := h.newResponseController(w, s)
-	enc := eventStreamEncoder{}
+	enc := responseEncoders[req.contentType]
 
 	if h.logger.Enabled(ctx, slog.LevelInfo) {
 		if claims != nil && h.logger.Enabled(ctx, slog.LevelDebug) {

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1503,6 +1503,55 @@ func TestSubscribeContentType(t *testing.T) {
 	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
 }
 
+// A subscription is answered with the media types a QUERY body can express it
+// in, so a client learns what the hub reads (RFC 10008, Section 3).
+func TestSubscribeAcceptQuery(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match=https://example.com/foo", nil).WithContext(ctx)
+
+	w := &responseTester{
+		header:             http.Header{},
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+
+	hub.SubscribeHandler(w, req)
+
+	assert.Equal(t, urlEncodedMediaType, w.Header().Get("Accept-Query"))
+}
+
+// A hub serving Events Query advertises every media type its parsers read, so
+// this expectation grows as parsers are added.
+func TestEventsQuerySubscribeAcceptQuery(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	req := eventsQueryRequest(ctx, url.Values{
+		paramMatch: {"https://example.com/foo"},
+		"events":   {""},
+	}.Encode())
+
+	w := &responseTester{
+		header:             http.Header{},
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+
+	hub.SubscribeHandler(w, req)
+
+	assert.Equal(t, "application/x-www-form-urlencoded", w.Header().Get("Accept-Query"))
+}
+
 // A subscription expressed as an Events Query receives the updates it asked
 // for. Nothing negotiates a carrier yet, so it is answered as an event
 // stream, like any other subscription.

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1511,10 +1511,7 @@ func TestEventsQuerySubscribeContentType(t *testing.T) {
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
 	ctx, cancel := context.WithCancel(t.Context())
-	req := eventsQueryRequest(ctx, url.Values{
-		paramMatch: {"https://example.com/books/1"},
-		"events":   {""},
-	}.Encode())
+	req := eventsQueryRequest(ctx, `{"url": ["https://example.com/books/1"], "events": {}}`)
 
 	w := &responseTester{
 		header:             http.Header{},
@@ -1560,10 +1557,7 @@ func TestEventsQuerySubscribeAcceptQuery(t *testing.T) {
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
 	ctx, cancel := context.WithCancel(t.Context())
-	req := eventsQueryRequest(ctx, url.Values{
-		paramMatch: {"https://example.com/foo"},
-		"events":   {""},
-	}.Encode())
+	req := eventsQueryRequest(ctx, `{"url": ["https://example.com/foo"], "events": {}}`)
 
 	w := &responseTester{
 		header:             http.Header{},
@@ -1575,7 +1569,8 @@ func TestEventsQuerySubscribeAcceptQuery(t *testing.T) {
 
 	hub.SubscribeHandler(w, req)
 
-	assert.Equal(t, "application/x-www-form-urlencoded", w.Header().Get("Accept-Query"))
+	assert.Equal(t, "application/events+json, application/x-www-form-urlencoded",
+		w.Header().Get("Accept-Query"))
 }
 
 // A subscription asks intermediaries to forward each chunk as it arrives,
@@ -1628,10 +1623,7 @@ func TestEventsQuerySubscribe(t *testing.T) {
 	}()
 
 	reqCtx, cancel := context.WithCancel(t.Context())
-	req := eventsQueryRequest(reqCtx, url.Values{
-		paramMatch: {"https://example.com/books/1"},
-		"events":   {""},
-	}.Encode())
+	req := eventsQueryRequest(reqCtx, `{"url": ["https://example.com/books/1"], "events": {}}`)
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
@@ -1668,10 +1660,8 @@ func TestEventsQuerySubscribeURLPattern(t *testing.T) {
 	}()
 
 	reqCtx, cancel := context.WithCancel(t.Context())
-	req := eventsQueryRequest(reqCtx, url.Values{
-		"match_urlpattern": {"https://example.com/books/:id"},
-		"events":           {""},
-	}.Encode())
+	req := eventsQueryRequest(reqCtx,
+		`{"url": {"match_urlpattern": ["https://example.com/books/:id"]}, "events": {}}`)
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
@@ -1690,15 +1680,16 @@ func TestEventsQuerySubscribeWithoutTopics(t *testing.T) {
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
 	w := newSubscribeRecorder()
-	hub.SubscribeHandler(w, eventsQueryRequest(t.Context(), "events="))
+	hub.SubscribeHandler(w, eventsQueryRequest(t.Context(), `{"events": {}}`))
 
 	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 }
 
-// eventsQueryRequest builds a subscription request carrying the given body.
+// eventsQueryRequest builds a subscription request carrying the given body,
+// expressed in the media type an Events Query is canonically written in.
 func eventsQueryRequest(ctx context.Context, body string) *http.Request {
 	req := httptest.NewRequest(methodQuery, defaultHubURL, strings.NewReader(body)).WithContext(ctx)
-	req.Header.Set("Content-Type", urlEncodedMediaType)
+	req.Header.Set("Content-Type", eventsJSONMediaType)
 
 	return req
 }
@@ -1713,11 +1704,8 @@ func TestEventsQuerySubscribeLastEventID(t *testing.T) {
 	reqCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	req := eventsQueryRequest(reqCtx, url.Values{
-		paramMatch:      {"https://example.com/books/1"},
-		"events":        {""},
-		"last_event_id": {"urn:uuid:0198c1f2-3f4a-7000-8000-9abcdef01234"},
-	}.Encode())
+	req := eventsQueryRequest(reqCtx,
+		`{"url": ["https://example.com/books/1"], "events": {}, "last_event_id": "urn:uuid:0198c1f2-3f4a-7000-8000-9abcdef01234"}`)
 
 	w := &responseTester{
 		header:             http.Header{},
@@ -1739,7 +1727,7 @@ func TestEventsQuerySubscribeRejectsMalformedBody(t *testing.T) {
 	hub := createAnonymousDummy(t, WithEventsQuery())
 
 	w := httptest.NewRecorder()
-	hub.SubscribeHandler(w, eventsQueryRequest(t.Context(), "match=%zz"))
+	hub.SubscribeHandler(w, eventsQueryRequest(t.Context(), `{"url": 42, "events": {}}`))
 
 	resp := w.Result()
 
@@ -1891,7 +1879,7 @@ func TestEventsQuerySubscribeStopsAfterTheRequestedDuration(t *testing.T) {
 
 	hub := createAnonymousDummy(t, WithEventsQuery(), WithWriteTimeout(0), WithDispatchTimeout(0))
 
-	req := eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events=")
+	req := eventsQueryRequest(t.Context(), `{"url": ["https://example.com/books/1"], "events": {}}`)
 	req.Header.Set("Events", "duration=0.2")
 
 	w := writeDeadlineRecorder{httptest.NewRecorder()}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1552,6 +1552,29 @@ func TestEventsQuerySubscribeAcceptQuery(t *testing.T) {
 	assert.Equal(t, "application/x-www-form-urlencoded", w.Header().Get("Accept-Query"))
 }
 
+// A subscription asks intermediaries to forward each chunk as it arrives,
+// which a buffered response would otherwise defeat.
+func TestSubscribeIncremental(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match=https://example.com/foo", nil).WithContext(ctx)
+
+	w := &responseTester{
+		header:             http.Header{},
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+
+	hub.SubscribeHandler(w, req)
+
+	assert.Equal(t, "?1", w.Header().Get("Incremental"))
+}
+
 // A subscription expressed as an Events Query receives the updates it asked
 // for. Nothing negotiates a carrier yet, so it is answered as an event
 // stream, like any other subscription.

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1386,7 +1386,7 @@ func TestNewResponseControllerDisconnectionTimeStaysInTheFuture(t *testing.T) {
 				}}
 			}
 
-			rc := h.newResponseController(httptest.NewRecorder(), s)
+			rc := h.newResponseController(httptest.NewRecorder(), s, 0)
 
 			assert.True(t, rc.disconnectionTime.After(time.Now()),
 				"disconnectionTime is %v in the past, the connection would close immediately", time.Until(rc.disconnectionTime))
@@ -1402,7 +1402,7 @@ func TestNewResponseControllerNoDeadline(t *testing.T) {
 	t.Parallel()
 
 	h := &Hub{opt: &opt{writeTimeout: 0, dispatchTimeout: DefaultDispatchTimeout}}
-	rc := h.newResponseController(httptest.NewRecorder(), &LocalSubscriber{})
+	rc := h.newResponseController(httptest.NewRecorder(), &LocalSubscriber{}, 0)
 
 	assert.True(t, rc.writeDeadline.IsZero())
 	assert.True(t, rc.disconnectionTime.IsZero())
@@ -1747,3 +1747,178 @@ func TestEventsQuerySubscribeRejectsMalformedBody(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
+
+// A subscription is served for as long as it asked. The dispatch of margin
+// belongs to the hub's own deadline, so it is not taken out of the bound the
+// client chose, whichever side of a dispatch that bound falls on.
+func TestNewResponseControllerServesTheRequestedDuration(t *testing.T) {
+	t.Parallel()
+
+	for _, requested := range []time.Duration{
+		30 * time.Second,
+		6 * time.Second,
+		5 * time.Second,
+		4 * time.Second,
+		time.Second,
+	} {
+		t.Run(requested.String(), func(t *testing.T) {
+			t.Parallel()
+
+			h := &Hub{opt: &opt{writeTimeout: 10 * time.Minute, dispatchTimeout: 5 * time.Second}}
+
+			rc := h.newResponseController(httptest.NewRecorder(), &LocalSubscriber{}, requested)
+
+			assert.InDelta(t, requested, time.Until(rc.disconnectionTime), float64(500*time.Millisecond))
+			assert.True(t, rc.writeDeadline.After(rc.disconnectionTime),
+				"the connection must outlive the notifications it carries")
+		})
+	}
+}
+
+// A hub with no deadline of its own stops when the subscription asked it to.
+func TestNewResponseControllerRequestedDurationWithoutHubDeadline(t *testing.T) {
+	t.Parallel()
+
+	h := &Hub{opt: &opt{writeTimeout: 0, dispatchTimeout: 5 * time.Second}}
+
+	rc := h.newResponseController(httptest.NewRecorder(), &LocalSubscriber{}, 30*time.Second)
+
+	assert.InDelta(t, 30*time.Second, time.Until(rc.disconnectionTime), float64(500*time.Millisecond))
+	// The connection keeps the deadline it had, which is none: what was asked
+	// for bounds the notifications, not the socket.
+	assert.True(t, rc.writeDeadline.IsZero())
+}
+
+// A bound looser than the hub's own changes nothing: a subscription may only
+// shorten the period it is served for.
+func TestNewResponseControllerRequestedDurationOnlyShortens(t *testing.T) {
+	t.Parallel()
+
+	h := &Hub{opt: &opt{writeTimeout: time.Minute, dispatchTimeout: 5 * time.Second}}
+
+	rc := h.newResponseController(httptest.NewRecorder(), &LocalSubscriber{}, time.Hour)
+
+	assert.False(t, rc.disconnectionTime.After(rc.writeDeadline.Add(-5*time.Second)),
+		"a longer request must not extend the period served")
+}
+
+// A token expiring inside the dispatch margin leaves no margin to give away,
+// and a request cannot buy more time than the token grants.
+func TestNewResponseControllerRequestedDurationCannotOutlastTheToken(t *testing.T) {
+	t.Parallel()
+
+	h := &Hub{opt: &opt{writeTimeout: 0, dispatchTimeout: 5 * time.Second}}
+
+	s := &LocalSubscriber{Subscriber: Subscriber{}}
+	s.Claims = &claims{RegisteredClaims: jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(2 * time.Second)),
+	}}
+
+	rc := h.newResponseController(httptest.NewRecorder(), s, 30*time.Second)
+
+	assert.Equal(t, rc.writeDeadline, rc.disconnectionTime,
+		"with the margin already spent the hub stops at the deadline itself")
+	assert.False(t, time.Until(rc.disconnectionTime) > 2*time.Second)
+}
+
+// The Events response field states the period notifications will be sent for,
+// in whole seconds rounded up: the hub may stop before the bound it
+// advertised, but must never still be sending after it.
+func TestSendHeadersEventsDuration(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		requested time.Duration
+		want      string
+	}{
+		{"whole seconds", 30 * time.Second, "duration=30"},
+		{"rounded up", 1500 * time.Millisecond, "duration=2"},
+		{"sub-second rounds up to a second", 500 * time.Millisecond, "duration=1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hub := createAnonymousDummy(t, WithEventsQuery(),
+				WithWriteTimeout(10*time.Minute), WithDispatchTimeout(5*time.Second))
+
+			s := &LocalSubscriber{}
+			w := httptest.NewRecorder()
+
+			rc := hub.newResponseController(w, s, tc.requested)
+			hub.sendHeaders(t.Context(), w, s, []string{eventStreamContentType}, ":\n", rc.disconnectionTime)
+
+			assert.Equal(t, tc.want, w.Header().Get("Events"))
+		})
+	}
+}
+
+// A hub not serving Events Query sends none of its fields.
+func TestSendHeadersOmitsEventsDurationWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithWriteTimeout(10*time.Minute))
+
+	s := &LocalSubscriber{}
+	w := httptest.NewRecorder()
+
+	rc := hub.newResponseController(w, s, 0)
+	hub.sendHeaders(t.Context(), w, s, []string{eventStreamContentType}, ":\n", rc.disconnectionTime)
+
+	assert.Empty(t, w.Header().Values("Events"))
+}
+
+// A hub that will not stop has no duration to state, and 0 would read as "no
+// notifications will be served".
+func TestSendHeadersOmitsEventsDurationWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery(), WithWriteTimeout(0), WithDispatchTimeout(0))
+
+	s := &LocalSubscriber{}
+	w := httptest.NewRecorder()
+
+	rc := hub.newResponseController(w, s, 0)
+	hub.sendHeaders(t.Context(), w, s, []string{eventStreamContentType}, ":\n", rc.disconnectionTime)
+
+	assert.Empty(t, w.Header().Values("Events"))
+}
+
+// A hub with no deadline of its own still stops when the subscription said
+// to: the bound it advertises is one it enforces.
+func TestEventsQuerySubscribeStopsAfterTheRequestedDuration(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery(), WithWriteTimeout(0), WithDispatchTimeout(0))
+
+	req := eventsQueryRequest(t.Context(), "match=https://example.com/books/1&events=")
+	req.Header.Set("Events", "duration=0.2")
+
+	w := writeDeadlineRecorder{httptest.NewRecorder()}
+
+	served := make(chan struct{})
+
+	go func() {
+		defer close(served)
+
+		hub.SubscribeHandler(w, req)
+	}()
+
+	select {
+	case <-served:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the hub streamed past the duration the subscription asked for")
+	}
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, ":\n", w.Body.String())
+	assert.Equal(t, "duration=1", w.Header().Get("Events"))
+}
+
+// writeDeadlineRecorder accepts the write deadlines a subscription sets on
+// its connection, which httptest.ResponseRecorder does not support at all.
+type writeDeadlineRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (writeDeadlineRecorder) SetWriteDeadline(time.Time) error { return nil }

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1478,3 +1478,27 @@ func TestSubscriptionEventReachesTheSubscriberItDescribes(t *testing.T) {
 	assert.Contains(t, body, `"active": true`)
 	assert.Contains(t, body, `"match": "/.well-known/mercure/subscriptions/:mt/:m/:s"`)
 }
+
+// A subscription response must state the media type it is framed in. Every
+// other assertion about a subscription looks at the body, so nothing else
+// would notice the hub answering with the wrong Content-Type.
+func TestSubscribeContentType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match=https://example.com/foo", nil).WithContext(ctx)
+
+	w := &responseTester{
+		header:             http.Header{},
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+
+	hub.SubscribeHandler(w, req)
+
+	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1503,6 +1503,32 @@ func TestSubscribeContentType(t *testing.T) {
 	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
 }
 
+// An Events Query is answered in the media type it negotiated, which is the
+// only framing this hub has to offer so far.
+func TestEventsQuerySubscribeContentType(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	req := eventsQueryRequest(ctx, url.Values{
+		paramMatch: {"https://example.com/books/1"},
+		"events":   {""},
+	}.Encode())
+
+	w := &responseTester{
+		header:             http.Header{},
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+
+	hub.SubscribeHandler(w, req)
+
+	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+}
+
 // A subscription is answered with the media types a QUERY body can express it
 // in, so a client learns what the hub reads (RFC 10008, Section 3).
 func TestSubscribeAcceptQuery(t *testing.T) {

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1502,3 +1502,150 @@ func TestSubscribeContentType(t *testing.T) {
 
 	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
 }
+
+// A subscription expressed as an Events Query receives the updates it asked
+// for. Nothing negotiates a carrier yet, so it is answered as an event
+// stream, like any other subscription.
+func TestEventsQuerySubscribe(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+	ctx := t.Context()
+
+	go func() {
+		s := hub.transport.(*LocalTransport)
+
+		var ready bool
+
+		for !ready {
+			s.RLock()
+			ready = s.subscribers.Len() == 1
+			s.RUnlock()
+		}
+
+		_ = hub.transport.Dispatch(ctx, &Update{
+			Topics: []string{"https://example.com/books/1"},
+			Event:  Event{Data: "Hello World", ID: "b"},
+		})
+	}()
+
+	reqCtx, cancel := context.WithCancel(t.Context())
+	req := eventsQueryRequest(reqCtx, url.Values{
+		paramMatch: {"https://example.com/books/1"},
+		"events":   {""},
+	}.Encode())
+
+	w := &responseTester{
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\nid: b\ndata: Hello World\n\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+	hub.SubscribeHandler(w, req)
+}
+
+// The parameters reach the same matcher implementation the query component
+// does, so a pattern matcher works identically in a request body.
+func TestEventsQuerySubscribeURLPattern(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+	ctx := t.Context()
+
+	go func() {
+		s := hub.transport.(*LocalTransport)
+
+		var ready bool
+
+		for !ready {
+			s.RLock()
+			ready = s.subscribers.Len() == 1
+			s.RUnlock()
+		}
+
+		_ = hub.transport.Dispatch(ctx, &Update{
+			Topics: []string{"https://example.com/books/1"},
+			Event:  Event{Data: "Hello World", ID: "b"},
+		})
+	}()
+
+	reqCtx, cancel := context.WithCancel(t.Context())
+	req := eventsQueryRequest(reqCtx, url.Values{
+		"match_urlpattern": {"https://example.com/books/:id"},
+		"events":           {""},
+	}.Encode())
+
+	w := &responseTester{
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\nid: b\ndata: Hello World\n\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+	hub.SubscribeHandler(w, req)
+}
+
+// A subscription naming no topic is refused the same way a subscription URL
+// without a match parameter is.
+func TestEventsQuerySubscribeWithoutTopics(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	w := newSubscribeRecorder()
+	hub.SubscribeHandler(w, eventsQueryRequest(t.Context(), "events="))
+
+	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+}
+
+// eventsQueryRequest builds a subscription request carrying the given body.
+func eventsQueryRequest(ctx context.Context, body string) *http.Request {
+	req := httptest.NewRequest(methodQuery, defaultHubURL, strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", urlEncodedMediaType)
+
+	return req
+}
+
+// A subscription resuming from a cursor in its parameters is answered with
+// the Mercure-Last-Event-Id field the protocol requires.
+func TestEventsQuerySubscribeLastEventID(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	reqCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req := eventsQueryRequest(reqCtx, url.Values{
+		paramMatch:      {"https://example.com/books/1"},
+		"events":        {""},
+		"last_event_id": {"urn:uuid:0198c1f2-3f4a-7000-8000-9abcdef01234"},
+	}.Encode())
+
+	w := &responseTester{
+		header:             http.Header{},
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+	hub.SubscribeHandler(w, req)
+
+	assert.Equal(t, EarliestLastEventID, w.Header().Get("Mercure-Last-Event-ID"))
+}
+
+// A malformed body is a bad request: the type is declared and understood, but
+// the content does not match it (RFC 10008, Section 2.3).
+func TestEventsQuerySubscribeRejectsMalformedBody(t *testing.T) {
+	t.Parallel()
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+
+	w := httptest.NewRecorder()
+	hub.SubscribeHandler(w, eventsQueryRequest(t.Context(), "match=%zz"))
+
+	resp := w.Result()
+
+	t.Cleanup(func() { assert.NoError(t, resp.Body.Close()) })
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1,12 +1,15 @@
 package mercure
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1513,17 +1516,15 @@ func TestEventsQuerySubscribeContentType(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	req := eventsQueryRequest(ctx, `{"url": ["https://example.com/books/1"], "events": {}}`)
 
-	w := &responseTester{
-		header:             http.Header{},
-		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\n",
-		tb:                 t,
-		cancel:             cancel,
-	}
+	// The delimiter that opens the stream is enough to know it started.
+	w := newEventsQueryTester(1, cancel)
 
 	hub.SubscribeHandler(w, req)
 
-	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+	mediaType, params, err := mime.ParseMediaType(w.Header().Get("Content-Type"))
+	require.NoError(t, err)
+	assert.Equal(t, multipartDigestContentType, mediaType)
+	assert.NotEmpty(t, params["boundary"], "every connection is framed by its own boundary")
 }
 
 // A subscription is answered with the media types a QUERY body can express it
@@ -1559,13 +1560,8 @@ func TestEventsQuerySubscribeAcceptQuery(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	req := eventsQueryRequest(ctx, `{"url": ["https://example.com/foo"], "events": {}}`)
 
-	w := &responseTester{
-		header:             http.Header{},
-		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\n",
-		tb:                 t,
-		cancel:             cancel,
-	}
+	// The delimiter that opens the stream is enough to know it started.
+	w := newEventsQueryTester(1, cancel)
 
 	hub.SubscribeHandler(w, req)
 
@@ -1625,13 +1621,11 @@ func TestEventsQuerySubscribe(t *testing.T) {
 	reqCtx, cancel := context.WithCancel(t.Context())
 	req := eventsQueryRequest(reqCtx, `{"url": ["https://example.com/books/1"], "events": {}}`)
 
-	w := &responseTester{
-		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\nid: b\ndata: Hello World\n\n",
-		tb:                 t,
-		cancel:             cancel,
-	}
+	// One delimiter opens the stream, the next closes the notification.
+	w := newEventsQueryTester(2, cancel)
 	hub.SubscribeHandler(w, req)
+
+	assertNotification(t, w, "b", "Hello World")
 }
 
 // The parameters reach the same matcher implementation the query component
@@ -1663,13 +1657,11 @@ func TestEventsQuerySubscribeURLPattern(t *testing.T) {
 	req := eventsQueryRequest(reqCtx,
 		`{"url": {"match_urlpattern": ["https://example.com/books/:id"]}, "events": {}}`)
 
-	w := &responseTester{
-		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\nid: b\ndata: Hello World\n\n",
-		tb:                 t,
-		cancel:             cancel,
-	}
+	// One delimiter opens the stream, the next closes the notification.
+	w := newEventsQueryTester(2, cancel)
 	hub.SubscribeHandler(w, req)
+
+	assertNotification(t, w, "b", "Hello World")
 }
 
 // A subscription naming no topic is refused the same way a subscription URL
@@ -1707,13 +1699,8 @@ func TestEventsQuerySubscribeLastEventID(t *testing.T) {
 	req := eventsQueryRequest(reqCtx,
 		`{"url": ["https://example.com/books/1"], "events": {}, "last_event_id": "urn:uuid:0198c1f2-3f4a-7000-8000-9abcdef01234"}`)
 
-	w := &responseTester{
-		header:             http.Header{},
-		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\n",
-		tb:                 t,
-		cancel:             cancel,
-	}
+	// The delimiter that opens the stream is enough to know it started.
+	w := newEventsQueryTester(1, cancel)
 	hub.SubscribeHandler(w, req)
 
 	assert.Equal(t, EarliestLastEventID, w.Header().Get("Mercure-Last-Event-ID"))
@@ -1899,7 +1886,10 @@ func TestEventsQuerySubscribeStopsAfterTheRequestedDuration(t *testing.T) {
 	}
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, ":\n", w.Body.String())
+	// The stream carried no notification and the hub closed it itself, so it
+	// is a preamble followed by the close-delimiter.
+	assert.True(t, strings.HasSuffix(w.Body.String(), "--\r\n"),
+		"the stream must end with the close-delimiter, got %q", w.Body.String())
 	assert.Equal(t, "duration=1", w.Header().Get("Events"))
 }
 
@@ -1910,3 +1900,80 @@ type writeDeadlineRecorder struct {
 }
 
 func (writeDeadlineRecorder) SetWriteDeadline(time.Time) error { return nil }
+
+// assertNotification reads back the one notification a stream carries, by the
+// length its message declares rather than the delimiter.
+func assertNotification(t *testing.T, w *eventsQueryTester, id, data string) {
+	t.Helper()
+
+	_, params, err := mime.ParseMediaType(w.Header().Get("Content-Type"))
+	require.NoError(t, err)
+	require.NotEmpty(t, params["boundary"])
+
+	// Close the body so the parser sees a complete multipart message: the hub
+	// writes the trailer only when it ends the response itself.
+	r := multipart.NewReader(strings.NewReader(w.String()+"--\r\n"), params["boundary"])
+
+	part, err := r.NextPart()
+	require.NoError(t, err)
+	assert.Empty(t, part.Header.Get("Content-Type"), "a notification takes the carrier's default")
+
+	header, body := readNotification(t, bufio.NewReader(part))
+	assert.Equal(t, data, body)
+	assert.Equal(t, id, header.Get("Event-ID"))
+
+	// Topics never reach a subscriber, over either carrier.
+	assert.Empty(t, header.Get("Topic"))
+}
+
+// eventsQueryTester collects a notifications stream, ending the request once
+// it has seen the delimiter that many times. Unlike responseTester it cannot
+// match against an expected body: the boundary is random per connection, so
+// the response is only knowable once parsed.
+type eventsQueryTester struct {
+	mu       sync.Mutex
+	body     strings.Builder
+	boundary string
+	// wanted is the number of delimiters to wait for before cancelling.
+	wanted int
+	cancel context.CancelFunc
+	header http.Header
+}
+
+func newEventsQueryTester(wanted int, cancel context.CancelFunc) *eventsQueryTester {
+	return &eventsQueryTester{wanted: wanted, cancel: cancel, header: http.Header{}}
+}
+
+func (t *eventsQueryTester) Header() http.Header { return t.header }
+
+func (t *eventsQueryTester) WriteHeader(int) {}
+
+func (t *eventsQueryTester) Flush() {}
+
+func (t *eventsQueryTester) SetWriteDeadline(_ time.Time) error { return nil }
+
+func (t *eventsQueryTester) Write(buf []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.body.Write(buf)
+
+	if t.boundary == "" {
+		if _, params, err := mime.ParseMediaType(t.header.Get("Content-Type")); err == nil {
+			t.boundary = params["boundary"]
+		}
+	}
+
+	if t.boundary != "" && strings.Count(t.body.String(), "--"+t.boundary) >= t.wanted {
+		t.cancel()
+	}
+
+	return len(buf), nil
+}
+
+func (t *eventsQueryTester) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.body.String()
+}

--- a/update.go
+++ b/update.go
@@ -42,12 +42,6 @@ func (u *Update) LogValue() slog.Value {
 	return slog.GroupValue(attrs...)
 }
 
-type serializedUpdate struct {
-	*Update
-
-	event string
-}
-
 // AssignUUID generates a new UUID an assign it to the given update if no ID is already set.
 func (u *Update) AssignUUID() {
 	if u.ID == "" {
@@ -66,8 +60,4 @@ func (u *Update) SpanAttributes() []attribute.KeyValue {
 		attribute.StringSlice("mercure.topics", u.Topics),
 		attribute.Bool("mercure.private", u.Private),
 	)
-}
-
-func newSerializedUpdate(u *Update) *serializedUpdate {
-	return &serializedUpdate{u, u.String()}
 }

--- a/update.go
+++ b/update.go
@@ -22,6 +22,12 @@ type Update struct {
 	// Private updates can only be dispatched to subscribers authorized to receive them.
 	Private bool
 
+	// The media type of Data, as declared by the publisher. Conveyed to
+	// subscribers when the negotiated response encoding can carry per-event
+	// metadata; text/event-stream defines no field for it. omitempty keeps
+	// history entries persisted before this field existed decodable.
+	ContentType string `json:",omitempty"`
+
 	// To print debug information
 	Debug bool
 }


### PR DESCRIPTION
A more detailed and (hopefully) instructive Events Query implementation.

AI (Claude Opus 5) has been used to develop this code. I have checked verified all changes/additions to the code, but have not verified all the tests.

The implementation proceeds in three stages:
1. Refactor of code without changing baseline functionality. I have made one or two changes by copying code from Kevin's PR.
2. Implementation of Events Query using existing form-encoded format for subscriptions, header field and content negotiation.
3. Implementation of JSON parser and Multipart Digest encoder.

The only change to existing functionality are subtle fixes to Accept and Content-Type handling that is now consistent with RFC9110 and RFC10008 respectively. Otherwise existing functionality is essentially untouched. Events Query is operated under a flag as designed by Kevin and is off by default.

There are no docs in this PR; as it is this took a lot of time.
