### PR TITLE
ci: regenerate values.schema.json for helm-values-schema-json v3.2.0

### DIFF
--- a/charts/mercure/values.schema.json
+++ b/charts/mercure/values.schema.json
@@ -107,7 +107,7 @@
     },
     "global": {
       "description": "Global values shared between all subcharts",
-      "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key.",
+      "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as this schema would otherwise not allow Helm's special 'global' values key.",
       "type": [
         "object",
         "null"


### PR DESCRIPTION
The `schema` check fails on `main` since https://github.com/dunglas/mercure/commit/dd4d9c2 bumped losisin/helm-values-schema-json-action to v3.2.0: the new release words the auto-added `global` `$comment` differently. This commits the regenerated file. Content change is that one comment string.