### PR TITLE
feat: accept multipart/form-data publications carrying binary payloads

### DIFF
--- a/bolt_test.go
+++ b/bolt_test.go
@@ -455,3 +455,29 @@ func TestBoltTransportKnownLastEventIDIsEchoed(t *testing.T) {
 
 	s.Disconnect()
 }
+
+// Binary payloads survive the JSON persistence thanks to Update.MarshalJSON's
+// base64 encoding.
+func TestBoltTransportBinary(t *testing.T) {
+	t.Parallel()
+
+	transport := createBoltTransport(t, 0, 0)
+	topics := []string{"https://example.com/foo"}
+	binaryData := "\xff\x00PNG"
+
+	require.NoError(t, transport.Dispatch(t.Context(), &Update{
+		Event:       Event{ID: "1", Data: binaryData},
+		Topics:      topics,
+		Binary:      true,
+		ContentType: "image/png",
+	}))
+
+	s := NewLocalSubscriber(EarliestLastEventID, transport.logger, &TopicMatcherStore{})
+	s.setMatchers(stringsToExactMatchers(topics), stringsToExactMatchers(nil))
+	require.NoError(t, transport.AddSubscriber(t.Context(), s))
+
+	u := <-s.Receive()
+	assert.Equal(t, binaryData, u.Data)
+	assert.True(t, u.Binary)
+	assert.Equal(t, "image/png", u.ContentType)
+}

--- a/contenttype_test.go
+++ b/contenttype_test.go
@@ -1,9 +1,12 @@
 package mercure
 
 import (
+	"bytes"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"net/url"
 	"strings"
 	"testing"
@@ -117,4 +120,150 @@ func TestPublishHandlerInvalidContentType(t *testing.T) {
 	})
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// newMultipartPublishRequest builds a multipart/form-data publication: every
+// field value plus a data part carrying raw bytes and, optionally, an
+// explicit Content-Type header.
+func newMultipartPublishRequest(t *testing.T, fields url.Values, data []byte, dataContentType string) *http.Request {
+	t.Helper()
+
+	var body bytes.Buffer
+
+	mw := multipart.NewWriter(&body)
+
+	for name, values := range fields {
+		for _, v := range values {
+			require.NoError(t, mw.WriteField(name, v))
+		}
+	}
+
+	header := textproto.MIMEHeader{"Content-Disposition": {`form-data; name="data"`}}
+	if dataContentType != "" {
+		header.Set("Content-Type", dataContentType)
+	}
+
+	pw, err := mw.CreatePart(header)
+	require.NoError(t, err)
+
+	_, err = pw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+
+	req := httptest.NewRequest(http.MethodPost, defaultHubURL, &body)
+	req.Header.Add("Content-Type", mw.FormDataContentType())
+	req.Header.Add("Authorization", bearerPrefix+createDummyAuthorizedJWT(rolePublisher, []string{"*"}))
+
+	return req
+}
+
+func TestPublishHandlerMultipart(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t, WithEventsQuery())
+
+	// The subscriber is registered before the publication, so by the time
+	// PublishHandler returns the update sits in its buffered channel.
+	s := NewLocalSubscriber("", hub.logger, hub.topicMatcherStore)
+	s.SetMatchers([]TopicMatcher{{Type: MatcherTypeExact, Pattern: "https://example.com/books/1"}}, nil)
+	require.NoError(t, hub.transport.AddSubscriber(t.Context(), s))
+
+	binaryData := []byte{0x89, 'P', 'N', 'G', 0xff, 0x00, 0xfe}
+	form := url.Values{"topic": {"https://example.com/books/1"}}
+
+	req := newMultipartPublishRequest(t, form, binaryData, "image/png")
+
+	w := httptest.NewRecorder()
+	hub.PublishHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case dispatched := <-s.Receive():
+		assert.Equal(t, string(binaryData), dispatched.Data)
+		assert.Equal(t, "image/png", dispatched.ContentType)
+		assert.True(t, dispatched.Binary)
+	case <-time.After(5 * time.Second):
+		t.Fatal("update not received")
+	}
+}
+
+// The explicit content_type field wins over the data part's own header.
+func TestPublishHandlerMultipartContentTypeFieldPrecedence(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t, WithEventsQuery())
+
+	s := NewLocalSubscriber("", hub.logger, hub.topicMatcherStore)
+	s.SetMatchers([]TopicMatcher{{Type: MatcherTypeExact, Pattern: "https://example.com/books/1"}}, nil)
+	require.NoError(t, hub.transport.AddSubscriber(t.Context(), s))
+
+	form := url.Values{"topic": {"https://example.com/books/1"}, "content_type": {"application/ld+json"}}
+	req := newMultipartPublishRequest(t, form, []byte(`{}`), "application/json")
+
+	w := httptest.NewRecorder()
+	hub.PublishHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case dispatched := <-s.Receive():
+		assert.Equal(t, "application/ld+json", dispatched.ContentType)
+	case <-time.After(5 * time.Second):
+		t.Fatal("update not received")
+	}
+}
+
+func TestPublishHandlerMultipartInvalidContentType(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t, WithEventsQuery())
+
+	form := url.Values{"topic": {"https://example.com/books/1"}}
+	req := newMultipartPublishRequest(t, form, []byte("Hello World"), "not a media type")
+
+	w := httptest.NewRecorder()
+	hub.PublishHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// Multipart publication belongs to the experimental events query surface:
+// without the option the hub must not silently parse an empty form.
+func TestPublishHandlerMultipartDisabled(t *testing.T) {
+	t.Parallel()
+
+	hub := createDummy(t)
+
+	form := url.Values{"topic": {"https://example.com/books/1"}}
+	req := newMultipartPublishRequest(t, form, []byte("Hello World"), "text/plain")
+
+	w := httptest.NewRecorder()
+	hub.PublishHandler(w, req)
+
+	resp := w.Result()
+
+	t.Cleanup(func() {
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
 }

--- a/encoder_eventstream.go
+++ b/encoder_eventstream.go
@@ -1,5 +1,7 @@
 package mercure
 
+import "encoding/base64"
+
 // The media type a Server-Sent Events stream is served as.
 const eventStreamContentType = "text/event-stream"
 
@@ -16,7 +18,20 @@ func (eventStreamEncoder) contentType() []string { return []string{eventStreamCo
 // headers, so writing it is what sends them.
 func (eventStreamEncoder) preamble() string { return ":\n" }
 
-func (eventStreamEncoder) encode(u *Update) string { return u.String() }
+// Binary payloads are always base64-encoded, even when the bytes happen to
+// be valid UTF-8: an event stream is a text format with no per-event
+// metadata slot, so only a rule fixed at publication time lets subscribers
+// decode deterministically. The multipart framing delivers them verbatim.
+func (eventStreamEncoder) encode(u *Update) string {
+	if !u.Binary {
+		return u.String()
+	}
+
+	e := u.Event
+	e.Data = base64.StdEncoding.EncodeToString([]byte(e.Data))
+
+	return e.String()
+}
 
 // An SSE comment, to prevent issues with some proxies and old browsers.
 func (eventStreamEncoder) heartbeat() string { return ":\n" }

--- a/encoder_eventstream_test.go
+++ b/encoder_eventstream_test.go
@@ -105,3 +105,17 @@ func TestEventStreamEncoderStream(t *testing.T) {
 	// Every event is terminated, so a subscriber never waits on a partial one.
 	assert.True(t, strings.HasSuffix(stream, "\n\n"))
 }
+
+// Binary updates are base64-encoded on the event stream, unconditionally:
+// without a per-event metadata slot, only a rule fixed at publication time
+// lets subscribers decode deterministically.
+func TestEventStreamEncoderBinary(t *testing.T) {
+	t.Parallel()
+
+	payload := eventStreamEncoder{}.encode(&Update{Binary: true, Event: Event{ID: "i", Data: "\xff\x00PNG"}})
+	assert.Equal(t, "id: i\ndata: /wBQTkc=\n\n", payload)
+
+	// Valid UTF-8 is encoded too when the update is marked binary.
+	payload = eventStreamEncoder{}.encode(&Update{Binary: true, Event: Event{ID: "i", Data: "text"}})
+	assert.Equal(t, "id: i\ndata: dGV4dA==\n\n", payload)
+}

--- a/encoder_multipartdigest.go
+++ b/encoder_multipartdigest.go
@@ -67,7 +67,13 @@ func (e *multipartDigestEncoder) encode(u *Update) string {
 
 	contentType := u.ContentType
 	if contentType == "" {
-		contentType = updateDataContentType
+		// Without a declared media type, binary payloads are opaque bytes;
+		// the text default would misdeclare them.
+		if u.Binary {
+			contentType = "application/octet-stream"
+		} else {
+			contentType = updateDataContentType
+		}
 	}
 
 	m.WriteString("Content-Type: ")

--- a/encoder_multipartdigest_test.go
+++ b/encoder_multipartdigest_test.go
@@ -244,3 +244,23 @@ func newDigestEncoder(t *testing.T) *multipartDigestEncoder {
 
 	return e
 }
+
+// A binary payload travels verbatim: the message body is length-delimited,
+// and an undeclared media type is opaque bytes, not text.
+func TestMultipartDigestEncoderBinary(t *testing.T) {
+	t.Parallel()
+
+	e := newDigestEncoder(t)
+
+	const data = "\x89PNG\xff\x00\xfe"
+
+	header, body := encodedNotification(t, e,
+		e.encode(&Update{Binary: true, Event: Event{ID: "a", Data: data}}))
+	assert.Equal(t, data, body)
+	assert.Equal(t, "application/octet-stream", header.Get("Content-Type"))
+
+	header, body = encodedNotification(t, e,
+		e.encode(&Update{Binary: true, ContentType: "image/png", Event: Event{ID: "a", Data: data}}))
+	assert.Equal(t, data, body)
+	assert.Equal(t, "image/png", header.Get("Content-Type"))
+}

--- a/publish.go
+++ b/publish.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"log/slog"
 	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -108,9 +110,11 @@ func (u *Update) Validate() error {
 		return ErrReservedEventType
 	}
 
-	// The protocol requires field values to be valid UTF-8; ParseForm does not
-	// enforce it, so reject invalid data rather than dispatch it.
-	if !utf8.ValidString(u.Data) {
+	// The protocol requires urlencoded field values to be valid UTF-8;
+	// ParseForm does not enforce it, so reject invalid data rather than
+	// dispatch it. Binary updates (multipart publications) may carry any
+	// bytes: they are base64-encoded when serialized to text formats.
+	if !u.Binary && !utf8.ValidString(u.Data) {
 		return ErrInvalidData
 	}
 
@@ -207,20 +211,39 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 
 	h.limitRequestBody(w, r)
 
-	if err := r.ParseForm(); err != nil {
-		status := http.StatusBadRequest
+	var (
+		form            url.Values
+		partContentType string
+		binary          bool
+	)
 
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
-			status = http.StatusRequestEntityTooLarge
+	if mediaType, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); mediaType == "multipart/form-data" { //nolint:nestif
+		// Multipart publication is part of the experimental events query
+		// support: it exists to carry binary payloads, which only the
+		// multipart subscription encoding delivers verbatim.
+		if !h.eventsQuery {
+			http.Error(w, http.StatusText(http.StatusUnsupportedMediaType), http.StatusUnsupportedMediaType)
+
+			return
 		}
 
-		http.Error(w, http.StatusText(status), status)
+		var err error
+		if form, partContentType, err = parseMultipartPublication(r.Body, params["boundary"]); err != nil {
+			writeParseError(w, err)
+
+			return
+		}
+
+		binary = true
+	} else if err := r.ParseForm(); err != nil {
+		writeParseError(w, err)
 
 		return
+	} else {
+		form = r.PostForm
 	}
 
-	topics := r.PostForm["topic"]
+	topics := form["topic"]
 	if len(topics) == 0 {
 		http.Error(w, `Missing "topic" parameter`, http.StatusBadRequest)
 
@@ -252,7 +275,7 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 
 	var retry uint64
 
-	if retryString := r.PostForm.Get("retry"); retryString != "" {
+	if retryString := form.Get("retry"); retryString != "" {
 		var err error
 		if retry, err = strconv.ParseUint(retryString, 10, 64); err != nil {
 			http.Error(w, `Invalid "retry" parameter`, http.StatusBadRequest)
@@ -261,7 +284,7 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	private := len(r.PostForm["private"]) != 0
+	private := len(form["private"]) != 0
 	if claims != nil && !claims.authz.grantsAll(h.topicMatcherStore, actionPublish, topics) { //nolint:nestif
 		if private {
 			h.writeBearerError(w, r, bearerErrInsufficientScope, http.StatusForbidden)
@@ -285,12 +308,20 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// The explicit content_type field wins over the data part's own
+	// Content-Type header, present only in multipart publications.
+	contentType := form.Get("content_type")
+	if contentType == "" {
+		contentType = partContentType
+	}
+
 	u = &Update{
 		Topics:      topics,
 		Private:     private,
 		Debug:       h.debug,
-		ContentType: r.PostForm.Get("content_type"),
-		Event:       Event{r.PostForm.Get("data"), r.PostForm.Get("id"), r.PostForm.Get("type"), retry},
+		ContentType: contentType,
+		Binary:      binary,
+		Event:       Event{form.Get(fieldData), form.Get("id"), form.Get("type"), retry},
 	}
 
 	dispatchCtx := context.WithoutCancel(ctx)
@@ -326,5 +357,65 @@ func (h *Hub) PublishHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		return
+	}
+}
+
+// fieldData is the publish form field carrying the update payload.
+const fieldData = "data"
+
+// writeParseError maps a publication body parsing failure to its status:
+// 413 when the MaxBytesReader cap fired, 400 otherwise.
+func writeParseError(w http.ResponseWriter, err error) {
+	status := http.StatusBadRequest
+	if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+		status = http.StatusRequestEntityTooLarge
+	}
+
+	http.Error(w, http.StatusText(status), status)
+}
+
+// parseMultipartPublication reads a multipart/form-data publication body.
+// Fields parse exactly like their urlencoded counterparts, but the data
+// part keeps its raw bytes — the reason this encoding exists: urlencoded
+// field values must be UTF-8, so they cannot carry binary payloads — and
+// its explicit Content-Type header, if any, declares the event media type.
+// The caller has already capped the body with MaxBytesReader.
+func parseMultipartPublication(body io.Reader, boundary string) (url.Values, string, error) {
+	if boundary == "" {
+		return nil, "", http.ErrMissingBoundary
+	}
+
+	var contentType string
+
+	form := url.Values{}
+	mr := multipart.NewReader(body, boundary)
+
+	for {
+		p, err := mr.NextPart()
+		if errors.Is(err, io.EOF) {
+			return form, contentType, nil
+		}
+
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid multipart publication body: %w", err)
+		}
+
+		name := p.FormName()
+		if name == "" {
+			// A part without a field name has no urlencoded equivalent;
+			// ignore it like an unknown field.
+			continue
+		}
+
+		v, err := io.ReadAll(p)
+		if err != nil {
+			return nil, "", fmt.Errorf("unable to read multipart publication part: %w", err)
+		}
+
+		if name == fieldData {
+			contentType = p.Header.Get("Content-Type")
+		}
+
+		form.Add(name, string(v))
 	}
 }

--- a/subscribe.go
+++ b/subscribe.go
@@ -480,10 +480,11 @@ func (h *Hub) dispatchSubscriptionUpdate(ctx context.Context, s *LocalSubscriber
 		// escapes control characters), not attacker-controlled. Keep that
 		// invariant if this function changes.
 		u := &Update{
-			Topics:  []string{subscription.ID},
-			Private: true,
-			Debug:   h.debug,
-			Event:   Event{Data: string(j), Type: reservedEventType},
+			Topics:      []string{subscription.ID},
+			Private:     true,
+			Debug:       h.debug,
+			ContentType: "application/json",
+			Event:       Event{Data: string(j), Type: reservedEventType},
 		}
 
 		if err := h.transport.Dispatch(ctx, u); err != nil && h.logger.Enabled(ctx, slog.LevelError) {

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1977,3 +1977,54 @@ func (t *eventsQueryTester) String() string {
 
 	return t.body.String()
 }
+
+// A binary update reaches a multipart/digest subscriber byte-exactly, with
+// the media type its publisher declared; the same update over an event
+// stream is base64-encoded (see the event stream encoder).
+func TestEventsQuerySubscribeBinary(t *testing.T) {
+	t.Parallel()
+
+	const binaryData = "\x89PNG\xff\x00\xfe"
+
+	hub := createAnonymousDummy(t, WithEventsQuery())
+	ctx := t.Context()
+
+	go func() {
+		s := hub.transport.(*LocalTransport)
+
+		var ready bool
+
+		for !ready {
+			s.RLock()
+			ready = s.subscribers.Len() == 1
+			s.RUnlock()
+		}
+
+		_ = hub.transport.Dispatch(ctx, &Update{
+			Topics:      []string{"https://example.com/books/1"},
+			Binary:      true,
+			ContentType: "image/png",
+			Event:       Event{Data: binaryData, ID: "b"},
+		})
+	}()
+
+	reqCtx, cancel := context.WithCancel(t.Context())
+	req := eventsQueryRequest(reqCtx, `{"url": ["https://example.com/books/1"], "events": {}}`)
+
+	// One delimiter opens the stream, the next closes the notification.
+	w := newEventsQueryTester(2, cancel)
+	hub.SubscribeHandler(w, req)
+
+	_, params, err := mime.ParseMediaType(w.Header().Get("Content-Type"))
+	require.NoError(t, err)
+
+	r := multipart.NewReader(strings.NewReader(w.String()+"--\r\n"), params["boundary"])
+
+	part, err := r.NextPart()
+	require.NoError(t, err)
+
+	header, body := readNotification(t, bufio.NewReader(part))
+	assert.Equal(t, binaryData, body)
+	assert.Equal(t, "b", header.Get("Event-ID"))
+	assert.Equal(t, "image/png", header.Get("Content-Type"))
+}

--- a/update.go
+++ b/update.go
@@ -1,6 +1,9 @@
 package mercure
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/gofrs/uuid/v5"
@@ -28,8 +31,55 @@ type Update struct {
 	// history entries persisted before this field existed decodable.
 	ContentType string `json:",omitempty"`
 
+	// Binary marks updates whose Data is an arbitrary byte payload
+	// (published as multipart/form-data): Data is base64-encoded when
+	// serialized to text formats (SSE, JSON) and delivered verbatim
+	// otherwise. omitempty keeps older history entries decodable.
+	Binary bool `json:",omitempty"`
+
 	// To print debug information
 	Debug bool
+}
+
+// updateJSON drops Update's methods so encoding/json does not recurse into
+// MarshalJSON; the wire shape stays byte-identical for non-binary updates.
+type updateJSON Update
+
+// MarshalJSON base64-encodes binary Data: encoding/json silently replaces
+// invalid UTF-8 in strings with U+FFFD, which would corrupt persisted
+// binary payloads.
+func (u *Update) MarshalJSON() ([]byte, error) {
+	c := updateJSON(*u)
+	if u.Binary {
+		c.Data = base64.StdEncoding.EncodeToString([]byte(u.Data))
+	}
+
+	b, err := json.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal update: %w", err)
+	}
+
+	return b, nil
+}
+
+func (u *Update) UnmarshalJSON(data []byte) error {
+	var c updateJSON
+	if err := json.Unmarshal(data, &c); err != nil {
+		return fmt.Errorf("unable to unmarshal update: %w", err)
+	}
+
+	if c.Binary {
+		d, err := base64.StdEncoding.DecodeString(c.Data)
+		if err != nil {
+			return fmt.Errorf("unable to decode binary update data: %w", err)
+		}
+
+		c.Data = string(d)
+	}
+
+	*u = Update(c)
+
+	return nil
 }
 
 func (u *Update) LogValue() slog.Value {

--- a/update_test.go
+++ b/update_test.go
@@ -54,6 +54,39 @@ func TestUpdateJSON(t *testing.T) {
 	assert.JSONEq(t, legacy, string(out))
 }
 
+// Binary payloads must survive JSON persistence byte-exactly: encoding/json
+// replaces invalid UTF-8 with U+FFFD, so MarshalJSON base64-encodes Data
+// when Binary is set.
+func TestUpdateBinaryJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	u := &Update{
+		Topics: []string{"https://example.com/books/1"},
+		Binary: true,
+		Event:  Event{Data: "\xff\x00\xfePNG", ID: "i"},
+	}
+
+	serialized, err := json.Marshal(u)
+	require.NoError(t, err)
+	assert.Contains(t, string(serialized), `"Data":"/wD+UE5H"`)
+	assert.Contains(t, string(serialized), `"Binary":true`)
+
+	var decoded Update
+
+	require.NoError(t, json.Unmarshal(serialized, &decoded))
+	assert.Equal(t, *u, decoded)
+}
+
+func TestUpdateValidateBinaryData(t *testing.T) {
+	t.Parallel()
+
+	u := &Update{Topics: []string{"https://example.com/books/1"}, Event: Event{Data: "\xff\x00"}}
+	require.ErrorIs(t, u.Validate(), ErrInvalidData)
+
+	u.Binary = true
+	require.NoError(t, u.Validate())
+}
+
 func TestLogUpdate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Stacked on https://github.com/dunglas/mercure/pull/1364 (via https://github.com/CxRes/mercure/pull/1, whose boundary commit is the base of this branch). Only the last commit is new here; retarget to `main` once #1364 lands. Carries the binary half of the closed https://github.com/dunglas/mercure/pull/1358, reworked for the `multipart/digest` framing.

## What

The publish endpoint accepts `multipart/form-data` bodies when `events_query` is enabled (415 otherwise). The `data` part carries raw bytes and its `Content-Type` header declares the event media type; the explicit `content_type` field wins when both are present. Fields other than `data` keep their urlencoded semantics; parts without a field name are ignored like unknown fields.

Delivery of a binary update:

- `multipart/digest` subscribers receive the bytes verbatim (the `message/rfc822` body is length-delimited) with the declared media type, defaulting to `application/octet-stream` instead of `text/plain; charset=utf-8` when the publisher declared none.
- Event stream subscribers receive `data` base64-encoded, always, even when the payload happens to be valid UTF-8: the format has no per-event metadata slot, so only a rule fixed at publication time decodes deterministically. This also gives byte-exact round-tripping, which SSE line splitting cannot (CR/CRLF normalize to LF).
- Persistence: `Update.MarshalJSON`/`UnmarshalJSON` base64-encode binary `Data` (`encoding/json` silently replaces invalid UTF-8 with U+FFFD), so the bolt JSON history is lossless. The legacy wire shape is untouched for non-binary updates.

Also sets `ContentType: application/json` on hub-generated subscription events, so their `multipart/digest` messages stop claiming `text/plain`.

## Follow-ups after this

A standalone RFC-style extension spec (`spec/mercure-events-query.md`) and documentation, once the encoding details settle in #1364.
