### PR TITLE
docs: eight corrections to the 1.0 documentation

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -163,7 +163,18 @@ The standalone non-Caddy binary is gone. It's been deprecated since Mercure 0.11
 
 Enabling it therefore weakens access-token validation, which is why the hub never turns it on by itself.
 
-Official binaries and Docker images ship with both tags, so you can run `protocol_version_compatibility 8` during the migration. A hub built without a tag rejects the corresponding 0.x behavior outright. Custom builds must pass the tags to `go build`.
+Official binaries and Docker images ship with both tags, so you can run `protocol_version_compatibility 8` during the migration. A hub built without a tag rejects the corresponding 0.x behavior outright.
+
+Custom builds must pass the tags to `go build`. With [`xcaddy`](https://github.com/caddyserver/xcaddy), that means `XCADDY_GO_BUILD_FLAGS`:
+
+```console
+# Custom build with compatibility mode
+XCADDY_GO_BUILD_FLAGS='-tags deprecated_topic,deprecated_claim' \
+  xcaddy build \
+  --with github.com/dunglas/mercure/caddy
+```
+
+See [Custom Caddy build](getting-started/installation.md#custom-caddy-build) for the Go toolchain requirement.
 
 #### Restore the removed Caddyfile directives
 

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -42,7 +42,7 @@ url.searchParams.append("match_urlpattern", "https://example.com/books/:id");
 - The exact-match parameter is `match` (explicit spelling: `match_exact`); the templated one is `match_urlpattern`, using [URL Pattern](https://urlpattern.spec.whatwg.org) syntax (`:id`, not `{id}`).
 - Parameter names are **case-sensitive**. Any other name under the `match` prefix is rejected with `400`, so typos fail loudly.
 - The `URI Template` matcher type is gone; it survives only on a hub built with `deprecated_topic` running `protocol_version_compatibility 8`. Rewrite templated topics as URL Patterns and string topics as exact topics.
-- The resumption cursor moves too: the `lastEventID` query parameter is now `last_event_id`. The `Last-Event-ID` request *header* is unchanged, so a client relying only on `EventSource`'s automatic reconnection needs no change — but one that seeds a cursor itself does, and a browser client has no choice but the query parameter. See [Reconnection and history](concepts/reconnection-and-history.md).
+- The resumption cursor moves too: the `lastEventID` query parameter is now `last_event_id`. The `Last-Event-ID` request _header_ is unchanged, so a client relying only on `EventSource`'s automatic reconnection needs no change — but one that seeds a cursor itself does, and a browser client has no choice but the query parameter. See [Reconnection and history](concepts/reconnection-and-history.md).
 
 ### Migrate your tokens
 
@@ -168,8 +168,8 @@ Enabling it therefore weakens access-token validation, which is why the hub neve
 
 The directive also accepts `7`, which is a **superset** of `8`: it restores everything `8` does, plus two behaviors deprecated in protocol version 7. Unlike the ones above, these two are not gated behind a build tag, so every build honors them:
 
-- the `Last-Event-ID` **query parameter** — the name in use *before* 0.14 renamed it `lastEventID`. Note what this does not cover: the hub never reads `lastEventID`, in any mode, so the name 0.x clients were told to adopt has no compatibility path and trips no log line;
-- publishing a *public* update to a topic the token grants no `publish` action on. Without `7` this is a `403 insufficient_scope`; grant the `*` topic instead.
+- the `Last-Event-ID` **query parameter** — the name in use _before_ 0.14 renamed it `lastEventID`. Note what this does not cover: the hub never reads `lastEventID`, in any mode, so the name 0.x clients were told to adopt has no compatibility path and trips no log line;
+- publishing a _public_ update to a topic the token grants no `publish` action on. Without `7` this is a `403 insufficient_scope`; grant the `*` topic instead.
 
 Prefer `8`. Reach for `7` only if you still run clients from before 0.14, and expect an `Unsupported:` log line naming the behavior when a request trips a relaxation you have not enabled.
 

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -163,6 +163,13 @@ The standalone non-Caddy binary is gone. It's been deprecated since Mercure 0.11
 
 Enabling it therefore weakens access-token validation, which is why the hub never turns it on by itself.
 
+The directive also accepts `7`, which is a **superset** of `8`: it restores everything `8` does, plus two behaviors deprecated in protocol version 7. Unlike the ones above, these two are not gated behind a build tag, so every build honors them:
+
+- the `Last-Event-ID` **query parameter**, renamed `last_event_id` in 0.14;
+- publishing a *public* update to a topic the token grants no `publish` action on. Without `7` this is a `403 insufficient_scope`; grant the `*` topic instead.
+
+Prefer `8`. Reach for `7` only if you still run clients from before 0.14, and expect an `Unsupported:` log line naming the behavior when a request trips a relaxation you have not enabled.
+
 Official binaries and Docker images ship with both tags, so you can run `protocol_version_compatibility 8` during the migration. A hub built without a tag rejects the corresponding 0.x behavior outright.
 
 Custom builds must pass the tags to `go build`. With [`xcaddy`](https://github.com/caddyserver/xcaddy), that means `XCADDY_GO_BUILD_FLAGS`:
@@ -271,7 +278,7 @@ The `Last-Event-ID` query parameter was renamed `last_event_id`. Update your cli
 
 Publishing public updates in topics not listed in `mercure.publish` was removed; use `["*"]` to keep the old behavior.
 
-A `protocol_version_compatibility 7` directive was added to ease the transition. It has since been removed in 1.0.
+A `protocol_version_compatibility 7` directive was added to ease the transition. It is still accepted in 1.0; see [Compatibility mode](#compatibility-mode).
 
 ### Mercure 0.13 upgrade notes
 

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -17,6 +17,7 @@ If you only run the hub and don't author clients or mint tokens, the upgrade is 
 | ------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | Matcher types             | URI Template, string, plus exploratory types                       | `exact` and `urlpattern` only                                                  |
 | Subscribe query parameter | `topic=<pattern>` (URI Template or string)                         | `match=<exact>` or `match_urlpattern=<pattern>` (case-sensitive)               |
+| Resumption parameter      | `lastEventID` (`Last-Event-ID` before 0.14)                        | `last_event_id` (the request header keeps its name)                            |
 | Templating language       | URI Templates ([RFC 6570](https://www.rfc-editor.org/rfc/rfc6570)) | URL Patterns ([WHATWG](https://urlpattern.spec.whatwg.org))                    |
 | Token                     | bespoke `mercure` JWT claim                                        | OAuth 2.0 access token: `typ: at+jwt`, `iss`, `aud`, `authorization_details`   |
 | Authorization             | `mercure.publish` / `mercure.subscribe` string arrays              | `authorization_details` entries with the Mercure `type` URI (see below)        |
@@ -41,6 +42,7 @@ url.searchParams.append("match_urlpattern", "https://example.com/books/:id");
 - The exact-match parameter is `match` (explicit spelling: `match_exact`); the templated one is `match_urlpattern`, using [URL Pattern](https://urlpattern.spec.whatwg.org) syntax (`:id`, not `{id}`).
 - Parameter names are **case-sensitive**. Any other name under the `match` prefix is rejected with `400`, so typos fail loudly.
 - The `URI Template` matcher type is gone; it survives only on a hub built with `deprecated_topic` running `protocol_version_compatibility 8`. Rewrite templated topics as URL Patterns and string topics as exact topics.
+- The resumption cursor moves too: the `lastEventID` query parameter is now `last_event_id`. The `Last-Event-ID` request *header* is unchanged, so a client relying only on `EventSource`'s automatic reconnection needs no change — but one that seeds a cursor itself does, and a browser client has no choice but the query parameter. See [Reconnection and history](concepts/reconnection-and-history.md).
 
 ### Migrate your tokens
 
@@ -125,6 +127,7 @@ Authorization failures now follow [RFC 6750](https://www.rfc-editor.org/rfc/rfc6
 - `"mercure": { "subscribe": [...] }` -> `authorization_details` with `actions: ["subscribe"]`
 - `mercureAuthorization` cookie -> `mercure_access_token`; `authorization=` query param -> `Authorization` header or cookie (no query parameter)
 - Hardcoded `subscriptions/{topic}/{subscriber}` paths -> add the `{match_type}` segment
+- `?lastEventID=` / `&lastEventID=` in subscriber URLs -> `last_event_id=`. Not covered by compatibility mode: `7` restores the pre-0.14 `Last-Event-ID` query parameter, not this one
 - `Last-Event-ID` read from a **response** -> `Mercure-Last-Event-ID` (the request header keeps its name; see [Reconnection and history](concepts/reconnection-and-history.md))
 
 - JSON-LD subscription documents (`application/ld+json`, `@context`) -> plain JSON served as `application/json`
@@ -165,7 +168,7 @@ Enabling it therefore weakens access-token validation, which is why the hub neve
 
 The directive also accepts `7`, which is a **superset** of `8`: it restores everything `8` does, plus two behaviors deprecated in protocol version 7. Unlike the ones above, these two are not gated behind a build tag, so every build honors them:
 
-- the `Last-Event-ID` **query parameter**, renamed `last_event_id` in 0.14;
+- the `Last-Event-ID` **query parameter** — the name in use *before* 0.14 renamed it `lastEventID`. Note what this does not cover: the hub never reads `lastEventID`, in any mode, so the name 0.x clients were told to adopt has no compatibility path and trips no log line;
 - publishing a *public* update to a topic the token grants no `publish` action on. Without `7` this is a `403 insufficient_scope`; grant the `*` topic instead.
 
 Prefer `8`. Reach for `7` only if you still run clients from before 0.14, and expect an `Unsupported:` log line naming the behavior when a request trips a relaxation you have not enabled.
@@ -274,7 +277,7 @@ The default development key changed from `!ChangeMe!` to `!ChangeThisMercureHubJ
 
 ### Mercure 0.14 upgrade notes
 
-The `Last-Event-ID` query parameter was renamed `last_event_id`. Update your clients.
+The `Last-Event-ID` query parameter was renamed `lastEventID`. Update your clients. (1.0 renamed it again, to `last_event_id`; see [Migrate your subscribers](#migrate-your-subscribers).)
 
 Publishing public updates in topics not listed in `mercure.publish` was removed; use `["*"]` to keep the old behavior.
 

--- a/docs/concepts/discovery.md
+++ b/docs/concepts/discovery.md
@@ -5,7 +5,7 @@ description: "How clients find the Mercure hub with a Link header and read its O
 
 # Discovery
 
-A client needs two things before it can subscribe to private updates: the **URL of the hub**, and the **authorization requirements** of that hub. Mercure exposes both through standard mechanisms, so a generic OAuth 2.0 client library can discover them without Mercure-specific code.
+A client needs three things before it can subscribe to private updates: the **URL of the hub**, the **canonical URL of the topic** it wants, and the **authorization requirements** of that hub. Mercure exposes all three through standard mechanisms, so a generic OAuth 2.0 client library can discover them without Mercure-specific code.
 
 ## Finding the hub
 
@@ -18,12 +18,34 @@ Host: example.com
 
 HTTP/2 200
 Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"
+Link: </books/42>; rel="self"
 Content-Type: application/json
 
 { "@id": "/books/42", "title": "..." }
 ```
 
 The client parses the header, takes the URL with `rel="mercure"`, appends its `match*` query parameters, and opens an `EventSource`. Reusing your existing API responses to carry the link keeps subscribers and publishers pointing at the same hub.
+
+## Finding the topic
+
+The same response says which topic to subscribe to. The publisher **may** include a second link, `rel="self"`, holding the canonical URL of the topic; when it is absent, the client falls back to the URL of the resource it just fetched:
+
+```javascript
+// Finding the topic
+const res = await fetch("https://example.com/books/42");
+const links = res.headers.get("Link");
+
+const hub = links.match(/<([^>]+)>;\s*rel="?mercure"?/)[1];
+const self = links.match(/<([^>]+)>;\s*rel="?self"?/)?.[1] ?? res.url;
+
+const url = new URL(hub);
+url.searchParams.append("match", new URL(self, res.url).toString());
+new EventSource(url);
+```
+
+This is what makes a subscriber generic: it never has to know how the publisher builds its topic URLs. It matters most when the resource URL and the topic are not the same string — a resource served under several representations (`/books/42.jsonld`, `/books/42.html`) can point every one of them at one canonical topic, or give each its own. The protocol allows either, as long as `rel="self"` says which; it is also how content negotiation works on the topic, since the hub cannot pick a representation on the subscriber's behalf.
+
+Publish on the topic the self link advertises, and use absolute URLs on both sides where you can; a relative value like `/books/42` is legal, but it then has to resolve the same way for the client that subscribes and for the hub that matches (see [`resource_identifier`](../deployment/configuration.md)).
 
 ## Protected resource metadata
 

--- a/docs/concepts/publishing.md
+++ b/docs/concepts/publishing.md
@@ -185,6 +185,8 @@ For stricter delivery guarantees (every state change reaches the hub even if the
 
 The Mercure protocol does not require an external hub. An application that already terminates HTTP/2 connections can speak the protocol directly: write SSE bytes to subscribers, validate JWTs, run matchers. This is unusual outside of frameworks that ship their own hub (FrankenPHP, for instance), but the spec allows it.
 
+Check which version of the protocol an embedded hub speaks before you rely on it. [FrankenPHP](https://frankenphp.dev) 1.12.7 embeds `github.com/dunglas/mercure v0.24.2`, so an application running its built-in hub — which includes anything built on the symfony-docker or API Platform distributions — is on 0.x and cannot opt into 1.0 by upgrading the PHP side. Reaching 1.0 there means either running a standalone hub next to the app, or building a custom binary with the 1.0 Caddy module (see [Custom Caddy build](../getting-started/installation.md#custom-caddy-build)).
+
 For everyone else, run the hub.
 
 ## Next steps for Mercure publishing

--- a/docs/concepts/publishing.md
+++ b/docs/concepts/publishing.md
@@ -185,8 +185,6 @@ For stricter delivery guarantees (every state change reaches the hub even if the
 
 The Mercure protocol does not require an external hub. An application that already terminates HTTP/2 connections can speak the protocol directly: write SSE bytes to subscribers, validate JWTs, run matchers. This is unusual outside of frameworks that ship their own hub (FrankenPHP, for instance), but the spec allows it.
 
-Check which version of the protocol an embedded hub speaks before you rely on it. [FrankenPHP](https://frankenphp.dev) 1.12.7 embeds `github.com/dunglas/mercure v0.24.2`, so an application running its built-in hub — which includes anything built on the symfony-docker or API Platform distributions — is on 0.x and cannot opt into 1.0 by upgrading the PHP side. Reaching 1.0 there means either running a standalone hub next to the app, or building a custom binary with the 1.0 Caddy module (see [Custom Caddy build](../getting-started/installation.md#custom-caddy-build)).
-
 For everyone else, run the hub.
 
 ## Next steps for Mercure publishing

--- a/docs/concepts/subscribing.md
+++ b/docs/concepts/subscribing.md
@@ -184,7 +184,7 @@ es.onmessage = (event) => {
 };
 ```
 
-JSON-LD's `@id` is the natural field because it is the topic URL itself, but any identifier works as long as every publisher of that topic sets it. Publishing a bare value with no identifier in it — a number, a status string — leaves a multi-topic subscriber unable to place the update.
+JSON-LD's [`@id`](https://www.w3.org/TR/json-ld11/#node-identifiers) is the natural field because it is the topic URL itself, but any identifier works as long as every publisher of that topic sets it. Publishing a bare value with no identifier in it — a number, a status string — leaves a multi-topic subscriber unable to place the update.
 
 For coarse routing, the publish `type` becomes the SSE `event` field, so a family of updates can be picked up with `addEventListener("<type>", ...)` instead. That is a label you choose, not the topic, and `mercure` is reserved for [subscription events](active-subscriptions.md).
 
@@ -202,7 +202,6 @@ Host: example.com
 200 OK
 Content-Type: application/ld+json
 Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"
-Link: </books/1>; rel="self"
 ```
 
 Subscribers that fetch the resource first can read the headers to find both the hub and the topic to subscribe to:
@@ -213,10 +212,9 @@ const res = await fetch("https://example.com/books/1");
 const links = res.headers.get("Link");
 
 const hub = links.match(/<([^>]+)>;\s*rel="?mercure"?/)[1];
-const self = links.match(/<([^>]+)>;\s*rel="?self"?/)?.[1] ?? res.url;
 
 const url = new URL(hub);
-url.searchParams.append("match", new URL(self, res.url).toString());
+url.searchParams.append("match", res.url);
 new EventSource(url);
 ```
 

--- a/docs/concepts/subscribing.md
+++ b/docs/concepts/subscribing.md
@@ -202,21 +202,21 @@ Host: example.com
 200 OK
 Content-Type: application/ld+json
 Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"
+Link: </books/1>; rel="self"
 ```
 
-Subscribers that fetch the resource first can read the header to find the hub:
+Subscribers that fetch the resource first can read the headers to find both the hub and the topic to subscribe to:
 
 ```javascript
 // Discovering the Mercure Hub via Link Header
 const res = await fetch("https://example.com/books/1");
-const link = res.headers.get("Link");
-const hub = link.match(/<([^>]+)>;\s*rel="?mercure"?/)[1];
+const links = res.headers.get("Link");
+
+const hub = links.match(/<([^>]+)>;\s*rel="?mercure"?/)[1];
+const self = links.match(/<([^>]+)>;\s*rel="?self"?/)?.[1] ?? res.url;
 
 const url = new URL(hub);
-url.searchParams.append(
-  "match",
-  res.headers.get("Content-Location") ?? res.url,
-);
+url.searchParams.append("match", new URL(self, res.url).toString());
 new EventSource(url);
 ```
 

--- a/docs/concepts/subscribing.md
+++ b/docs/concepts/subscribing.md
@@ -39,7 +39,7 @@ es.onerror = () => {
 A few things to know:
 
 - Browsers cap concurrent HTTP/1.1 requests per origin at 6. With HTTP/2 (the default everywhere on HTTPS) the cap is 100 streams negotiated with the server. **Use HTTP/2**: your hub already speaks it.
-- A single `EventSource` connection can carry as many topic subscriptions as you want by passing more `match*` parameters.
+- A single `EventSource` connection can carry as many topic subscriptions as you want by passing more `match*` parameters. The frames it delivers carry no topic field, so see [Telling which topic an update belongs to](#telling-which-topic-an-update-belongs-to) for how to route them.
 - `EventSource` does not let you set `Authorization` headers. For private subscriptions, use the [`__Secure-mercure_access_token` cookie](authorization.md#cookies-in-detail), or consume the stream with `fetch()` and an `Authorization` header when a cookie can't work (per-tab tokens, cross-domain hub).
 
 ### `fetch-event-source` for advanced cases
@@ -170,6 +170,26 @@ Fields:
 - `event`: the `type` field from the publish request, if any. Defaults to `message`. `EventSource` triggers `addEventListener("<type>", ...)` for non-default types.
 - `data`: whatever the publisher sent in `data`. Mercure does not interpret it; it's bytes you decided on (JSON, HTML, JSON Patch, plain text...).
 
+### Telling which topic an update belongs to
+
+There is no topic field in the frame, so the hub does not tell a subscriber which of its matchers an update arrived on. It could not say it unambiguously anyway: [several `match*` parameters are a logical OR](topics-and-matchers.md#combining-matchers) and one update can satisfy more than one of them, and an update published with [alternate topics](topics-and-matchers.md#alternate-topics) carries several topics to begin with.
+
+On a connection carrying more than one subscription, **the payload is the discriminator**. Publish something self-describing and route on it:
+
+```javascript
+// Telling which topic an update belongs to
+es.onmessage = (event) => {
+  const update = JSON.parse(event.data);
+  render(update["@id"], update);
+};
+```
+
+JSON-LD's `@id` is the natural field because it is the topic URL itself, but any identifier works as long as every publisher of that topic sets it. Publishing a bare value with no identifier in it — a number, a status string — leaves a multi-topic subscriber unable to place the update.
+
+For coarse routing, the publish `type` becomes the SSE `event` field, so a family of updates can be picked up with `addEventListener("<type>", ...)` instead. That is a label you choose, not the topic, and `mercure` is reserved for [subscription events](active-subscriptions.md).
+
+None of this applies to a connection with a single subscription: the topic is the one you passed in the single `match*` parameter.
+
 ## Discovering the Mercure hub via link header
 
 The publisher of a resource can advertise its hub via a `Link` header so clients don't need to hardcode it:
@@ -216,7 +236,7 @@ If you set `heartbeat 0s` to disable them, make sure nothing on the network path
 | Concurrent HTTP/1.1 connections per origin | 6 (browser-enforced)                       |
 | Concurrent connections to the hub          | Hardware-bound on OSS; tier-bound on Cloud |
 
-A single connection serves any number of topics: pass more `match*` parameters rather than opening more `EventSource` instances.
+A single connection serves any number of topics: pass more `match*` parameters rather than opening more `EventSource` instances, and [route the updates on their payload](#telling-which-topic-an-update-belongs-to).
 
 ## Next steps for Mercure subscribing
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -114,6 +114,19 @@ xcaddy build \
   --with github.com/dunglas/mercure/caddy
 ```
 
+**Build with Go 1.26 or later.** That is the `go` directive in `caddy/go.mod`. Older toolchains fail the build outright, which includes the `caddy:2.8-builder` image (Go 1.23).
+
+To keep accepting 0.x clients during a migration, the two [compatibility-mode](../UPGRADE.md#compatibility-mode) build tags have to be compiled in. `xcaddy` passes `XCADDY_GO_BUILD_FLAGS` through to `go build`:
+
+```console
+# Custom Caddy build with compatibility mode
+XCADDY_GO_BUILD_FLAGS='-tags deprecated_topic,deprecated_claim' \
+  xcaddy build \
+  --with github.com/dunglas/mercure/caddy
+```
+
+The official binaries and Docker images already ship both tags. The tags only make the 0.x behaviors *available*; the hub still needs `protocol_version_compatibility` in its Caddyfile to honor them.
+
 Or use the [Caddy download page](https://caddyserver.com/download?package=github.com%2Fdunglas%2Fmercure%2Fcaddy) to assemble a build in the browser.
 
 ## Embedding the Mercure hub in a Go binary

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -125,7 +125,7 @@ XCADDY_GO_BUILD_FLAGS='-tags deprecated_topic,deprecated_claim' \
   --with github.com/dunglas/mercure/caddy
 ```
 
-The official binaries and Docker images already ship both tags. The tags only make the 0.x behaviors *available*; the hub still needs `protocol_version_compatibility` in its Caddyfile to honor them.
+The official binaries and Docker images already ship both tags. The tags only make the 0.x behaviors _available_; the hub still needs `protocol_version_compatibility` in its Caddyfile to honor them.
 
 Or use the [Caddy download page](https://caddyserver.com/download?package=github.com%2Fdunglas%2Fmercure%2Fcaddy) to assemble a build in the browser.
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -96,6 +96,8 @@ The hub must respond with the right CORS headers (`cors_origins` listing the cal
 
 Technically yes: the protocol allows applications to deliver SSE directly. In practice, the only people doing this are framework authors who embed the hub inside their stack ([FrankenPHP](https://frankenphp.dev), for instance). For everyone else, run the hub.
 
+An embedded hub is pinned to whatever version of the Mercure module its host compiled in, which is not necessarily the current one: FrankenPHP 1.12.7 embeds `mercure v0.24.2`, so its built-in hub speaks 0.x. See [Embedded publishing](../concepts/publishing.md#embedded-publishing-no-external-hub).
+
 ## Does Mercure work with serverless?
 
 Yes, on the publisher side: a Lambda or Cloud Function can `POST` to the hub and exit. On the subscriber side, the hub is the long-lived process; your serverless functions don't have to keep connections open.


### PR DESCRIPTION
Eight corrections to the 1.0 documentation, found while migrating
[`api-platform/esa`](https://github.com/api-platform/esa) onto `v1.0.0-alpha.3` —
hub, Caddyfile, tokens, JS client and a Symfony/API Platform app. Seven commits, one
per finding except the two custom-build ones, which touch the same paragraphs. Each is
independent, so any one can be dropped without touching the rest.

Worth saying first: the 1.0 docs are good. `UPGRADE` is a real migration guide with a
find-and-replace checklist, and every breaking change we had reverse-engineered from
the Go and PHP sources was already documented there. What follows is the residue.

### 1. `docker run dunglas/mercure` gives you a 0.x hub

`latest` tracks the newest stable release and GoReleaser suppresses rolling tags on
prereleases, so `latest` and `v0.24.2` share a digest today (`sha256:916834e4…`) while
`v1.0.0-alpha.3` is another (`sha256:16485a0b…`). The quickstart says
`docker run dunglas/mercure`, then subscribes with `match=`, publishes with an `at+jwt`
token and points at `caddy mercure-token --dev`. All three fail against the hub the
page just started, with nothing indicating the version is the problem.

Pins `v1.0.0-alpha.3` on the pages that then exercise 1.0 (quickstart, installation,
GitHub Actions) and says why. Deployment pages, where the version is the reader's
choice, keep the untagged image; `deployment/docker`'s image-variants list states the
rolling-tag policy instead.

**The cost, stated plainly:** 12 literal `v1.0.0-alpha.3` strings in `docs/` — seven
image tags, three Go module versions, two in prose — and alpha.1 through alpha.3
shipped inside five days. Mitigated, not free: every prose mention says "until 1.0 is
stable" and `grep -rn 'v1.0.0-alpha.3' docs/` finds all twelve, so a bump is one `sed`.
Nothing cheaper exists today — Docker Hub carries no floating 1.0 tag (only the exact
`v1.0.0-alpha.N` and their per-arch variants; `.goreleaser.yml` suppresses the rolling
tags on prereleases on purpose) and Go rejects a prerelease prefix query
(`.../caddy@v1.0.0-alpha` is an "unknown revision", `@latest` resolves to `v0.24.2`).
Which puts the clean fix in the release config rather than this PR: one floating
prerelease tag, `:next` or `:v1.0.0-alpha`, is a line of `.goreleaser.yml` and the docs
could then name it once and never churn. If that is preferred, this commit can shrink
to its prose half, or drop entirely — it is first on the branch and nothing else needs
it.

### 2. `xcaddy` builds a 0.x hub, and the Go floor is unstated

`installation` shows `xcaddy build --with github.com/dunglas/mercure/caddy`. Unpinned,
Go resolves the module to its newest stable tag, which the module proxy reports as
`v0.24.2` (2026-06-01) — so the documented command silently builds a 0.x hub.
`caddy/go.mod` at `v1.0.0-alpha.3` also declares `go 1.26`, which is unstated;
`caddy:2.8-builder` ships Go 1.23 and fails outright.

### 3. No recipe for a compatibility-mode build

`UPGRADE` says "Custom builds must pass the tags to `go build`" but never shows how,
and nothing connects it to `xcaddy` — the build path `installation` recommends, whose
escape hatch is the non-obvious `XCADDY_GO_BUILD_FLAGS`. Adds the one-liner to both
pages, and notes that the tags only make the behaviors available: the Caddyfile still
needs `protocol_version_compatibility`.

### 4. `protocol_version_compatibility 7` was not removed in 1.0

The 0.14 upgrade notes state the directive "has since been removed in 1.0". It has not:

- `caddy/mercure.go` rejects the value only when `v != 7 && v != 8`, with the error
  "compatibility mode only supports protocol versions 7 and 8";
- `WithProtocolVersionCompatibility` accepts `case 7, 8`;
- `isBackwardCompatiblyEnabledWith` tests `version >= o.protocolVersionCompatibility`,
  so `7` restores every `8` behavior as well as its own.

Two behaviors are reachable only with `7`: the `Last-Event-ID` query parameter
(`subscribe.go`) and publishing a public update to a topic the token does not grant
`publish` on (`publish.go`). Neither lives in a `_deprecated.go` file, so both compile
into every build and cannot be excluded the way `deprecated_topic` and
`deprecated_claim` can — setting `7` to reach one of them relaxes more than an operator
may expect.

Corrects the claim and documents what `7` relaxes, while steering readers to `8`. If
the docs were stating the intended end state, the opposite fix applies — remove `7`
from the code — and this commit should be dropped in favor of that.

### 5. How a subscriber attributes an update to a topic is shown, never stated

Multiplexing many topics over one connection is the headline of 1.0, and "which topic
is this update for?" is the first question it raises. `concepts/subscribing` says twice
that one connection carries any number of subscriptions and documents the frame as
`id` / `event` / `data` — no topic field — then never closes the loop. The answer
appears only as an example on `use-cases/live-data`, where the discriminator happens to
sit in the payload; the FAQ does not cover it either.

States it next to the frame it concerns: the payload is the discriminator, JSON-LD
`@id` is the natural field, a payload carrying no identifier cannot be placed, and the
publish `type` is available for coarse routing. Also notes why the hub cannot supply
the topic itself — matchers OR together, and alternate topics make the attribution
ambiguous by design.

### 6. `rel="self"` is missing from `concepts/discovery`

The discovery page covers only `rel="mercure"`. It opens by saying a client needs two
things — the hub URL and the authorization requirements — and never mentions the third:
which topic to subscribe to. The spec devotes a section to it (Topic Discovery): "The
publisher **MAY** include one Link Header with `rel=self` (the self link header). It
**SHOULD** contain the canonical URL for the topic. If the link with `rel=self` is
omitted, the current URL of the resource **MAY** be used as a fallback", followed by
content-negotiation rules built entirely on that link. Documenting only `rel="mercure"`
reads as though 1.0 dropped it.

`concepts/subscribing` had the same gap from the other side: its discovery example
subscribed to `Content-Location ?? res.url`, which the spec's discovery section does
not mention. Both pages now read the self link with the spec's fallback.

### 7. An embedded hub is pinned to its host's Mercure version

`concepts/publishing` and the FAQ both point at FrankenPHP as *the* example of a
framework shipping its own hub, and neither says which protocol version that hub
speaks. FrankenPHP's `go.mod` on `main` pins `github.com/dunglas/mercure v0.24.2` as of
v1.12.7, so its embedded hub is 0.x — and that is the default way to run a Symfony or
API Platform app with an embedded hub, since symfony-docker and the API Platform
distribution both build on FrankenPHP. A reader who follows these pages onto 1.0 hits a
hub that rejects 1.0 matchers and tokens, and no amount of upgrading on the PHP side
changes it. Says so, and points at the two ways out.

### 8. The 1.0 section never says the resumption parameter was renamed

`lastEventID` became `last_event_id` in 1.0, and the 1.0 half of this page does not
mention it: not in "What changed at a glance", not in "Migrate your subscribers", and
not in the find-and-replace checklist, whose only `Last-Event-ID` entry is about the
**response** header. `spec/mercure.md`'s own migration table has the row —
`lastEventID` -> `last_event_id` — so the two documents disagree.

The one mention in this file sits under the historical **0.14** heading and names the
wrong source parameter: "The `Last-Event-ID` query parameter was renamed
`last_event_id`". 0.14 renamed it to `lastEventID` — "replace all occurrences of the
`Last-Event-ID` query parameter with `lastEventID`" (`0.x:docs/UPGRADE.md`), and the
0.x hub reads `query.Get("lastEventID")` (`0.x:subscribe.go`). `last_event_id` is the
1.0 name (`subscribe.go`, `retrieveLastEventID`). Under 1.0 there are four names and
four fates:

| Sent by the client | Under 1.0 |
| --- | --- |
| `last_event_id` query parameter | works |
| `Last-Event-ID` request header | works, name unchanged |
| `Last-Event-ID` query parameter | `protocol_version_compatibility 7` only, and logged either way |
| `lastEventID` query parameter | never read, in any mode, and never logged |

So the name every up-to-date 0.x client uses — the one 0.x's own upgrade note and
deprecation message told it to adopt — is the single one with no compatibility path and
no log line, while the older, already-deprecated name has both. A client
find-and-replaces on this page, finds nothing about `lastEventID`, ships, and stops
replaying silently. `symfony/mercure`'s Twig helper is exactly that client: it emits
`&lastEventID=` regardless of the configured protocol version, and its comment cites
this very 0.14 note. Filed separately.

Adds the table row, a subscriber bullet and a checklist entry; corrects the 0.14 note;
and corrects finding 4's own bullet, which had inherited the same mistake — the behavior
`7` restores is the *pre*-0.14 `Last-Event-ID` parameter, not `lastEventID`.

### Not in this PR

- **No Symfony or API Platform page in the 1.0 tree.** The biggest gap we found, but a
  page to write rather than a correction, so it is a separate PR.
- **`/spec` is labelled "v0.x (stable)" while serving the 1.0 text**, and
  `reference/protocol` sends every normative question to it, so a reader who trusts the
  selector either reads 1.0 semantics as 0.x or dismisses the page. The label does not
  come from this repository — there is no site or nav configuration here, and
  `spec/mercure.md`'s own `draft-dunglas-mercure-08` is correct (`0deb240` bumped it
  from 07 in the 1.0 spec pass) — so it is a mercure.rocks fix, flagged not patched.

### Verification

Every finding was checked against `main` at `abcdfb7`, not the rendered site, and the
code claims cite files in this repository. Re-checked live: the Docker Hub tag list and
the manifest digests for `latest`, `v0.24.2` and `v1.0.0-alpha.3`; `go list -m` for
`github.com/dunglas/mercure/caddy` at `@latest` and at the `@v1.0.0-alpha` prefix;
FrankenPHP's `go.mod` at `v1.12.7` and on `main`. Finding 8 was checked on both sides of
the rename — `0.x:docs/UPGRADE.md` and `0.x:subscribe.go` for the 0.14 name, `main`'s
`retrieveLastEventID` for the 1.0 one, and a grep of `main` confirming no code path
reads `lastEventID`.

Docs only — no code, no behavior change. Relative links and heading anchors across
`docs/` were checked to resolve. `prettier`, `markdownlint` and `textlint` have not been
run; their output will be applied on request.
