### PR TITLE
feat: expose authorized topics as "topics" SSE fields

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -159,6 +159,10 @@ The standalone non-Caddy binary is gone. It's been deprecated since Mercure 0.11
 
 ### Compatibility mode
 
+Setting `protocol_version_compatibility` to `7` or `8` omits the `topics` SSE fields from live
+and replayed updates, regardless of build tags. In modern mode, every update includes its
+authorized topics; see [What the hub sends](concepts/subscribing.md#what-the-hub-sends).
+
 0.x behaviors are gated behind two build tags, honored only with `protocol_version_compatibility 8`:
 
 - `deprecated_topic`: URI Template selectors in `topic=`, bare-string JWT matcher claims, the `/subscriptions/{topic}` routes. Canonical and alternate topics (repeated `topic=` publish fields) are a modern-mode feature, not gated by this tag; see [Alternate topics](concepts/topics-and-matchers.md#alternate-topics).

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -159,9 +159,10 @@ The standalone non-Caddy binary is gone. It's been deprecated since Mercure 0.11
 
 ### Compatibility mode
 
-Setting `protocol_version_compatibility` to `7` or `8` omits the `topics` SSE fields from live
-and replayed updates, regardless of build tags. In modern mode, every update includes its
-authorized topics; see [What the hub sends](concepts/subscribing.md#what-the-hub-sends).
+With `protocol_version_compatibility` set to `7` or `8`, subscriptions using only the legacy
+`topic` parameter omit the `topics` SSE fields. Requests containing `match` or `match_*`
+parameters include authorized topics even with compatibility enabled or when mixed with `topic`.
+This applies to live and replayed updates; see [What the hub sends](concepts/subscribing.md#what-the-hub-sends).
 
 0.x behaviors are gated behind two build tags, honored only with `protocol_version_compatibility 8`:
 

--- a/docs/concepts/subscribing.md
+++ b/docs/concepts/subscribing.md
@@ -188,9 +188,12 @@ Some libraries report unknown fields as errors or can be configured to terminate
 Ensure your parser accepts `topics` fields. The `eventsource-parser` unknown-field error callback
 alone is unsuitable: version 4.1.0 can discard unknown fields split across chunks.
 
-Setting [`protocol_version_compatibility`](../deployment/configuration.md) to `7` or `8` omits
-`topics` fields from both live and replayed updates. Clients using such a hub, or an older hub,
-must obtain topic information from the payload if needed.
+When [`protocol_version_compatibility`](../deployment/configuration.md) is set to `7` or `8`,
+only subscriptions using exclusively the legacy `topic` parameter omit `topics` fields.
+Requests containing `match` or `match_*` parameters receive them even with compatibility enabled,
+including requests that also contain `topic`. This applies to GET query parameters and QUERY
+body parameters, for both live and replayed updates. Legacy subscriptions and older hubs require
+topic information in the payload if needed.
 
 If your client is a plain `EventSource` and you need the topic, keep putting it in the payload
 on the publisher side.

--- a/docs/concepts/subscribing.md
+++ b/docs/concepts/subscribing.md
@@ -158,8 +158,9 @@ Each event is a standard SSE message:
 
 ```text
 # What the hub sends
-id: urn:uuid:e1ee88e2-532a-4d6f-ba70-f0f8bd584022
 event: message
+topic: https://example.com/books/1
+id: urn:uuid:e1ee88e2-532a-4d6f-ba70-f0f8bd584022
 data: {"status": "checked out"}
 
 ```
@@ -168,7 +169,33 @@ Fields:
 
 - `id`: a unique identifier the hub assigns to every update. Clients send it back in `Last-Event-ID` to resume after a disconnect. See [Reconnection and history](reconnection-and-history.md).
 - `event`: the `type` field from the publish request, if any. Defaults to `message`. `EventSource` triggers `addEventListener("<type>", ...)` for non-default types.
+- `topic`: one field per topic of the update that your subscription matched (and, for private updates, that your token authorizes). This is how you tell which concrete topic fired when you subscribe with a pattern such as `match_urlpattern=/books/:id`.
 - `data`: whatever the publisher sent in `data`. Mercure does not interpret it; it's bytes you decided on (JSON, HTML, JSON Patch, plain text...).
+
+`topic` is a Mercure extension to the SSE format. The native `EventSource` API cannot expose it
+(it only surfaces `data`, the event type, and `lastEventId`), and spec-compliant parsers ignore
+it, so it never breaks existing subscribers. To read it, consume the stream with a parser that
+surfaces unknown fields, such as [`eventsource-parser`](https://github.com/rexxars/eventsource-parser):
+
+```javascript
+// Reading topic fields with eventsource-parser
+import { createParser } from "eventsource-parser";
+
+let topics = [];
+const parser = createParser({
+  onEvent: (event) => {
+    console.log(topics, event.data);
+    topics = [];
+  },
+  onError: (err) => {
+    if (err.type === "unknown-field" && err.field === "topic")
+      topics.push(err.value);
+  },
+});
+```
+
+If your client is a plain `EventSource` and you need the topic, keep putting it in the payload
+on the publisher side.
 
 ## Discovering the Mercure hub via link header
 

--- a/docs/concepts/subscribing.md
+++ b/docs/concepts/subscribing.md
@@ -159,7 +159,7 @@ Each event is a standard SSE message:
 ```text
 # What the hub sends
 event: message
-topic: https://example.com/books/1
+topics: https://example.com/books/1
 id: urn:uuid:e1ee88e2-532a-4d6f-ba70-f0f8bd584022
 data: {"status": "checked out"}
 
@@ -169,30 +169,28 @@ Fields:
 
 - `id`: a unique identifier the hub assigns to every update. Clients send it back in `Last-Event-ID` to resume after a disconnect. See [Reconnection and history](reconnection-and-history.md).
 - `event`: the `type` field from the publish request, if any. Defaults to `message`. `EventSource` triggers `addEventListener("<type>", ...)` for non-default types.
-- `topic`: one field per topic of the update that your subscription matched (and, for private updates, that your token authorizes). This is how you tell which concrete topic fired when you subscribe with a pattern such as `match_urlpattern=/books/:id`.
+- `topics`: one field per topic of a public update, or per topic your token authorizes for a private update. Every update includes at least one. Fields preserve publication order after authorization filtering; the first topic is canonical only if the canonical topic is included.
 - `data`: whatever the publisher sent in `data`. Mercure does not interpret it; it's bytes you decided on (JSON, HTML, JSON Patch, plain text...).
 
-`topic` is a Mercure extension to the SSE format. The native `EventSource` API cannot expose it
-(it only surfaces `data`, the event type, and `lastEventId`), and spec-compliant parsers ignore
-it, so it never breaks existing subscribers. To read it, consume the stream with a parser that
-surfaces unknown fields, such as [`eventsource-parser`](https://github.com/rexxars/eventsource-parser):
+Topics need not match your subscription's routing pattern. For example, you can subscribe to
+`https://example.com/books/:id` while your token authorizes only `https://example.com/users/42/*`.
+A private update with topics `https://example.com/books/1` and
+`https://example.com/users/42/books/1` is delivered with
+`topics: https://example.com/users/42/books/1`.
 
-```javascript
-// Reading topic fields with eventsource-parser
-import { createParser } from "eventsource-parser";
+`topics` is a Mercure extension to the SSE format. Native browser `EventSource` ignores these
+fields and continues to receive events. To read them, use a parser that preserves repeated
+extension fields across network chunks. Collect the `topics` values for each event block in
+order, clear them at every blank-line block boundary, and discard pending values when the
+connection ends. Each new connection starts with an empty list.
 
-let topics = [];
-const parser = createParser({
-  onEvent: (event) => {
-    console.log(topics, event.data);
-    topics = [];
-  },
-  onError: (err) => {
-    if (err.type === "unknown-field" && err.field === "topic")
-      topics.push(err.value);
-  },
-});
-```
+Some libraries report unknown fields as errors or can be configured to terminate on them.
+Ensure your parser accepts `topics` fields. The `eventsource-parser` unknown-field error callback
+alone is unsuitable: version 4.1.0 can discard unknown fields split across chunks.
+
+Setting [`protocol_version_compatibility`](../deployment/configuration.md) to `7` or `8` omits
+`topics` fields from both live and replayed updates. Clients using such a hub, or an older hub,
+must obtain topic information from the payload if needed.
 
 If your client is a plain `EventSource` and you need the topic, keep putting it in the payload
 on the publisher side.

--- a/event.go
+++ b/event.go
@@ -29,11 +29,7 @@ func (e *Event) String() string {
 	return e.serialize(nil)
 }
 
-// serialize is the "text/event-stream" representation of the event, carrying
-// one "topic" field per given topic. Compliant SSE parsers ignore fields with
-// unrecognized names, so the extra fields are invisible to subscribers not
-// expecting them. Topic values are constrained at publication (no control
-// characters), so writing them raw cannot inject SSE fields.
+// serialize relies on publication validation to prevent topic values from injecting SSE fields.
 func (e *Event) serialize(topics []string) string {
 	var b strings.Builder
 
@@ -46,7 +42,7 @@ func (e *Event) serialize(topics []string) string {
 	}
 
 	for _, t := range topics {
-		_, _ = fmt.Fprintf(&b, "topic: %s\n", t)
+		_, _ = fmt.Fprintf(&b, "topics: %s\n", t)
 	}
 
 	_, _ = fmt.Fprintf(&b, "id: %s\ndata: %s\n\n", e.ID, dataReplacer.Replace(e.Data))

--- a/event.go
+++ b/event.go
@@ -26,6 +26,15 @@ type Event struct {
 
 // String serializes the event in a "text/event-stream" representation.
 func (e *Event) String() string {
+	return e.serialize(nil)
+}
+
+// serialize is the "text/event-stream" representation of the event, carrying
+// one "topic" field per given topic. Compliant SSE parsers ignore fields with
+// unrecognized names, so the extra fields are invisible to subscribers not
+// expecting them. Topic values are constrained at publication (no control
+// characters), so writing them raw cannot inject SSE fields.
+func (e *Event) serialize(topics []string) string {
 	var b strings.Builder
 
 	if e.Type != "" {
@@ -34,6 +43,10 @@ func (e *Event) String() string {
 
 	if e.Retry != 0 {
 		_, _ = fmt.Fprintf(&b, "retry: %d\n", e.Retry)
+	}
+
+	for _, t := range topics {
+		_, _ = fmt.Fprintf(&b, "topic: %s\n", t)
 	}
 
 	_, _ = fmt.Fprintf(&b, "id: %s\ndata: %s\n\n", e.ID, dataReplacer.Replace(e.Data))

--- a/event_test.go
+++ b/event_test.go
@@ -37,7 +37,7 @@ func TestEncodeTopics(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"event: type\ntopic: https://example.com/books/1\ntopic: https://example.com/alt/1\nid: custom-id\ndata: data\n\n",
+		"event: type\ntopics: https://example.com/books/1\ntopics: https://example.com/alt/1\nid: custom-id\ndata: data\n\n",
 		e.serialize([]string{"https://example.com/books/1", "https://example.com/alt/1"}),
 	)
 }

--- a/event_test.go
+++ b/event_test.go
@@ -29,3 +29,15 @@ func TestEncodeNoRetry(t *testing.T) {
 
 	assert.Equal(t, "id: custom-id\ndata: data\n\n", e.String())
 }
+
+func TestEncodeTopics(t *testing.T) {
+	t.Parallel()
+
+	e := &Event{"data", "custom-id", "type", 0}
+
+	assert.Equal(
+		t,
+		"event: type\ntopic: https://example.com/books/1\ntopic: https://example.com/alt/1\nid: custom-id\ndata: data\n\n",
+		e.serialize([]string{"https://example.com/books/1", "https://example.com/alt/1"}),
+	)
+}

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -225,18 +225,33 @@ a partial update in formats such as JSON Patch [@RFC6902] or JSON Merge Patch [@
 All other properties defined in the Server-Sent Events specification **MAY** be used and **MUST**
 be supported by hubs.
 
-In addition to the fields defined in the Server-Sent Events specification, the hub **MUST** add
-one `topic` field per topic of the update that matches the subscriber's topic matchers and, if
-the update is private, for which the subscriber is authorized. The `topic` fields come before
-the `data` field, in the update's topic order (the canonical topic first). The `topic` field
-name is reserved for this purpose. Fields with unrecognized names are ignored by compliant
-Server-Sent Events parsers [@!HTML], so subscribers not expecting `topic` fields are unaffected.
-Topics of the update not satisfying the restriction above **MUST NOT** be emitted: an update can
-carry topics its recipient is not entitled to observe (see (#topic-disclosure)).
+In addition to the fields defined in the Server-Sent Events specification, each update the hub
+dispatches **MUST** contain at least one `topics` field. For a public update, the hub **MUST**
+include one `topics` field per topic of the update. For a private update, the hub **MUST** include
+one `topics` field per topic on which the subscriber's access token grants the `subscribe` action
+(see (#subscribers)), and **MUST NOT** include any other topic (see (#topic-disclosure)).
+The subscriber's routing matchers **MUST NOT** restrict this list: routing and authorization can
+match different topics of the same update. Private delivery already requires a grant on at
+least one topic, so the list is non-empty.
 
-The `EventSource` interface [@!HTML] exposes no field other than `data`, `event` and `id`.
-Subscribers needing `topic` fields have to consume the stream with a Server-Sent Events parser
-surfacing fields with unrecognized names.
+Each `topics` field value **MUST** equal the corresponding topic string of the update, without
+URL normalization or additional escaping. The hub **MUST** emit these fields before the first
+`data` field, preserving publication order after authorization filtering. The canonical topic
+is first only if included; the first received topic is not necessarily canonical.
+The `topics` field name is reserved for this purpose within the Mercure protocol.
+
+Subscribers processing this extension **MUST** maintain an ordered topic list for each event
+block, initially empty. They **MUST** parse field names and values according to the Server-Sent
+Events rules [@!HTML] and append the value of each `topics` field to the list, preserving repeated
+values. They **MUST** associate the list with the event dispatched for that block and clear it
+at every blank-line block boundary, including blocks that dispatch no event. They **MUST**
+discard pending topics at the end of a stream and start with an empty list on reconnection.
+Topic values **MUST NOT** carry over to a subsequent event or connection.
+
+Server-Sent Events parsers ignore fields with unrecognized names [@!HTML]. Native browser
+`EventSource` clients therefore continue to receive events but cannot access `topics` fields;
+their `MessageEvent` objects expose the SSE data, type, and identifier through `data`, `type`,
+and `lastEventId`. Subscribers needing topics must use a parser that supports this extension.
 
 The resource **MAY** be represented in a format with hypermedia capabilities such as
 JSON-LD [@W3C.REC-json-ld11-20200716], Atom [@RFC4287], XML [@W3C.REC-xml-20081126] or HTML
@@ -1696,14 +1711,14 @@ forged field, so this serialization is a security requirement, not only a format
 
 ## Topic Disclosure
 
-A private update is dispatched to every subscriber authorized for at least one of its topics, so
-a recipient is not necessarily subscribed to, nor authorized for, every topic the update
-carries. Emitting the update's full topic list in `topic` fields (see (#subscription)) would
-disclose the other topics: a subscriber matched through an alternate topic could learn a
-canonical topic embedding information it is not authorized for, such as another user's
-identifier. This is why (#subscription) requires hubs to filter the `topic` fields against each
-subscriber's matchers and authorization instead of writing one shared serialization of the
-update.
+A private update can be delivered when routing and authorization match different topics of the
+update (see (#subscribers)). Its recipient is not necessarily authorized for every topic it
+carries. Emitting the full topic list in `topics` fields (see (#subscription)) could disclose
+a canonical topic embedding information the recipient is not authorized for, such as another
+user's identifier. Hubs therefore filter these fields against the subscriber's `subscribe`
+grants. Authorized topics are included even when they do not match the routing matchers.
+Public updates disclose all their topics; publishers requiring topic confidentiality must use
+private updates and appropriately scoped grants.
 
 ## Reserved Hub Namespace
 

--- a/spec/mercure.md
+++ b/spec/mercure.md
@@ -225,6 +225,19 @@ a partial update in formats such as JSON Patch [@RFC6902] or JSON Merge Patch [@
 All other properties defined in the Server-Sent Events specification **MAY** be used and **MUST**
 be supported by hubs.
 
+In addition to the fields defined in the Server-Sent Events specification, the hub **MUST** add
+one `topic` field per topic of the update that matches the subscriber's topic matchers and, if
+the update is private, for which the subscriber is authorized. The `topic` fields come before
+the `data` field, in the update's topic order (the canonical topic first). The `topic` field
+name is reserved for this purpose. Fields with unrecognized names are ignored by compliant
+Server-Sent Events parsers [@!HTML], so subscribers not expecting `topic` fields are unaffected.
+Topics of the update not satisfying the restriction above **MUST NOT** be emitted: an update can
+carry topics its recipient is not entitled to observe (see (#topic-disclosure)).
+
+The `EventSource` interface [@!HTML] exposes no field other than `data`, `event` and `id`.
+Subscribers needing `topic` fields have to consume the stream with a Server-Sent Events parser
+surfacing fields with unrecognized names.
+
 The resource **MAY** be represented in a format with hypermedia capabilities such as
 JSON-LD [@W3C.REC-json-ld11-20200716], Atom [@RFC4287], XML [@W3C.REC-xml-20081126] or HTML
 [@!HTML].
@@ -1680,6 +1693,17 @@ it is not constrained the same way, so the hub **MUST** serialize it as one `dat
 line (see (#publication)) rather than emitting the raw value. A hub that writes the value
 without this line-splitting would let a `data` value containing `\nevent:` or `\nid:` inject a
 forged field, so this serialization is a security requirement, not only a formatting one.
+
+## Topic Disclosure
+
+A private update is dispatched to every subscriber authorized for at least one of its topics, so
+a recipient is not necessarily subscribed to, nor authorized for, every topic the update
+carries. Emitting the update's full topic list in `topic` fields (see (#subscription)) would
+disclose the other topics: a subscriber matched through an alternate topic could learn a
+canonical topic embedding information it is not authorized for, such as another user's
+identifier. This is why (#subscription) requires hubs to filter the `topic` fields against each
+subscriber's matchers and authorization instead of writing one shared serialization of the
+update.
 
 ## Reserved Hub Namespace
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -10,6 +10,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -129,6 +130,11 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Modern matchers opt this connection into topic metadata even on a compatibility hub.
+	includeTopics := slices.ContainsFunc(s.SubscribedMatchers, func(m TopicMatcher) bool {
+		return m.Type != deprecatedMatcherTypeName
+	})
+
 	ctx = context.WithValue(ctx, SubscriberContextKey, &s.Subscriber)
 
 	defer h.shutdown(ctx, s)
@@ -211,7 +217,7 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 			}
 
 			var topics []string
-			if h.protocolVersionCompatibility == 0 {
+			if includeTopics {
 				topics = update.Topics
 				// Delivery already proves authorization for a single-topic update.
 				if update.Private && len(topics) > 1 {

--- a/subscribe.go
+++ b/subscribe.go
@@ -206,7 +206,21 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 			// Cleanly close the HTTP connection before the write deadline to prevent client-side errors
 			return
 		case update, ok := <-s.Receive():
-			if !ok || !h.write(ctx, rc, newSerializedUpdate(update).event) {
+			if !ok {
+				return
+			}
+
+			// Transports only dispatch updates the subscriber matches, so for a
+			// single-topic update — the common case — that one topic is already
+			// proven subscribed and, if private, authorized: skip the per-topic
+			// re-match that multi-topic updates need (their audience is the
+			// union of their topics' audiences, see MatchedTopics).
+			topics := update.Topics
+			if len(topics) > 1 {
+				topics = s.MatchedTopics(update)
+			}
+
+			if !h.write(ctx, rc, update.serialize(topics)) {
 				return
 			}
 

--- a/subscribe.go
+++ b/subscribe.go
@@ -210,14 +210,13 @@ func (h *Hub) SubscribeHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			// Transports only dispatch updates the subscriber matches, so for a
-			// single-topic update — the common case — that one topic is already
-			// proven subscribed and, if private, authorized: skip the per-topic
-			// re-match that multi-topic updates need (their audience is the
-			// union of their topics' audiences, see MatchedTopics).
-			topics := update.Topics
-			if len(topics) > 1 {
-				topics = s.MatchedTopics(update)
+			var topics []string
+			if h.protocolVersionCompatibility == 0 {
+				topics = update.Topics
+				// Delivery already proves authorization for a single-topic update.
+				if update.Private && len(topics) > 1 {
+					topics = s.AuthorizedTopics(update)
+				}
 			}
 
 			if !h.write(ctx, rc, update.serialize(topics)) {

--- a/subscribe_deprecated_test.go
+++ b/subscribe_deprecated_test.go
@@ -4,9 +4,11 @@ package mercure
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 )
 
 // TestSubscribeDeprecatedTopicParam covers the v8 end-to-end flow: a
@@ -45,4 +47,31 @@ func TestSubscribeDeprecatedTopicParam(t *testing.T) {
 	}
 
 	hub.SubscribeHandler(w, req)
+}
+
+func TestSubscribeTopicsLegacyRequests(t *testing.T) {
+	t.Parallel()
+
+	requests := map[string]topicFieldsRequest{
+		"legacy":            {method: http.MethodGet, query: "topic=https://example.com/books/{id}"},
+		"legacy_query_body": {method: methodQuery, body: "topic=https://example.com/books/{id}"},
+		// The modern matcher opts in even when only the legacy matcher selects the update.
+		"mixed":            {method: http.MethodGet, query: "topic=https://example.com/books/{id}&match=https://example.com/other", wantTopics: true},
+		"mixed_query_body": {method: methodQuery, query: "topic=https://example.com/books/{id}", body: "match_urlpattern=https://example.com/other/:id", wantTopics: true},
+	}
+	for name, request := range requests {
+		for _, compatibility := range []int{7, 8} {
+			for _, private := range []bool{false, true} {
+				for _, replay := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%s/compatibility=%d/private=%t/replay=%t", name, compatibility, private, replay), func(t *testing.T) {
+						t.Parallel()
+
+						synctest.Test(t, func(t *testing.T) {
+							testSubscribeTopics(t, compatibility, private, replay, request)
+						})
+					})
+				}
+			}
+		}
+	}
 }

--- a/subscribe_deprecated_test.go
+++ b/subscribe_deprecated_test.go
@@ -39,7 +39,7 @@ func TestSubscribeDeprecatedTopicParam(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\nid: a\ndata: Hello World\n\n",
+		expectedBody:       ":\ntopic: https://example.com/books/1\nid: a\ndata: Hello World\n\n",
 		tb:                 t,
 		cancel:             cancel,
 	}

--- a/subscribe_deprecated_test.go
+++ b/subscribe_deprecated_test.go
@@ -39,7 +39,7 @@ func TestSubscribeDeprecatedTopicParam(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\ntopic: https://example.com/books/1\nid: a\ndata: Hello World\n\n",
+		expectedBody:       ":\nid: a\ndata: Hello World\n\n",
 		tb:                 t,
 		cancel:             cancel,
 	}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -466,7 +466,7 @@ func TestSubscribeQueryMethod(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\ntopic: https://example.com/books/1\nid: b\ndata: Hello World\n\n",
+		expectedBody:       ":\ntopics: https://example.com/books/1\nid: b\ndata: Hello World\n\n",
 		tb:                 t,
 		cancel:             cancel,
 	}
@@ -521,7 +521,7 @@ func subscribe(tb testing.TB, numberOfSubscribers int) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/books/1\nid: b\ndata: Hello World\n\ntopic: https://example.com/reviews/22\nid: c\ndata: Great\n\ntopic: https://example.com/hub?topic=faulty{iri\nid: d\ndata: Faulty IRI\n\ntopic: string\nid: e\ndata: string\n\n",
+				expectedBody:       ":\ntopics: https://example.com/books/1\nid: b\ndata: Hello World\n\ntopics: https://example.com/reviews/22\nid: c\ndata: Great\n\ntopics: https://example.com/hub?topic=faulty{iri\nid: d\ndata: Faulty IRI\n\ntopics: string\nid: e\ndata: string\n\n",
 				tb:                 tb,
 				cancel:             cancel,
 			}
@@ -701,7 +701,7 @@ func TestSubscribePrivate(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\nevent: test\ntopic: https://example.com/reviews/22\nid: b\ndata: Hello World\n\nretry: 1\ntopic: https://example.com/reviews/23\nid: c\ndata: Great\n\n",
+		expectedBody:       ":\nevent: test\ntopics: https://example.com/reviews/22\nid: b\ndata: Hello World\n\nretry: 1\ntopics: https://example.com/reviews/23\nid: c\ndata: Great\n\n",
 		tb:                 t,
 		cancel:             cancel,
 	}
@@ -862,7 +862,7 @@ func TestSubscribeAll(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\ntopic: https://example.com/reviews/21\nid: a\ndata: Foo\n\nevent: test\ntopic: https://example.com/reviews/22\nid: b\ndata: Hello World\n\n",
+		expectedBody:       ":\ntopics: https://example.com/reviews/21\nid: a\ndata: Foo\n\nevent: test\ntopics: https://example.com/reviews/22\nid: b\ndata: Hello World\n\n",
 		tb:                 t,
 		cancel:             cancel,
 	}
@@ -897,7 +897,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -911,7 +911,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -926,7 +926,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -964,7 +964,7 @@ func TestSendAllEvents(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/a\nid: a\ndata: d1\n\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/a\nid: a\ndata: d1\n\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -980,7 +980,7 @@ func TestSendAllEvents(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/a\nid: a\ndata: d1\n\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/a\nid: a\ndata: d1\n\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1014,7 +1014,7 @@ func TestUnknownLastEventID(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1033,7 +1033,7 @@ func TestUnknownLastEventID(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1093,7 +1093,7 @@ func TestUnknownLastEventIDDoesNotLeakPrivateEventID(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/c\nid: c\ndata: d3\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/c\nid: c\ndata: d3\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1145,7 +1145,7 @@ func TestUnknownLastEventIDEmptyHistory(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1162,7 +1162,7 @@ func TestUnknownLastEventIDEmptyHistory(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1209,7 +1209,7 @@ func TestEmptyLastEventIDGetsResponseHeader(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\ntopic: https://example.com/foo\nid: e1\ndata: d\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foo\nid: e1\ndata: d\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1266,7 +1266,7 @@ func TestSubscribeHeartbeat(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\ntopic: https://example.com/books/1\nid: b\ndata: Hello World\n\n:\n",
+		expectedBody:       ":\ntopics: https://example.com/books/1\nid: b\ndata: Hello World\n\n:\n",
 		tb:                 t,
 		cancel:             cancel,
 	}
@@ -1520,47 +1520,88 @@ func TestSubscriptionEventReachesTheSubscriberItDescribes(t *testing.T) {
 	}), "the subscriber was not told about its own subscription")
 }
 
-// A subscriber matched through an alternate topic must not learn the other
-// topics a private update carries: only topics it is both subscribed to and
-// authorized for are exposed as "topic" SSE fields.
-func TestSubscribeTopicFieldsFilteredPerSubscriber(t *testing.T) {
+func TestSubscribeTopics(t *testing.T) {
 	t.Parallel()
 
-	hub := createDummy(t)
-	s, _ := hub.transport.(*LocalTransport)
-	ctx := t.Context()
+	for _, compatibility := range []int{0, 7, 8} {
+		for _, private := range []bool{false, true} {
+			for _, replay := range []bool{false, true} {
+				t.Run(fmt.Sprintf("compatibility=%d/private=%t/replay=%t", compatibility, private, replay), func(t *testing.T) {
+					t.Parallel()
 
-	go func() {
-		for {
-			s.RLock()
-			empty := s.subscribers.Len() == 0
-			s.RUnlock()
-
-			if empty {
-				continue
+					synctest.Test(t, func(t *testing.T) {
+						testSubscribeTopics(t, compatibility, private, replay)
+					})
+				})
 			}
-
-			_ = hub.transport.Dispatch(ctx, &Update{
-				Topics: []string{"https://example.com/users/123/books/1", "https://example.com/books/1"},
-				Data:   "Foo", ID: "a",
-				Private: true,
-			})
-
-			return
 		}
-	}()
+	}
+}
 
-	ctx, cancel := context.WithCancel(t.Context())
-	// The subscription pattern matches both topics; the token authorizes only the alternate.
-	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match_urlpattern=https://example.com/*", nil).WithContext(ctx)
-	req.AddCookie(&http.Cookie{Name: defaultCookieName, Value: createDummyAuthorizedJWT(roleSubscriber, []string{"https://example.com/books/1"})})
+func testSubscribeTopics(t *testing.T, compatibility int, private, replay bool) {
+	t.Helper()
 
-	w := &responseTester{
-		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\ntopic: https://example.com/books/1\nid: a\ndata: Foo\n\n",
-		tb:                 t,
-		cancel:             cancel,
+	var transport Transport = NewLocalTransport(NewSubscriberList(0))
+	if replay {
+		transport = createBoltTransport(t, 0, 0)
 	}
 
-	hub.SubscribeHandler(w, req)
+	options := []Option{WithTransport(transport)}
+	if compatibility != 0 {
+		options = append(options, WithProtocolVersionCompatibility(compatibility))
+	}
+
+	hub := createDummy(t, options...)
+
+	update := &Update{
+		Topics: []string{
+			"https://example.com/books/1",
+			"https://example.com/users/42/books/1",
+			"https://example.com/users/7/books/1",
+			"https://example.com/users/42/inbox/1",
+		},
+		Data: "Foo", ID: "a", Private: private,
+	}
+	if replay {
+		require.NoError(t, transport.Dispatch(t.Context(), update))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Routing selects the canonical topic; authorization selects only alternates.
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match_urlpattern=https://example.com/books/:id", nil).WithContext(ctx)
+	req.Header.Set("Authorization", bearerPrefix+createDummySubscriberJWTWithDetails(t, nil,
+		TopicMatcher{Type: MatcherTypeURLPattern, Pattern: "https://example.com/users/42/*"}))
+
+	if replay {
+		req.Header.Set("Last-Event-ID", EarliestLastEventID)
+	}
+
+	w := newSubscribeRecorder()
+
+	go hub.SubscribeHandler(w, req)
+
+	synctest.Wait()
+
+	if !replay {
+		require.NoError(t, transport.Dispatch(t.Context(), update))
+		synctest.Wait()
+	}
+
+	cancel()
+	synctest.Wait()
+
+	var fields string
+
+	if compatibility == 0 {
+		if private {
+			fields = "topics: https://example.com/users/42/books/1\ntopics: https://example.com/users/42/inbox/1\n"
+		} else {
+			fields = "topics: https://example.com/books/1\ntopics: https://example.com/users/42/books/1\ntopics: https://example.com/users/7/books/1\ntopics: https://example.com/users/42/inbox/1\n"
+		}
+	}
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, fields+"id: a\ndata: Foo\n\n", w.Body.String())
 }

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -466,7 +466,7 @@ func TestSubscribeQueryMethod(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\nid: b\ndata: Hello World\n\n",
+		expectedBody:       ":\ntopic: https://example.com/books/1\nid: b\ndata: Hello World\n\n",
 		tb:                 t,
 		cancel:             cancel,
 	}
@@ -521,7 +521,7 @@ func subscribe(tb testing.TB, numberOfSubscribers int) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: Hello World\n\nid: c\ndata: Great\n\nid: d\ndata: Faulty IRI\n\nid: e\ndata: string\n\n",
+				expectedBody:       ":\ntopic: https://example.com/books/1\nid: b\ndata: Hello World\n\ntopic: https://example.com/reviews/22\nid: c\ndata: Great\n\ntopic: https://example.com/hub?topic=faulty{iri\nid: d\ndata: Faulty IRI\n\ntopic: string\nid: e\ndata: string\n\n",
 				tb:                 tb,
 				cancel:             cancel,
 			}
@@ -701,7 +701,7 @@ func TestSubscribePrivate(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\nevent: test\nid: b\ndata: Hello World\n\nretry: 1\nid: c\ndata: Great\n\n",
+		expectedBody:       ":\nevent: test\ntopic: https://example.com/reviews/22\nid: b\ndata: Hello World\n\nretry: 1\ntopic: https://example.com/reviews/23\nid: c\ndata: Great\n\n",
 		tb:                 t,
 		cancel:             cancel,
 	}
@@ -862,7 +862,7 @@ func TestSubscribeAll(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\nid: a\ndata: Foo\n\nevent: test\nid: b\ndata: Hello World\n\n",
+		expectedBody:       ":\ntopic: https://example.com/reviews/21\nid: a\ndata: Foo\n\nevent: test\ntopic: https://example.com/reviews/22\nid: b\ndata: Hello World\n\n",
 		tb:                 t,
 		cancel:             cancel,
 	}
@@ -897,7 +897,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -911,7 +911,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -926,7 +926,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -964,7 +964,7 @@ func TestSendAllEvents(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: a\ndata: d1\n\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/a\nid: a\ndata: d1\n\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -980,7 +980,7 @@ func TestSendAllEvents(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: a\ndata: d1\n\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/a\nid: a\ndata: d1\n\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1014,7 +1014,7 @@ func TestUnknownLastEventID(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1033,7 +1033,7 @@ func TestUnknownLastEventID(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1093,7 +1093,7 @@ func TestUnknownLastEventIDDoesNotLeakPrivateEventID(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: c\ndata: d3\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/c\nid: c\ndata: d3\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1145,7 +1145,7 @@ func TestUnknownLastEventIDEmptyHistory(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1162,7 +1162,7 @@ func TestUnknownLastEventIDEmptyHistory(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1209,7 +1209,7 @@ func TestEmptyLastEventIDGetsResponseHeader(t *testing.T) {
 			w := &responseTester{
 				header:             http.Header{},
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: e1\ndata: d\n\n",
+				expectedBody:       ":\ntopic: https://example.com/foo\nid: e1\ndata: d\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1266,7 +1266,7 @@ func TestSubscribeHeartbeat(t *testing.T) {
 
 	w := &responseTester{
 		expectedStatusCode: http.StatusOK,
-		expectedBody:       ":\nid: b\ndata: Hello World\n\n:\n",
+		expectedBody:       ":\ntopic: https://example.com/books/1\nid: b\ndata: Hello World\n\n:\n",
 		tb:                 t,
 		cancel:             cancel,
 	}
@@ -1518,4 +1518,49 @@ func TestSubscriptionEventReachesTheSubscriberItDescribes(t *testing.T) {
 	assert.True(t, slices.ContainsFunc(subs, func(sub subscription) bool {
 		return sub.Active && sub.Match == "/.well-known/mercure/subscriptions/:mt/:m/:s"
 	}), "the subscriber was not told about its own subscription")
+}
+
+// A subscriber matched through an alternate topic must not learn the other
+// topics a private update carries: only topics it is both subscribed to and
+// authorized for are exposed as "topic" SSE fields.
+func TestSubscribeTopicFieldsFilteredPerSubscriber(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t)
+	s, _ := hub.transport.(*LocalTransport)
+	ctx := t.Context()
+
+	go func() {
+		for {
+			s.RLock()
+			empty := s.subscribers.Len() == 0
+			s.RUnlock()
+
+			if empty {
+				continue
+			}
+
+			_ = hub.transport.Dispatch(ctx, &Update{
+				Topics: []string{"https://example.com/users/123/books/1", "https://example.com/books/1"},
+				Data:   "Foo", ID: "a",
+				Private: true,
+			})
+
+			return
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	// The subscription pattern matches both topics; the token authorizes only the alternate.
+	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match_urlpattern=https://example.com/*", nil).WithContext(ctx)
+	req.AddCookie(&http.Cookie{Name: defaultCookieName, Value: createDummyAuthorizedJWT(roleSubscriber, []string{"https://example.com/books/1"})})
+
+	w := &responseTester{
+		expectedStatusCode: http.StatusOK,
+		expectedBody:       ":\ntopic: https://example.com/books/1\nid: a\ndata: Foo\n\n",
+		tb:                 t,
+		cancel:             cancel,
+	}
+
+	hub.SubscribeHandler(w, req)
 }

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -897,7 +897,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -911,7 +911,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -926,7 +926,7 @@ func TestSendMissedEvents(t *testing.T) {
 
 			w := &responseTester{
 				expectedStatusCode: http.StatusOK,
-				expectedBody:       ":\nid: b\ndata: d2\n\n",
+				expectedBody:       ":\ntopics: https://example.com/foos/b\nid: b\ndata: d2\n\n",
 				tb:                 t,
 				cancel:             cancel,
 			}
@@ -1520,25 +1520,37 @@ func TestSubscriptionEventReachesTheSubscriberItDescribes(t *testing.T) {
 	}), "the subscriber was not told about its own subscription")
 }
 
+type topicFieldsRequest struct {
+	method, query, body string
+	wantTopics          bool
+}
+
 func TestSubscribeTopics(t *testing.T) {
 	t.Parallel()
 
-	for _, compatibility := range []int{0, 7, 8} {
-		for _, private := range []bool{false, true} {
-			for _, replay := range []bool{false, true} {
-				t.Run(fmt.Sprintf("compatibility=%d/private=%t/replay=%t", compatibility, private, replay), func(t *testing.T) {
-					t.Parallel()
+	requests := map[string]topicFieldsRequest{
+		"exact":      {method: http.MethodGet, query: "match=https://example.com/books/1", wantTopics: true},
+		"urlpattern": {method: http.MethodGet, query: "match_urlpattern=https://example.com/books/:id", wantTopics: true},
+		"query_body": {method: methodQuery, body: "match=https://example.com/books/1", wantTopics: true},
+	}
+	for name, request := range requests {
+		for _, compatibility := range []int{0, 7, 8} {
+			for _, private := range []bool{false, true} {
+				for _, replay := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%s/compatibility=%d/private=%t/replay=%t", name, compatibility, private, replay), func(t *testing.T) {
+						t.Parallel()
 
-					synctest.Test(t, func(t *testing.T) {
-						testSubscribeTopics(t, compatibility, private, replay)
+						synctest.Test(t, func(t *testing.T) {
+							testSubscribeTopics(t, compatibility, private, replay, request)
+						})
 					})
-				})
+				}
 			}
 		}
 	}
 }
 
-func testSubscribeTopics(t *testing.T, compatibility int, private, replay bool) {
+func testSubscribeTopics(t *testing.T, compatibility int, private, replay bool, request topicFieldsRequest) {
 	t.Helper()
 
 	var transport Transport = NewLocalTransport(NewSubscriberList(0))
@@ -1570,7 +1582,8 @@ func testSubscribeTopics(t *testing.T, compatibility int, private, replay bool) 
 	defer cancel()
 
 	// Routing selects the canonical topic; authorization selects only alternates.
-	req := httptest.NewRequest(http.MethodGet, defaultHubURL+"?match_urlpattern=https://example.com/books/:id", nil).WithContext(ctx)
+	req := httptest.NewRequest(request.method, defaultHubURL+"?"+request.query, strings.NewReader(request.body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Authorization", bearerPrefix+createDummySubscriberJWTWithDetails(t, nil,
 		TopicMatcher{Type: MatcherTypeURLPattern, Pattern: "https://example.com/users/42/*"}))
 
@@ -1594,7 +1607,7 @@ func testSubscribeTopics(t *testing.T, compatibility int, private, replay bool) 
 
 	var fields string
 
-	if compatibility == 0 {
+	if request.wantTopics {
 		if private {
 			fields = "topics: https://example.com/users/42/books/1\ntopics: https://example.com/users/42/inbox/1\n"
 		} else {

--- a/subscriber.go
+++ b/subscriber.go
@@ -60,6 +60,31 @@ func (s *Subscriber) Match(u *Update) bool {
 	return s.MatchTopics(u.Topics, u.Private)
 }
 
+// MatchedTopics returns the topics of the update the subscriber could receive
+// the update on individually, in the update's order (canonical topic first).
+// A private update is dispatched to any subscriber authorized for at least one
+// of its topics, so a recipient is not necessarily subscribed to, nor
+// authorized for, every topic the update carries: exposing an unmatched topic
+// (in "topic" SSE fields, notably) would disclose it.
+func (s *Subscriber) MatchedTopics(u *Update) []string {
+	var matched []string
+
+	for i := range u.Topics {
+		topic := u.Topics[i : i+1 : i+1]
+		if !s.matchesAny(topic, s.SubscribedMatchers) {
+			continue
+		}
+
+		if u.Private && !s.matchesAny(topic, s.AllowedPrivateMatchers) {
+			continue
+		}
+
+		matched = append(matched, u.Topics[i])
+	}
+
+	return matched
+}
+
 func (s *Subscriber) LogValue() slog.Value {
 	attrs := []slog.Attr{
 		slog.String("id", s.ID),

--- a/subscriber.go
+++ b/subscriber.go
@@ -60,29 +60,24 @@ func (s *Subscriber) Match(u *Update) bool {
 	return s.MatchTopics(u.Topics, u.Private)
 }
 
-// MatchedTopics returns the topics of the update the subscriber could receive
-// the update on individually, in the update's order (canonical topic first).
-// A private update is dispatched to any subscriber authorized for at least one
-// of its topics, so a recipient is not necessarily subscribed to, nor
-// authorized for, every topic the update carries: exposing an unmatched topic
-// (in "topic" SSE fields, notably) would disclose it.
-func (s *Subscriber) MatchedTopics(u *Update) []string {
-	var matched []string
+// AuthorizedTopics returns the update's authorized topics in publication order.
+func (s *Subscriber) AuthorizedTopics(u *Update) []string {
+	if !u.Private {
+		return u.Topics
+	}
+
+	var authorized []string
 
 	for i := range u.Topics {
 		topic := u.Topics[i : i+1 : i+1]
-		if !s.matchesAny(topic, s.SubscribedMatchers) {
+		if !s.matchesAny(topic, s.AllowedPrivateMatchers) {
 			continue
 		}
 
-		if u.Private && !s.matchesAny(topic, s.AllowedPrivateMatchers) {
-			continue
-		}
-
-		matched = append(matched, u.Topics[i])
+		authorized = append(authorized, u.Topics[i])
 	}
 
-	return matched
+	return authorized
 }
 
 func (s *Subscriber) LogValue() slog.Value {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -104,3 +104,41 @@ func TestSubscriberDoesNotBlockWhenChanIsFull(t *testing.T) {
 	for range s.Receive() { //nolint:revive
 	}
 }
+
+func TestMatchedTopics(t *testing.T) {
+	t.Parallel()
+
+	tms, err := NewTopicMatcherStore(0)
+	require.NoError(t, err)
+
+	s := NewLocalSubscriber("", slog.Default(), tms)
+	s.setMatchers([]TopicMatcher{
+		{Type: MatcherTypeURLPattern, Pattern: "https://example.com/books/:id"},
+		{Type: MatcherTypeExact, Pattern: "https://example.com/alt/1"},
+	}, []TopicMatcher{
+		{Type: MatcherTypeExact, Pattern: "https://example.com/alt/1"},
+	})
+
+	// Public update: subscribed topics only, in the update's order.
+	assert.Equal(
+		t,
+		[]string{"https://example.com/books/1", "https://example.com/alt/1"},
+		s.MatchedTopics(&Update{Topics: []string{
+			"https://example.com/books/1",
+			"https://example.com/not-subscribed",
+			"https://example.com/alt/1",
+		}}),
+	)
+
+	// Private update: a subscribed but unauthorized topic must not be exposed.
+	assert.Equal(
+		t,
+		[]string{"https://example.com/alt/1"},
+		s.MatchedTopics(&Update{
+			Topics:  []string{"https://example.com/books/1", "https://example.com/alt/1"},
+			Private: true,
+		}),
+	)
+
+	assert.Empty(t, s.MatchedTopics(&Update{Topics: []string{"https://example.com/not-subscribed"}}))
+}

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -105,7 +105,7 @@ func TestSubscriberDoesNotBlockWhenChanIsFull(t *testing.T) {
 	}
 }
 
-func TestMatchedTopics(t *testing.T) {
+func TestAuthorizedTopics(t *testing.T) {
 	t.Parallel()
 
 	tms, err := NewTopicMatcherStore(0)
@@ -114,31 +114,30 @@ func TestMatchedTopics(t *testing.T) {
 	s := NewLocalSubscriber("", slog.Default(), tms)
 	s.setMatchers([]TopicMatcher{
 		{Type: MatcherTypeURLPattern, Pattern: "https://example.com/books/:id"},
-		{Type: MatcherTypeExact, Pattern: "https://example.com/alt/1"},
 	}, []TopicMatcher{
 		{Type: MatcherTypeExact, Pattern: "https://example.com/alt/1"},
 	})
 
-	// Public update: subscribed topics only, in the update's order.
 	assert.Equal(
 		t,
-		[]string{"https://example.com/books/1", "https://example.com/alt/1"},
-		s.MatchedTopics(&Update{Topics: []string{
+		[]string{"https://example.com/books/1", "https://example.com/not-subscribed", "https://example.com/alt/1"},
+		s.AuthorizedTopics(&Update{Topics: []string{
 			"https://example.com/books/1",
 			"https://example.com/not-subscribed",
 			"https://example.com/alt/1",
 		}}),
 	)
 
-	// Private update: a subscribed but unauthorized topic must not be exposed.
+	u := &Update{
+		Topics:  []string{"https://example.com/books/1", "https://example.com/alt/1"},
+		Private: true,
+	}
+	require.True(t, s.Match(u))
 	assert.Equal(
 		t,
 		[]string{"https://example.com/alt/1"},
-		s.MatchedTopics(&Update{
-			Topics:  []string{"https://example.com/books/1", "https://example.com/alt/1"},
-			Private: true,
-		}),
+		s.AuthorizedTopics(u),
 	)
 
-	assert.Empty(t, s.MatchedTopics(&Update{Topics: []string{"https://example.com/not-subscribed"}}))
+	assert.Empty(t, s.AuthorizedTopics(&Update{Topics: []string{"https://example.com/not-authorized"}, Private: true}))
 }

--- a/update.go
+++ b/update.go
@@ -42,12 +42,6 @@ func (u *Update) LogValue() slog.Value {
 	return slog.GroupValue(attrs...)
 }
 
-type serializedUpdate struct {
-	*Update
-
-	event string
-}
-
 // AssignUUID generates a new UUID an assign it to the given update if no ID is already set.
 func (u *Update) AssignUUID() {
 	if u.ID == "" {
@@ -66,8 +60,4 @@ func (u *Update) SpanAttributes() []attribute.KeyValue {
 		attribute.StringSlice("mercure.topics", u.Topics),
 		attribute.Bool("mercure.private", u.Private),
 	)
-}
-
-func newSerializedUpdate(u *Update) *serializedUpdate {
-	return &serializedUpdate{u, u.String()}
 }


### PR DESCRIPTION
Subscribers using pattern matchers cannot identify an update's concrete topics unless the publisher includes them in the payload. For subscriptions using `match` or `match_*` parameters, the hub emits one `topics` SSE field per disclosed topic, before `data`.

- Public updates include all their topics.
- Private updates include every topic on which the subscriber's token grants the `subscribe` action. Unauthorized topics are excluded.
- Routing matchers do not filter the emitted list. A subscriber routing through a canonical topic and authorized through an alternate receives the authorized alternate. Every update delivered to a modern subscription therefore includes at least one `topics` field.
- With `protocol_version_compatibility` set to `7` or `8`, only subscriptions using exclusively the legacy `topic` parameter omit these fields. Requests containing `match` or `match_*` parameters receive them even with compatibility enabled, including requests that mix modern and legacy parameters. This applies to GET query parameters and QUERY body parameters, for both live and replayed updates.

Fields preserve publication order after authorization filtering. The first emitted topic is canonical only if the canonical topic is included. The specification requires the fields and defines accumulation of repeated values, clearing at event-block boundaries, and discarding pending topics on disconnection. The security considerations explain why private updates must not disclose unauthorized topic names.

Native browser `EventSource` ignores the extra fields and continues receiving events. Clients needing topics must use a parser that preserves repeated extension fields across network chunks and resets their state between events and connections. The docs cover libraries that report unknown fields as errors and the limitation of using `eventsource-parser` 4.1.0's unknown-field callback.

Each emitted topic adds its UTF-8 byte length plus 9 bytes to the stream. Existing publication validation excludes characters that could inject SSE fields. Single-topic updates reuse the transport's authorization decision; only private updates with multiple topics require per-topic filtering.

Hub and Caddy tests passed with the race detector. Regression coverage checks public and private updates, disjoint routing and authorization, GET and QUERY requests, and live delivery and replay in modern mode and compatibility versions 7 and 8. Legacy-only requests omit the fields; modern and mixed requests include them. Both Go lint configurations and `gopls` checks passed.
