### PR TITLE
ci: fix golangci-lint v2.13 findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - depguard
     - errcheck
     - exhaustruct
+    - exhaustruct_v5
     - forcetypeassert
     - gomodguard
     - intrange

--- a/caddy/mercure_deprecated_transport.go
+++ b/caddy/mercure_deprecated_transport.go
@@ -14,6 +14,7 @@ import (
 
 // Deprecated: use transports Caddy modules.
 var transports = caddy.NewUsagePool() //nolint:gochecknoglobals
+
 // Deprecated
 //
 //nolint:wrapcheck,ireturn,nilnil

--- a/publish.go
+++ b/publish.go
@@ -199,8 +199,7 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		status := http.StatusBadRequest
 
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			status = http.StatusRequestEntityTooLarge
 		}
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -235,8 +235,7 @@ func (h *Hub) registerSubscriber(ctx context.Context, w http.ResponseWriter, r *
 	if err != nil {
 		status := http.StatusBadRequest
 
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			status = http.StatusRequestEntityTooLarge
 		}
 


### PR DESCRIPTION
golangci-lint latest (v2.13.1) deprecated exhaustruct in favor of exhaustruct_v5; default:all enables both, so the disable list must name both. Also apply the new modernize errorsastype suggestion (errors.As -> errors.AsType) and a gofumpt blank-line fix in the caddy module.
