### PR TITLE
docs: point hosted-service reports at the Mercure Cloud policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,15 @@ Report security issues through GitHub's private vulnerability reporting:
 
 Do not open public issues or PRs for suspected vulnerabilities.
 
+### Mercure Cloud
+
+This policy covers the Hub in this repository. For the hosted service at
+mercure.rocks, including its API, dashboard and the hubs we operate, report to
+<contact+security@mercure.rocks> instead. That service publishes its own
+scope, triage targets and safe-harbour terms, which authorise good-faith
+research against it:
+<https://mercure.rocks/legal/security#vulnerability-disclosure-policy>.
+
 ## Supported versions
 
 | Version | Branch | Status                                                                                                              |


### PR DESCRIPTION
`SECURITY.md` covers the Hub in this repository. A researcher who finds a flaw in the hosted service at mercure.rocks had no stated channel here, and nothing authorised them to test it.

Adds a short section pointing at the hosted service's own contact address and its disclosure policy, which now publishes scope, triage targets and safe-harbour terms: <https://mercure.rocks/legal/security#vulnerability-disclosure-policy>

No change to how vulnerabilities in this repository are reported.